### PR TITLE
refactor(state): portfolio computation reducer -> memoized selectors (Phase 2 / A1+A2)

### DIFF
--- a/libs/frontend/state/src/lib/+state/state.reducer.ts
+++ b/libs/frontend/state/src/lib/+state/state.reducer.ts
@@ -17,323 +17,44 @@ import {
   saveTransactionSuccess,
   setChartData,
 } from './state.actions';
-import {
-  ChartData,
-  Summary,
-  Transactions,
-  getDailyDates,
-  getDividendPerQuarterByYear,
-  getMostRecentValueFromList,
-  getPortfolioValues,
-  getReturn,
-  getTransactionAmountsAndValues,
-  subtractLists,
-  transactionsDboToStocks,
-  getDividendTtmPerQuarter,
-  getDividendPerQuarter,
-  getYieldPerYear,
-  Stock,
-  addLists,
-  getStartDate,
-  transactionsDboToTransactions,
-  updateDividends, getCurrencies
-} from '@aws/util';
+import { Ticker, TransactionsDbo } from '@aws/util';
 
 export const featureKey = 'state';
 
+// The reducer stores only RAW inputs: the transactions loaded from the backend
+// and the Yahoo price tickers. Every derived value (stocks, dates, summary,
+// chart data) is computed on demand in memoized selectors — see
+// state.selectors.ts. This keeps the reducer pure and cheap, and means the
+// expensive portfolio math runs only when its inputs actually change.
 export interface FeatureState {
-  transactions: Transactions;
-  stocks: { [ticker: string]: Stock };
-  dates: Date[];
-  summary: Summary;
-  currencies: string[];
+  transactionsDbo: TransactionsDbo;
+  tickers: { [ticker: string]: Ticker };
   loading: boolean;
   error: string | null;
 }
 
 export const initialState: FeatureState = {
-  transactions: {
-    stock: [],
-    dividend: [],
-    commission: [],
-  },
-  stocks: {},
-  dates: [],
-  summary: {
-    portfolioValue: 0,
-    totalInvested: 0,
-    totalDividend: 0,
-    totalCommission: 0,
-    startDate: new Date(),
-    dailyReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-    weeklyReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-    monthlyReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-    totalReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-  },
-  currencies: [],
+  transactionsDbo: { stock: [], dividend: [], commission: [] },
+  tickers: {},
   loading: false,
   error: null,
 };
 
 export const reducer = createReducer(
   initialState,
-  on(getDataSuccess, (state, action) => {
-    const stocks = transactionsDboToStocks(action.data)
-    return {
+  on(getDataSuccess, (state, { data }) => ({
     ...state,
-    transactions: transactionsDboToTransactions(action.data),
-    stocks,
-    currencies: getCurrencies(stocks)
-  }}),
+    transactionsDbo: data,
+  })),
   on(
     saveTransactionSuccess,
     deleteTransactionSuccess,
     deleteAllTransactionsSuccess,
     handleFileInputSuccess,
-    (state, action) => {
-      const stocks = transactionsDboToStocks(action.transactions)
-      return {
-      ...state,
-      transactions: transactionsDboToTransactions(action.transactions),
-      stocks,
-      currencies: getCurrencies(stocks)
-    }}
+    (state, { transactions }) => ({ ...state, transactionsDbo: transactions })
   ),
-  on(
-    getDataSuccess,
-    saveTransactionSuccess,
-    deleteTransactionSuccess,
-    deleteAllTransactionsSuccess,
-    handleFileInputSuccess,
-    (state) => {
-      const stocks = state.stocks;
-      const startDate: Date = getStartDate(stocks);
-      console.log('Started investing on: ', startDate);
-
-      if (Object.keys(stocks).length > 0) {
-        const dates = getDailyDates(startDate, new Date());
-
-        let totalInvestedSummary = 0;
-        let totalDividendSummary = 0;
-        let totalCommissionSummary = 0;
-
-        for (const key in stocks) {
-          const stock = stocks[key];
-          const transactions = stock.transactions;
-          const stockTransactionAmountsAndValues =
-            getTransactionAmountsAndValues(dates, transactions.stock);
-          const dividendTransactionAmountsAndValues =
-            getTransactionAmountsAndValues(dates, transactions.dividend);
-          const dividendPerQuarterByYear = getDividendPerQuarterByYear(
-            startDate,
-            transactions.dividend
-          );
-          const dividendPerQuarter = getDividendPerQuarter(
-            startDate,
-            dividendPerQuarterByYear
-          );
-          const dividendTtmPerQuarter =
-            getDividendTtmPerQuarter(dividendPerQuarter);
-
-          const commissionTransactionAmountsAndValues =
-            getTransactionAmountsAndValues(dates, transactions.commission);
-
-          const totalInvested = getMostRecentValueFromList(
-            stockTransactionAmountsAndValues.aggregatedValues
-          ).value;
-          totalInvestedSummary += totalInvested;
-          const amountOfShares = getMostRecentValueFromList(
-            stockTransactionAmountsAndValues.aggregatedAmounts
-          ).value;
-
-          const totalDividend = getMostRecentValueFromList(
-            dividendTransactionAmountsAndValues.aggregatedValues
-          ).value;
-          totalDividendSummary += totalDividend;
-
-          const totalCommission = getMostRecentValueFromList(
-            commissionTransactionAmountsAndValues.aggregatedValues
-          ).value;
-          totalCommissionSummary += totalCommission;
-
-          stocks[key] = {
-            ...stock,
-            chartData: {
-              ...stock.chartData,
-              stock: {
-                ...stockTransactionAmountsAndValues,
-              },
-              dividend: {
-                ...dividendTransactionAmountsAndValues,
-                perQuarterByYear: dividendPerQuarterByYear,
-                perQuarter: dividendPerQuarter,
-                ttmPerQuarter: dividendTtmPerQuarter,
-              },
-              commission: { ...commissionTransactionAmountsAndValues },
-            },
-            summary: {
-              ...stock.summary,
-              totalInvested,
-              amountOfShares,
-              averageSharePrice:
-                amountOfShares !== 0 ? totalInvested / amountOfShares : 0,
-              totalDividend,
-              totalCommission,
-            },
-          };
-        }
-
-        return {
-          ...state,
-          dates,
-          stocks,
-          summary: {
-            ...state.summary,
-            totalInvested: totalInvestedSummary,
-            totalDividend: totalDividendSummary,
-            totalCommission: totalCommissionSummary,
-            startDate,
-          },
-        };
-      }
-      return {
-        ...state,
-      };
-    }
-  ),
-  on(setChartData, (state, action) => {
-    const stocks = state.stocks;
-
-    let portfolioValuesSummary = 0;
-    let aggregatedPortfolioValues: number[] = [];
-    let aggregatedProfit: number[] = [];
-    let totalDividendSummary = 0;
-
-    const updatedStocks: { [ticker: string]: Stock } = {};
-    for (const key of Object.keys(stocks)) {
-      const stock = stocks[key];
-      const ticker = action.tickers[key];
-
-      const portfolioValues = getPortfolioValues(
-        state.dates,
-        stock.chartData.stock.aggregatedAmounts,
-        ticker
-      );
-      aggregatedPortfolioValues =
-        aggregatedPortfolioValues.length > 0
-          ? addLists(aggregatedPortfolioValues, portfolioValues)
-          : portfolioValues;
-      const portfolioValue = getMostRecentValueFromList(portfolioValues).value;
-      portfolioValuesSummary += portfolioValue;
-
-      const profit = subtractLists(
-        subtractLists(portfolioValues, stock.chartData.stock.aggregatedValues),
-        stock.chartData.commission.aggregatedValues
-      );
-      aggregatedProfit =
-        aggregatedProfit.length > 0
-          ? addLists(aggregatedProfit, profit)
-          : profit;
-
-      const dailyReturn = getReturn(portfolioValues, profit, 1);
-      const weeklyReturn = getReturn(portfolioValues, profit, 7);
-      const monthlyReturn = getReturn(portfolioValues, profit, 30);
-      const totalReturn = getReturn(
-        portfolioValues,
-        profit,
-        portfolioValues.length
-      );
-
-      const yieldPerYear = getYieldPerYear(
-        state.dates,
-        portfolioValues,
-        profit
-      );
-
-      const updatedDividend = updateDividends(
-        stock.chartData.dividend,
-        stock.chartData.stock.aggregatedAmounts,
-        ticker,
-        state.dates,
-        state.summary.startDate
-      );
-
-      const totalDividend = getMostRecentValueFromList(
-        updatedDividend.aggregatedValues
-      ).value;
-      totalDividendSummary += totalDividend;
-
-      updatedStocks[key] = {
-        ...stock,
-        summary: {
-          ...stock.summary,
-          portfolioValue,
-          currentSharePrice: getMostRecentValueFromList(ticker.values).value,
-          dailyReturn,
-          weeklyReturn,
-          monthlyReturn,
-          totalReturn,
-          totalDividend,
-        },
-        chartData: {
-          ...stock.chartData,
-          portfolioValues,
-          profit,
-          yieldPerYear,
-          dividend: updatedDividend,
-        },
-      };
-    }
-
-    const dailyReturnSummary = getReturn(
-      aggregatedPortfolioValues,
-      aggregatedProfit,
-      1
-    );
-    const weeklyReturnSummary = getReturn(
-      aggregatedPortfolioValues,
-      aggregatedProfit,
-      7
-    );
-    const monthlyReturnSummary = getReturn(
-      aggregatedPortfolioValues,
-      aggregatedProfit,
-      30
-    );
-    const totalReturnSummary = getReturn(
-      aggregatedPortfolioValues,
-      aggregatedProfit,
-      aggregatedPortfolioValues.length
-    );
-
-    return {
-      ...state,
-      stocks: updatedStocks,
-      summary: {
-        ...state.summary,
-        portfolioValue: portfolioValuesSummary,
-        dailyReturn: dailyReturnSummary,
-        weeklyReturn: weeklyReturnSummary,
-        monthlyReturn: monthlyReturnSummary,
-        totalReturn: totalReturnSummary,
-        totalDividend: totalDividendSummary,
-      },
-    };
-  }),
+  on(setChartData, (state, { tickers }) => ({ ...state, tickers })),
   // --- request / success / failure status tracking ---
-  // Composed alongside the data handlers above (NgRx runs every matching `on`).
   on(
     getData,
     saveTransaction,

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -1,11 +1,17 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { computePortfolioState } from '@aws/util';
 import { FeatureState, featureKey } from './state.reducer';
 
 export const selectFeature = createFeatureSelector<FeatureState>(featureKey);
 
-export const selectState = createSelector(
+const selectTransactionsDbo = createSelector(
   selectFeature,
-  (state: FeatureState) => state
+  (state: FeatureState) => state.transactionsDbo
+);
+
+const selectTickers = createSelector(
+  selectFeature,
+  (state: FeatureState) => state.tickers
 );
 
 export const selectLoading = createSelector(
@@ -16,4 +22,22 @@ export const selectLoading = createSelector(
 export const selectError = createSelector(
   selectFeature,
   (state: FeatureState) => state.error
+);
+
+// Heavy portfolio derivation. Memoized by NgRx: it recomputes only when the raw
+// transactions or tickers change — NOT on every action or on loading/error
+// toggles. This is the work that previously ran in the reducer on every action.
+const selectPortfolio = createSelector(
+  selectTransactionsDbo,
+  selectTickers,
+  (transactionsDbo, tickers) => computePortfolioState(transactionsDbo, tickers)
+);
+
+// Public view-model — the same shape components and the Yahoo effect consumed
+// before A1 (transactions, stocks, dates, summary, currencies) plus loading/error.
+export const selectState = createSelector(
+  selectPortfolio,
+  selectLoading,
+  selectError,
+  (portfolio, loading, error) => ({ ...portfolio, loading, error })
 );

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/util.module';
 export * from './lib/util';
 export * from './lib/types';
+export * from './lib/portfolio';

--- a/libs/shared/util/src/lib/portfolio.spec.ts
+++ b/libs/shared/util/src/lib/portfolio.spec.ts
@@ -1,0 +1,104 @@
+import { Ticker, TransactionsDbo } from './types';
+import { getDailyDates, getStartDate, transactionsDboToStocks } from './util';
+import { computePortfolioState } from './portfolio';
+
+// Silence util.ts diagnostic logging so the output stays readable.
+beforeAll(() => jest.spyOn(console, 'log').mockImplementation(() => undefined));
+afterAll(() => jest.restoreAllMocks());
+
+describe('computePortfolioState', () => {
+  const dbo: TransactionsDbo = {
+    stock: [
+      {
+        ticker: 'VUSA.AS',
+        type: 'stock',
+        date: '2023-01-10',
+        amount: 2,
+        value: 200,
+        currency: 'EUR',
+      },
+    ],
+    dividend: [
+      {
+        ticker: 'VUSA.AS',
+        type: 'dividend',
+        date: '2023-02-10',
+        amount: 1,
+        value: 5,
+        currency: 'EUR',
+      },
+    ],
+    commission: [
+      {
+        ticker: 'VUSA.AS',
+        type: 'commission',
+        date: '2023-01-10',
+        amount: 1,
+        value: 3,
+        currency: 'EUR',
+      },
+    ],
+  };
+
+  it('derives transaction data (no prices yet)', () => {
+    const result = computePortfolioState(dbo, {});
+
+    expect(Object.keys(result.stocks)).toEqual(['VUSA.AS']);
+    expect(result.transactions.stock).toHaveLength(1);
+    expect(result.dates.length).toBeGreaterThan(0);
+
+    // Aggregated, carried-forward totals.
+    expect(result.summary.totalInvested).toBe(200);
+    expect(result.summary.totalDividend).toBe(5);
+    expect(result.summary.totalCommission).toBe(3);
+
+    const stock = result.stocks['VUSA.AS'];
+    expect(stock.summary.amountOfShares).toBe(2);
+    expect(stock.summary.averageSharePrice).toBe(100); // 200 / 2
+
+    // No tickers -> no price-derived values.
+    expect(result.summary.portfolioValue).toBe(0);
+    expect(stock.chartData.portfolioValues).toEqual([]);
+  });
+
+  it('adds price-derived data once tickers are present', () => {
+    // Build a ticker whose dates line up exactly with the computed daily dates
+    // and a flat price of 150, so values are deterministic regardless of range.
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(dbo)),
+      new Date()
+    );
+    const ticker: Ticker = {
+      name: 'VUSA.AS',
+      currency: 'EUR',
+      dates,
+      values: dates.map(() => 150),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(dbo, { 'VUSA.AS': ticker });
+    const stock = result.stocks['VUSA.AS'];
+
+    // 2 shares * 150 at the most recent day.
+    expect(result.summary.portfolioValue).toBe(300);
+    expect(stock.summary.portfolioValue).toBe(300);
+    expect(stock.summary.currentSharePrice).toBe(150);
+
+    // Stage-1 totals are preserved through stage 2.
+    expect(stock.summary.totalInvested).toBe(200);
+    expect(stock.chartData.portfolioValues).toHaveLength(dates.length);
+  });
+
+  it('returns an empty portfolio for no transactions', () => {
+    const result = computePortfolioState(
+      { stock: [], dividend: [], commission: [] },
+      {}
+    );
+
+    expect(result.stocks).toEqual({});
+    expect(result.dates).toEqual([]);
+    expect(result.currencies).toEqual([]);
+    expect(result.summary.totalInvested).toBe(0);
+    expect(result.summary.portfolioValue).toBe(0);
+  });
+});

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -1,0 +1,256 @@
+import { Stock, Summary, Ticker, Transactions, TransactionsDbo } from './types';
+import {
+  addLists,
+  getCurrencies,
+  getDailyDates,
+  getDividendPerQuarter,
+  getDividendPerQuarterByYear,
+  getDividendTtmPerQuarter,
+  getMostRecentValueFromList,
+  getPortfolioValues,
+  getReturn,
+  getStartDate,
+  getTransactionAmountsAndValues,
+  getYieldPerYear,
+  subtractLists,
+  transactionsDboToStocks,
+  transactionsDboToTransactions,
+  updateDividends,
+} from './util';
+
+export interface PortfolioState {
+  transactions: Transactions;
+  stocks: { [ticker: string]: Stock };
+  dates: Date[];
+  summary: Summary;
+  currencies: string[];
+}
+
+export function createInitialSummary(): Summary {
+  return {
+    portfolioValue: 0,
+    totalInvested: 0,
+    totalDividend: 0,
+    totalCommission: 0,
+    startDate: new Date(),
+    dailyReturn: { absolute: 0, percentage: 0 },
+    weeklyReturn: { absolute: 0, percentage: 0 },
+    monthlyReturn: { absolute: 0, percentage: 0 },
+    totalReturn: { absolute: 0, percentage: 0 },
+  };
+}
+
+/**
+ * Derives the full portfolio view-model from the raw inputs: the stored
+ * transactions (DTO) and the fetched Yahoo price tickers.
+ *
+ * This is a pure, memoizable port of what used to live in the NgRx reducer.
+ * It runs in two stages, mirroring the old getDataSuccess and setChartData
+ * handlers:
+ *   1. transaction-derived data (amounts, values, dividends, invested totals),
+ *      available as soon as the transactions load.
+ *   2. price-derived data (portfolio value, profit, returns, yield), added once
+ *      the Yahoo tickers are available.
+ */
+export function computePortfolioState(
+  transactionsDbo: TransactionsDbo,
+  tickers: { [ticker: string]: Ticker }
+): PortfolioState {
+  const baseStocks = transactionsDboToStocks(transactionsDbo);
+  const transactions = transactionsDboToTransactions(transactionsDbo);
+  const currencies = getCurrencies(baseStocks);
+
+  // No transactions yet -> empty portfolio with default summary.
+  if (Object.keys(baseStocks).length === 0) {
+    return {
+      transactions,
+      stocks: {},
+      dates: [],
+      summary: createInitialSummary(),
+      currencies,
+    };
+  }
+
+  // --- Stage 1: transaction-derived data ---
+  const startDate = getStartDate(baseStocks);
+  const dates = getDailyDates(startDate, new Date());
+
+  let totalInvestedSummary = 0;
+  let totalDividendSummary = 0;
+  let totalCommissionSummary = 0;
+
+  const computedStocks: { [ticker: string]: Stock } = {};
+  for (const key of Object.keys(baseStocks)) {
+    const stock = baseStocks[key];
+    const t = stock.transactions;
+
+    const stockAmountsAndValues = getTransactionAmountsAndValues(dates, t.stock);
+    const dividendAmountsAndValues = getTransactionAmountsAndValues(
+      dates,
+      t.dividend
+    );
+    const dividendPerQuarterByYear = getDividendPerQuarterByYear(
+      startDate,
+      t.dividend
+    );
+    const dividendPerQuarter = getDividendPerQuarter(
+      startDate,
+      dividendPerQuarterByYear
+    );
+    const dividendTtmPerQuarter = getDividendTtmPerQuarter(dividendPerQuarter);
+    const commissionAmountsAndValues = getTransactionAmountsAndValues(
+      dates,
+      t.commission
+    );
+
+    const totalInvested = getMostRecentValueFromList(
+      stockAmountsAndValues.aggregatedValues
+    ).value;
+    totalInvestedSummary += totalInvested;
+    const amountOfShares = getMostRecentValueFromList(
+      stockAmountsAndValues.aggregatedAmounts
+    ).value;
+    const totalDividend = getMostRecentValueFromList(
+      dividendAmountsAndValues.aggregatedValues
+    ).value;
+    totalDividendSummary += totalDividend;
+    const totalCommission = getMostRecentValueFromList(
+      commissionAmountsAndValues.aggregatedValues
+    ).value;
+    totalCommissionSummary += totalCommission;
+
+    computedStocks[key] = {
+      ...stock,
+      chartData: {
+        ...stock.chartData,
+        stock: { ...stockAmountsAndValues },
+        dividend: {
+          ...dividendAmountsAndValues,
+          perQuarterByYear: dividendPerQuarterByYear,
+          perQuarter: dividendPerQuarter,
+          ttmPerQuarter: dividendTtmPerQuarter,
+        },
+        commission: { ...commissionAmountsAndValues },
+      },
+      summary: {
+        ...stock.summary,
+        totalInvested,
+        amountOfShares,
+        averageSharePrice:
+          amountOfShares !== 0 ? totalInvested / amountOfShares : 0,
+        totalDividend,
+        totalCommission,
+      },
+    };
+  }
+
+  let summary: Summary = {
+    ...createInitialSummary(),
+    totalInvested: totalInvestedSummary,
+    totalDividend: totalDividendSummary,
+    totalCommission: totalCommissionSummary,
+    startDate,
+  };
+
+  // No prices yet -> return the transaction-only view.
+  if (Object.keys(tickers).length === 0) {
+    return { transactions, stocks: computedStocks, dates, summary, currencies };
+  }
+
+  // --- Stage 2: price-derived data ---
+  let portfolioValuesSummary = 0;
+  let aggregatedPortfolioValues: number[] = [];
+  let aggregatedProfit: number[] = [];
+  let chartTotalDividendSummary = 0;
+
+  const chartedStocks: { [ticker: string]: Stock } = {};
+  for (const key of Object.keys(computedStocks)) {
+    const stock = computedStocks[key];
+    const ticker = tickers[key];
+
+    // Prices for this stock haven't arrived (yet) — keep the stage-1 view so a
+    // transient ticker/transaction mismatch can't crash the derivation.
+    if (!ticker) {
+      chartedStocks[key] = stock;
+      continue;
+    }
+
+    const portfolioValues = getPortfolioValues(
+      dates,
+      stock.chartData.stock.aggregatedAmounts,
+      ticker
+    );
+    aggregatedPortfolioValues =
+      aggregatedPortfolioValues.length > 0
+        ? addLists(aggregatedPortfolioValues, portfolioValues)
+        : portfolioValues;
+    const portfolioValue = getMostRecentValueFromList(portfolioValues).value;
+    portfolioValuesSummary += portfolioValue;
+
+    const profit = subtractLists(
+      subtractLists(portfolioValues, stock.chartData.stock.aggregatedValues),
+      stock.chartData.commission.aggregatedValues
+    );
+    aggregatedProfit =
+      aggregatedProfit.length > 0
+        ? addLists(aggregatedProfit, profit)
+        : profit;
+
+    const dailyReturn = getReturn(portfolioValues, profit, 1);
+    const weeklyReturn = getReturn(portfolioValues, profit, 7);
+    const monthlyReturn = getReturn(portfolioValues, profit, 30);
+    const totalReturn = getReturn(portfolioValues, profit, portfolioValues.length);
+
+    const yieldPerYear = getYieldPerYear(dates, portfolioValues, profit);
+
+    const updatedDividend = updateDividends(
+      stock.chartData.dividend,
+      stock.chartData.stock.aggregatedAmounts,
+      ticker,
+      dates,
+      startDate
+    );
+
+    const totalDividend = getMostRecentValueFromList(
+      updatedDividend.aggregatedValues
+    ).value;
+    chartTotalDividendSummary += totalDividend;
+
+    chartedStocks[key] = {
+      ...stock,
+      summary: {
+        ...stock.summary,
+        portfolioValue,
+        currentSharePrice: getMostRecentValueFromList(ticker.values).value,
+        dailyReturn,
+        weeklyReturn,
+        monthlyReturn,
+        totalReturn,
+        totalDividend,
+      },
+      chartData: {
+        ...stock.chartData,
+        portfolioValues,
+        profit,
+        yieldPerYear,
+        dividend: updatedDividend,
+      },
+    };
+  }
+
+  summary = {
+    ...summary,
+    portfolioValue: portfolioValuesSummary,
+    dailyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 1),
+    weeklyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 7),
+    monthlyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 30),
+    totalReturn: getReturn(
+      aggregatedPortfolioValues,
+      aggregatedProfit,
+      aggregatedPortfolioValues.length
+    ),
+    totalDividend: chartTotalDividendSummary,
+  };
+
+  return { transactions, stocks: chartedStocks, dates, summary, currencies };
+}


### PR DESCRIPTION
## Summary

Phase 2 / **A1** (+**A2**) — the keystone architectural refactor. The NgRx reducer previously ran the **entire** portfolio derivation on every action and **mutated `state.stocks` in place**. This moves that computation into a pure, tested function driven by **memoized selectors**, and reduces the reducer to storing raw inputs.

This was deliberately sequenced last: it's de-risked by the financial-core tests (T1, #29) and gated by CI (T2, #31).

## What changed
- **New pure function** `computePortfolioState(transactionsDbo, tickers)` in `@aws/util` — a faithful, **immutable** port of the old `getDataSuccess` + `setChartData` reducer handlers. Two stages: transaction-derived data (amounts, dividends, invested totals), then price-derived data (portfolio value, profit, returns, yield) once tickers arrive. Adds a guard so a transient ticker/transaction mismatch can't crash the derivation (selectors run on every state read, unlike the old action-gated handler).
- **Reducer thinned** to raw inputs only: `transactionsDbo`, `tickers`, `loading`, `error`. ~296 fewer lines; **no more in-place mutation (A2)**.
- **Memoized `selectPortfolio`** runs the computation; **`selectState` keeps the exact same shape** (`transactions, stocks, dates, summary, currencies, loading, error`) — so components and the Yahoo effect are **untouched**.

## Why it matters
| Finding | Before | After |
|---|---|---|
| **Performance (P1)** | full recompute on every action + loading toggle | memoized — recomputes only when transactions/prices change |
| **Correctness (A2)** | reducer mutated `state.stocks` in place | reducer is pure spreads; derivation builds new objects |
| **Testability** | math locked inside the reducer | pure function, unit-tested in isolation |

## Verified
- `nx test util` → **32 pass** (29 existing + 3 new `portfolio.spec` covering both stages + the empty case).
- `nx build frontend` → green (AOT typechecks the full reducer → selector → compute → template chain).
- `nx run-many -t lint test --projects=state,util,ui,frontend` → green (0 errors).
- Confirmed every `selectState` consumer (dashboard, scrolling-text, transactions, Yahoo effect) reads only fields the new `selectState` still provides.

## Notes / follow-ups (not in this PR)
- The Yahoo `setChartData$` effect is now partly redundant (selectors recompute automatically when transactions change), but left untouched to keep blast radius small — candidate for a later cleanup, along with consolidating the two slices (A5).
- Could enable `@ngrx/store` `strictStateImmutability` runtime checks now that the reducer is pure — small follow-up to lock in A2.
- **Please smoke-test the running app** (load dashboard, add/delete a transaction, check charts + summary): the math is verified by tests, but this changes how the view-model is produced, so a real-data pass is worth it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)