### PR TITLE
feat(state): surface loading + errors to the user (Phase 1 / A3)

### DIFF
--- a/apps/frontend/src/styles/_globals.scss
+++ b/apps/frontend/src/styles/_globals.scss
@@ -67,3 +67,11 @@
     left: 100%;
   }
 }
+
+// Error toast (MatSnackBar panelClass: 'error-snackbar'). Rendered in the CDK
+// overlay, so it must be styled globally rather than in a component stylesheet.
+.error-snackbar {
+  --mdc-snackbar-container-color: #b00020;
+  --mdc-snackbar-supporting-text-color: #fff;
+  --mat-snack-bar-button-color: #fff;
+}

--- a/libs/frontend/state/src/lib/+state/state.effects.ts
+++ b/libs/frontend/state/src/lib/+state/state.effects.ts
@@ -1,9 +1,10 @@
 import { StateService } from './../state.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { switchMap, catchError, of, map } from 'rxjs';
+import { switchMap, catchError, of, map, tap } from 'rxjs';
 import {
   deleteAllTransactions,
   deleteAllTransactionsFailure,
@@ -28,8 +29,31 @@ export class StateEffects {
   constructor(
     private store: Store,
     private readonly actions$: Actions,
-    private readonly service: StateService
+    private readonly service: StateService,
+    private readonly snackBar: MatSnackBar
   ) {}
+
+  // Surface any failure to the user as a dismissible toast. Without this, the
+  // *Failure actions are dispatched but never shown — a save could fail silently.
+  public readonly showError$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(
+          getDataFailure,
+          saveTransactionFailure,
+          deleteTransactionFailure,
+          deleteAllTransactionsFailure,
+          handleFileInputFailure
+        ),
+        tap(({ error }) =>
+          this.snackBar.open(error || 'Something went wrong', 'Dismiss', {
+            duration: 6000,
+            panelClass: 'error-snackbar',
+          })
+        )
+      ),
+    { dispatch: false }
+  );
 
   public readonly getData$ = createEffect(() =>
     this.actions$.pipe(

--- a/libs/frontend/state/src/lib/+state/state.reducer.ts
+++ b/libs/frontend/state/src/lib/+state/state.reducer.ts
@@ -1,9 +1,19 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
 import {
+  deleteAllTransactions,
+  deleteAllTransactionsFailure,
   deleteAllTransactionsSuccess,
+  deleteTransaction,
+  deleteTransactionFailure,
   deleteTransactionSuccess,
+  getData,
+  getDataFailure,
   getDataSuccess,
+  handleFileInput,
+  handleFileInputFailure,
   handleFileInputSuccess,
+  saveTransaction,
+  saveTransactionFailure,
   saveTransactionSuccess,
   setChartData,
 } from './state.actions';
@@ -37,6 +47,8 @@ export interface FeatureState {
   dates: Date[];
   summary: Summary;
   currencies: string[];
+  loading: boolean;
+  error: string | null;
 }
 
 export const initialState: FeatureState = {
@@ -71,6 +83,8 @@ export const initialState: FeatureState = {
     },
   },
   currencies: [],
+  loading: false,
+  error: null,
 };
 
 export const reducer = createReducer(
@@ -317,7 +331,33 @@ export const reducer = createReducer(
         totalDividend: totalDividendSummary,
       },
     };
-  })
+  }),
+  // --- request / success / failure status tracking ---
+  // Composed alongside the data handlers above (NgRx runs every matching `on`).
+  on(
+    getData,
+    saveTransaction,
+    deleteTransaction,
+    deleteAllTransactions,
+    handleFileInput,
+    (state) => ({ ...state, loading: true, error: null })
+  ),
+  on(
+    getDataSuccess,
+    saveTransactionSuccess,
+    deleteTransactionSuccess,
+    deleteAllTransactionsSuccess,
+    handleFileInputSuccess,
+    (state) => ({ ...state, loading: false })
+  ),
+  on(
+    getDataFailure,
+    saveTransactionFailure,
+    deleteTransactionFailure,
+    deleteAllTransactionsFailure,
+    handleFileInputFailure,
+    (state, { error }) => ({ ...state, loading: false, error })
+  )
 );
 
 export const feature = createFeature({ name: featureKey, reducer });

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -7,3 +7,13 @@ export const selectState = createSelector(
   selectFeature,
   (state: FeatureState) => state
 );
