### PR TITLE
feat(validation): zod at the HTTP trust boundaries (Phase 3 / S4)

### DIFF
--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -33,8 +33,8 @@
           "budgets": [
             {
               "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1mb"
+              "maximumWarning": "1.25mb",
+              "maximumError": "1.5mb"
             },
             {
               "type": "anyComponentStyle",

--- a/libs/frontend/state/src/lib/state.service.ts
+++ b/libs/frontend/state/src/lib/state.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { DatabaseDto, Transactions } from '@aws/util';
-import { Observable } from 'rxjs';
+import { DatabaseDto, parseDatabaseDto, Transactions } from '@aws/util';
+import { map, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -14,14 +14,16 @@ export class StateService {
 
   public getData(): Observable<DatabaseDto> {
     console.log('AWS LAMBDA CALL - Database - get data');
-    return this.http.get<DatabaseDto>(`${this.environment.dynamoDBLambdaUrl}`);
+    return this.http
+      .get<unknown>(`${this.environment.dynamoDBLambdaUrl}`)
+      .pipe(map((response) => parseDatabaseDto(response)));
   }
 
   public setTransactions(transactions: Transactions): Observable<DatabaseDto> {
     console.log('AWS LAMBDA CALL - Database - set data');
     console.log(transactions);
-    return this.http.put<DatabaseDto>(`${this.environment.dynamoDBLambdaUrl}`, {
-      transactions,
-    });
+    return this.http
+      .put<unknown>(`${this.environment.dynamoDBLambdaUrl}`, { transactions })
+      .pipe(map((response) => parseDatabaseDto(response)));
   }
 }

--- a/libs/frontend/yahoo/src/lib/yahoo.service.ts
+++ b/libs/frontend/yahoo/src/lib/yahoo.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { Stock, YahooObject } from '@aws/util';
+import { map, Observable } from 'rxjs';
+import { parseYahooObjects, Stock, YahooObject } from '@aws/util';
 
 @Injectable({
   providedIn: 'root',
@@ -40,6 +40,8 @@ export class YahooService {
       start: start,
       end: end,
     };
-    return this.http.post<YahooObject[]>(this.environment.yahooLambdaUrl, body);
+    return this.http
+      .post<unknown>(this.environment.yahooLambdaUrl, body)
+      .pipe(map((response) => parseYahooObjects(response)));
   }
 }

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/util.module';
 export * from './lib/util';
 export * from './lib/types';
 export * from './lib/portfolio';
+export * from './lib/schemas';

--- a/libs/shared/util/src/lib/schemas.spec.ts
+++ b/libs/shared/util/src/lib/schemas.spec.ts
@@ -1,0 +1,105 @@
+import { parseDatabaseDto, parseYahooObjects } from './schemas';
+
+// parseYahooObjects warns on skipped entries; keep test output clean.
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+afterAll(() => jest.restoreAllMocks());
+
+describe('parseDatabaseDto', () => {
+  const valid = {
+    transactions: {
+      stock: [
+        {
+          ticker: 'VUSA.AS',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 2,
+          value: 200,
+          currency: 'EUR',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    },
+  };
+
+  it('accepts a well-formed response and defaults startDate', () => {
+    const result = parseDatabaseDto(valid);
+    expect(result.transactions.stock).toHaveLength(1);
+    expect(result.startDate).toBe('');
+  });
+
+  it('keeps startDate and tolerates extra fields', () => {
+    const result = parseDatabaseDto({
+      ...valid,
+      startDate: '2023-01-10',
+      extraneous: 'ignored',
+    });
+    expect(result.startDate).toBe('2023-01-10');
+  });
+
+  it('throws when transactions is missing', () => {
+    expect(() => parseDatabaseDto({})).toThrow();
+  });
+
+  it('throws when a numeric field is the wrong type', () => {
+    expect(() =>
+      parseDatabaseDto({
+        transactions: {
+          stock: [
+            {
+              ticker: 'VUSA.AS',
+              type: 'stock',
+              date: '2023-01-10',
+              amount: 2,
+              value: 'not-a-number',
+              currency: 'EUR',
+            },
+          ],
+          dividend: [],
+          commission: [],
+        },
+      })
+    ).toThrow();
+  });
+});
+
+describe('parseYahooObjects', () => {
+  function validYahoo(symbol = 'VUSA.AS') {
+    return {
+      symbol,
+      data: {
+        chart: {
+          result: [
+            {
+              meta: { currency: 'EUR', symbol },
+              timestamp: [1696550400],
+              indicators: { quote: [{ close: [100, null] }] },
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  it('returns valid entries unchanged', () => {
+    const result = parseYahooObjects([validYahoo(), validYahoo('EUR=X')]);
+    expect(result).toHaveLength(2);
+    expect(result[0].symbol).toBe('VUSA.AS');
+  });
+
+  it('skips malformed / error entries instead of crashing the batch', () => {
+    const result = parseYahooObjects([
+      validYahoo(),
+      { symbol: 'BAD', error: 'Failed to fetch' }, // Yahoo error entry
+      { totally: 'wrong' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].symbol).toBe('VUSA.AS');
+  });
+
+  it('throws when the payload is not an array', () => {
+    expect(() => parseYahooObjects({ not: 'an array' })).toThrow();
+  });
+});

--- a/libs/shared/util/src/lib/schemas.ts
+++ b/libs/shared/util/src/lib/schemas.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import { DatabaseDto, YahooObject } from './types';
+
+// Runtime validation for data crossing a trust boundary (HTTP responses).
+// Without this, a malformed payload is cast to its TypeScript type and flows
+// straight into the financial math, where missing fields become NaN money.
+
+// --- DynamoDB API (our backend) -------------------------------------------
+
+const transactionDboSchema = z
+  .object({
+    ticker: z.string(),
+    type: z.string(),
+    date: z.string(),
+    amount: z.number(),
+    value: z.number(),
+    currency: z.string(),
+  })
+  // Keep any extra columns the backend may add rather than stripping them.
+  .passthrough();
+
+const transactionsDboSchema = z.object({
+  stock: z.array(transactionDboSchema),
+  dividend: z.array(transactionDboSchema),
+  commission: z.array(transactionDboSchema),
+});
+
+const databaseDtoSchema = z
+  .object({
+    startDate: z.string().optional().default(''),
+    transactions: transactionsDboSchema,
+  })
+  .passthrough();
+
+/**
+ * Validate the DynamoDB response before it enters the store. Throws a ZodError
+ * on a malformed shape, which the effect maps to a *Failure action (and a user
+ * facing error toast) instead of silently feeding bad data into the reducer.
+ */
+export function parseDatabaseDto(raw: unknown): DatabaseDto {
+  return databaseDtoSchema.parse(raw) as DatabaseDto;
+}
+
+// --- Yahoo Finance (external) ---------------------------------------------
+
+const yahooObjectSchema = z.object({
+  symbol: z.string(),
+  data: z.object({
+    chart: z.object({
+      result: z
+        .array(
+          z.object({
+            meta: z.object({ currency: z.string(), symbol: z.string() }),
+            timestamp: z.array(z.number()),
+            events: z
+              .object({
+                dividends: z.record(
+                  z.object({ amount: z.number(), date: z.number() })
+                ),
+              })
+              .optional(),
+            indicators: z.object({
+              quote: z
+                .array(z.object({ close: z.array(z.number().nullable()) }))
+                .min(1),
+            }),
+          })
+        )
+        .min(1),
+    }),
+  }),
+});
+
+/**
+ * Validate the Yahoo Lambda response. Yahoo intermittently returns error
+ * objects or partial payloads; rather than crash the whole batch in
+ * yahooObjectToTicker, keep only the entries matching the expected shape.
+ * Throws only when the payload isn't an array at all.
+ */
+export function parseYahooObjects(raw: unknown): YahooObject[] {
+  const entries = z.array(z.unknown()).parse(raw);
+  const valid: YahooObject[] = [];
+  for (const entry of entries) {
+    const result = yahooObjectSchema.safeParse(entry);
+    if (result.success) {
+      valid.push(result.data as YahooObject);
+    } else {
+      console.warn('Skipping malformed Yahoo response entry');
+    }
+  }
+  return valid;
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ngx-papaparse": "^8.0.0",
     "oidc-client-ts": "^3.1.0",
     "rxjs": "~7.8.0",
+    "zod": "^3.23.8",
     "zone.js": "~0.13.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12139,6 +12139,11 @@ yoctocolors-cjs@^2.1.2:
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
+zod@^3.23.8:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+
 zone.js@~0.13.0:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.13.3.tgz#344c24098fa047eda6427a4c7ed486e391fd67b5"


### PR DESCRIPTION
## Summary

Phase 3 / **S4** — runtime validation at the trust boundaries. External and backend data was cast straight to its TypeScript type and flowed into the financial pipeline, where a missing/empty field becomes **NaN money**, and a malformed Yahoo entry crashed the whole batch in `yahooObjectToTicker`.

## Changes
- **`parseYahooObjects`** (`@aws/util`): validates the Yahoo Lambda response and keeps only entries matching the expected shape. Yahoo's intermittent error objects / partial payloads are **skipped** rather than crashing the batch; throws only if the payload isn't an array at all (→ `getTickerFailure`).
- **`parseDatabaseDto`** (`@aws/util`): validates the DynamoDB response. A bad shape throws, which the effects already map to a `*Failure` action + the error toast from A3 — instead of silently feeding malformed data into the reducer.
- Wired into the boundary services: `yahoo.service.getTickers`, `state.service.getData` / `setTransactions`.
- Tests for both parsers (valid, malformed, Yahoo error-entry, non-array, wrong-type).
- Bumped the initial bundle budget — zod (~46 kB raw) pushed it past the old 1 MB ceiling (the initial bundle was already ~956 kB; the 500 kB warning had always been exceeded).

## Verified
`nx run-many -t lint test build --all` → green (6 projects). util now has **39 tests** (29 + 3 portfolio + 7 schemas).

## ⚠️ Please smoke-test before merge
`parseDatabaseDto` validates the **critical data-load path**. The schema matches what the app writes (a `Transactions` round-tripped through JSON → dates as ISO strings), and is lenient (passes through extra fields, optional `startDate`). But since it gates `getData`, please load the dashboard once on the deployed/local app to confirm real production payloads validate cleanly. If any legacy record has a different shape, it would now surface as an error toast rather than load — easy to relax the schema if so.

## Notes / not in scope
- CSV upload validation was considered but left out: `parseCsvInput` already skips malformed rows and R4 guards the effect; a strict DEGIRO-format schema risks rejecting valid exports. Candidate follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)