### PR TITLE
chore(ts): enable strict mode + noImplicitOverride (Phase 2 / D1)

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,8 @@
     "target": "es2015",
     "module": "esnext",
     "lib": ["es2020", "dom"],
+    "strict": true,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",


### PR DESCRIPTION
## Summary

Phase 2 / **D1** — turn on TypeScript `strict` and `noImplicitOverride` in `tsconfig.base.json`.

Pleasant surprise: the codebase is **already clean under both** — `nx run-many -t lint test build --all` is green for all 6 projects with these on. I confirmed strict is genuinely enforced (not silently overridden) by temporarily adding an implicit-`any` + `undefined`-assignment probe, which failed the build as expected.

## Why it's valuable even at 0 current errors
`strict` (strictNullChecks, noImplicitAny, strictPropertyInitialization, …) now **gates all future code** — no new implicit `any`, null-unsafe access, or uninitialized fields can merge, because CI (#31) runs the typecheck on every PR. It encodes the discipline the code already follows.

## Scope decision: `noUncheckedIndexedAccess` deferred
I measured it: it produces **465 errors (433 in `util.ts`)**, concentrated in the array-indexing-heavy financial math (`transactions[i]`, `values[i]`, list math, …).

That's not a flag-flip — it's a dedicated, careful burndown. Reflexively adding `!` would *mask* the exact `undefined`/`NaN` bugs the flag is meant to surface; doing it right means analyzing each access (guard vs. genuinely-safe). So it's left as a separate follow-up, ideally tackled alongside splitting `util.ts` (Q1) and with the financial-core tests (T1) as the safety net.

## Verified
- `nx run-many -t lint test build --all` → green (6 projects) with `strict` + `noImplicitOverride`.
- Strict enforcement confirmed via a deliberate-violation probe (reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)