+
+export const selectLoading = createSelector(
+  selectFeature,
+  (state: FeatureState) => state.loading
+);
+
+export const selectError = createSelector(
+  selectFeature,
+  (state: FeatureState) => state.error
+);

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
@@ -4,6 +4,12 @@
     <aws-scrolling-text></aws-scrolling-text>
   </mat-toolbar>
 
+  <mat-progress-bar
+    *ngIf="loading$ | async"
+    mode="indeterminate"
+    color="accent"
+  ></mat-progress-bar>
+
   <mat-sidenav-container
     class="example-sidenav-container"
     [style.marginTop.px]="mobileQuery.matches ? 56 : 0"

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
@@ -13,12 +13,13 @@ import {
   MatSidenavContent,
 } from '@angular/material/sidenav';
 import { Store } from '@ngrx/store';
-import { getData } from '@aws/state';
+import { getData, selectLoading } from '@aws/state';
 import { ScrollingTextComponent } from '../scrolling-text/scrolling-text.component';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatListItem, MatNavList } from '@angular/material/list';
 import { CommonModule } from '@angular/common';
 import { MatButton } from '@angular/material/button';
+import { MatProgressBar } from '@angular/material/progress-bar';
 
 @Component({
   selector: 'aws-page-wrapper',
@@ -35,9 +36,11 @@ import { MatButton } from '@angular/material/button';
     CommonModule,
     MatButton,
     MatListItem,
+    MatProgressBar,
   ],
 })
 export class PageWrapperComponent implements OnInit, OnDestroy {
+  loading$ = this.store.select(selectLoading);
   mobileQuery: MediaQueryList;
   navigationOptions = [
     {


### PR DESCRIPTION
## Summary

Phase 1 / **A3 — make failures visible.** Today the `*Failure` actions are dispatched by the effects but **never handled by the reducer**, and the feature state has no `loading`/`error` fields — so a failed load, save, delete, or CSV import is silently swallowed, leaving the UI frozen with no feedback. For a finance app, a save that *looks* like it worked but didn't is dangerous.

## Changes
- **State:** added `loading: boolean` and `error: string | null` to `FeatureState`.
- **Reducer:** `loading=true` (+ clear error) on each request action; `loading=false` on success; `loading=false` + `error` on failure. These are composed alongside the existing data handlers (NgRx runs every matching `on`), so the calculation logic is untouched.
- **Selectors:** `selectLoading`, `selectError`.
- **Errors → toast:** a new `showError$` effect opens a dismissible `MatSnackBar` for every failure action.
- **Loading → spinner:** an indeterminate `MatProgressBar` under the toolbar in `page-wrapper` (which fires the initial `getData`).
- **Styling:** global `.error-snackbar` class (snackbars render in the CDK overlay, so it must be global).

## Verified
- `nx build frontend` ✅
- `nx test state` / `nx test util` ✅
- Pre-existing lint errors in untouched files (`state.service.ts`, `bar-chart-per-quarter-by-year.ts`, `chart.component.ts`) are **not** affected by this PR.

## Notes / scope
- Loading is tied to the primary data round-trip (`getData` → `getDataSuccess`/`Failure`). The subsequent Yahoo price fetch / `setChartData` enrichment is intentionally **not** gated on the spinner, so a Yahoo hiccup can't leave it stuck.
- The Yahoo slice's own `getTickerFailure` isn't toasted here (separate slice) — a small follow-up if you want price-fetch failures surfaced too.

Independent of #29 (T1 tests); both branch from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)