### PR TITLE
chore(infra): manage the backend as code via sam deploy (Phase 3 / IaC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,19 @@ node libs/backend/lambdas/src/dynamodb/init-dynamodb.js
 ### 2. Start the backend APIs (AWS SAM)
 
 ```
-sam build
+node libs/backend/lambdas/build.mjs
 sam local start-api
 ```
 
-This serves the Lambda functions on `http://localhost:3000`. `sam build` installs each Lambda's
-dependencies (including `jwks-rsa`, used for token verification) and `sam local start-api` reads
-configuration — Cognito user-pool/client IDs and allowed CORS origins — from `template.yaml`.
+`build.mjs` bundles each Lambda (with its dependencies, e.g. `jwks-rsa`) into a single file under
+`dist/lambdas/<name>/`, which is where `template.yaml`'s `CodeUri` points. `sam local start-api`
+then serves the functions on `http://localhost:3000`, reading configuration — Cognito
+user-pool/client IDs and allowed CORS origins — from `template.yaml` parameter defaults.
 
 > **Note:** the DynamoDB Lambda verifies the Cognito **ID token** on every request, so it needs
 > internet access to fetch the Cognito JWKS, and you must be signed in through the frontend (which
-> supplies a valid token). Re-run `sam build` whenever you change a Lambda's code or dependencies.
+> supplies a valid token). Re-run `node libs/backend/lambdas/build.mjs` whenever you change a
+> Lambda's code.
 
 ### 3. Start the frontend
 
@@ -75,13 +77,38 @@ SAM APIs on `:3000` (see `apps/frontend/proxy.conf.json`).
 | `nx build frontend` | Production build of the frontend |
 | `node libs/backend/lambdas/build.mjs` | Bundle the Lambdas (what CI does before deploy) |
 
-## Deployment
+## Deployment (Infrastructure as Code)
 
-CI (`buildspec.yml`) builds the frontend, bundles each Lambda into a single self-contained file
-with esbuild (`libs/backend/lambdas/build.mjs`), and deploys the functions with
-`aws lambda update-function-code`. The frontend bundle is published as the build artifact.
+The backend is managed as code with AWS SAM/CloudFormation. `template.yaml` defines the two
+Lambdas, a single API Gateway, and their environment variables; `samconfig.toml` holds the
+per-environment deploy settings (stack name, region, parameters).
 
-> **Production configuration:** the Lambdas read `ALLOWED_ORIGINS`, `COGNITO_USER_POOL_ID` and
-> `COGNITO_CLIENT_ID` from their environment. `template.yaml` sets dev-friendly defaults; the
-> deployed functions should have these set to the production values (the deploy step updates code
-> only, not configuration).
+CI (`buildspec.yml`) builds the frontend, bundles the Lambdas (`libs/backend/lambdas/build.mjs`),
+and runs `sam deploy --config-env prod` to provision/update the whole stack. The frontend bundle
+is published as the build artifact. Production parameters (prod CORS origin, Cognito IDs) live in
+`samconfig.toml`'s `[prod.deploy.parameters]`.
+
+> **CodeBuild role:** `sam deploy` needs permission to manage CloudFormation, IAM, API Gateway,
+> Lambda and S3 — broader than the old `update-function-code` flow. Grant these to the CodeBuild
+> service role before the first CI deploy.
+
+### One-time migration to the SAM stack
+
+The original prod functions and API Gateways were created by hand; the SAM stack is a fresh set of
+resources with **new** API URLs, so a one-time cutover is required:
+
+1. Ensure the CodeBuild (or your local) role has the permissions above, then deploy the stack:
+   ```
+   node libs/backend/lambdas/build.mjs
+   sam deploy --config-env prod
+   ```
+2. Read the stack **Outputs** (`YahooEndpoint`, `MicroserviceEndpoint`) — e.g.
+   `sam list stack-outputs --stack-name investments-tracker-prod` — and paste them into
+   `apps/frontend/src/environments/environment.prod.ts` (`yahooLambdaUrl`, `dynamoDBLambdaUrl`).
+3. Rebuild and redeploy the frontend so it points at the new endpoints.
+4. Once verified, delete the **old** hand-made `yahoo_finance` / `microservice` functions and their
+   API Gateways.
+
+> The existing **`Investment_Tracker` DynamoDB table is intentionally not managed by the stack** so
+> a deploy can never replace it with an empty table — the function is only granted access to it.
+> Cognito callback URLs point at the frontend domain (unchanged), so no Cognito changes are needed.

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,12 +7,12 @@ phases:
     commands:
       - echo Installing nx...
       - yarn global add nx
+      # The CodeBuild standard images ship the SAM CLI; install it if missing.
+      - sam --version || pip install aws-sam-cli
   pre_build:
     commands:
       - echo Installing dependencies...
-      # Root install covers the Lambda packages too (they are workspace members),
-      # so their deps (jsonwebtoken, jwks-rsa, ...) land in the root node_modules
-      # where the bundler resolves them.
+      # Root install covers the Lambda packages too (they are workspace members).
       - yarn install
       - echo Installing dependencies completed
   build:
@@ -20,20 +20,18 @@ phases:
       - echo Building frontend...
       - nx build frontend
       - echo Bundling Lambda functions...
-      # esbuild bundles each handler + its deps into a single self-contained
-      # file under dist/lambdas/<name>/index.mjs (see libs/backend/lambdas/build.mjs).
+      # esbuild bundles each handler + its deps into a single self-contained file
+      # under dist/lambdas/<name>/index.mjs (the template's CodeUri points there).
       - node libs/backend/lambdas/build.mjs
-      - echo Packaging Lambda function yahoo...
-      - cd dist/lambdas/yahoo && zip -r ../../../yahoo.zip index.mjs && cd ../../..
-      - echo Packaging Lambda function dynamo db...
-      - cd dist/lambdas/dynamodb && zip -r ../../../dynamodb.zip index.mjs && cd ../../..
       - echo Build completed on `date`
   post_build:
     commands:
-      - echo Deploying lambda function yahoo...
-      - aws lambda update-function-code --function-name yahoo_finance --zip-file fileb://yahoo.zip --region us-east-1
-      - echo Deploying lambda function dynamodb...
-      - aws lambda update-function-code --function-name microservice --zip-file fileb://dynamodb.zip --region us-east-1
+      - echo Deploying backend stack with SAM...
+      # Infrastructure as code: provisions/updates the Lambdas + API Gateway +
+      # env vars from template.yaml. Config (stack name, region, prod params) is
+      # in samconfig.toml [prod]. Requires the CodeBuild role to have permission
+      # to manage CloudFormation, IAM, API Gateway, Lambda and S3.
+      - sam deploy --config-env prod --no-confirm-changeset --no-fail-on-empty-changeset
       - echo Deployment completed on `date`
 
 artifacts:

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,23 @@
+version = 0.1
+
+# Deploy with:  sam deploy --config-env prod
+# (CodeUri points at the esbuild output, so run `node libs/backend/lambdas/build.mjs`
+#  first — the buildspec does this in CI.)
+
+[default.deploy.parameters]
+stack_name = "investments-tracker"
+region = "us-east-1"
+capabilities = "CAPABILITY_IAM"
+resolve_s3 = true
+confirm_changeset = false
+fail_on_empty_changeset = false
+parameter_overrides = "Stage=\"dev\" AllowedOrigins=\"http://localhost:4200\""
+
+[prod.deploy.parameters]
+stack_name = "investments-tracker-prod"
+region = "us-east-1"
+capabilities = "CAPABILITY_IAM"
+resolve_s3 = true
+confirm_changeset = false
+fail_on_empty_changeset = false
+parameter_overrides = "Stage=\"prod\" AllowedOrigins=\"https://investments-tracker.toondeboer.com\" CognitoUserPoolId=\"us-east-1_liCB4LgDE\" CognitoClientId=\"3o34bbl92faeo9ljo11eebtim2\""

--- a/template.yaml
+++ b/template.yaml
@@ -1,46 +1,95 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  yahoo
+  Investments Tracker backend — Yahoo Finance + DynamoDB Lambdas behind a single
+  API Gateway. Managed as code (CloudFormation/SAM); deploy with `sam deploy`.
 
-  Sample SAM Template for yahoo
+Parameters:
+  Stage:
+    Type: String
+    Default: dev
+    AllowedValues: [dev, prod]
+    Description: API Gateway stage name; also drives the DynamoDB Lambda's ENVIRONMENT.
+  AllowedOrigins:
+    Type: String
+    Default: http://localhost:4200
+    Description: Comma-separated CORS allowlist (the Lambdas reflect a matching Origin).
+  CognitoUserPoolId:
+    Type: String
+    Default: us-east-1_liCB4LgDE
+  CognitoClientId:
+    Type: String
+    Default: 3o34bbl92faeo9ljo11eebtim2
+  TableName:
+    Type: String
+    Default: Investment_Tracker
+    Description: >
+      Existing DynamoDB table (holds user data). Intentionally NOT created by this
+      stack so a fresh deploy can't replace it with an empty table — the function is
+      only granted access to it.
+
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Architectures: [x86_64]
+    # Yahoo fetches and the Cognito JWKS lookup can exceed the 3s default.
+    Timeout: 30
+    MemorySize: 256
 
 Resources:
+  Api:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: !Ref Stage
+
   YahooFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: libs/backend/lambdas/src/yahoo/
+      # Pre-bundled by esbuild (libs/backend/lambdas/build.mjs) into a single
+      # self-contained file; @aws-sdk is left external (provided by the runtime).
+      CodeUri: dist/lambdas/yahoo/
       Handler: index.handler
-      Runtime: nodejs22.x
-      Architectures:
-        - x86_64
+      Environment:
+        Variables:
+          ALLOWED_ORIGINS: !Ref AllowedOrigins
       Events:
         YahooFinance:
           Type: Api
           Properties:
+            RestApiId: !Ref Api
             Path: /yahoo_finance
-            Method: post
-      Environment:
-        Variables:
-          ALLOWED_ORIGINS: http://localhost:4200,https://investments-tracker.toondeboer.com
+            # ANY so the Lambda also answers the CORS preflight (OPTIONS).
+            Method: any
 
   DynamoDBFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: libs/backend/lambdas/src/dynamodb/
+      CodeUri: dist/lambdas/dynamodb/
       Handler: index.handler
-      Runtime: nodejs22.x
-      Architectures:
-        - x86_64
-      Events:
-        DynamoDB:
-          Type: Api
-          Properties:
-            Path: /microservice
-            Method: any
       Environment:
         Variables:
-          ENVIRONMENT: dev
-          ALLOWED_ORIGINS: http://localhost:4200,https://investments-tracker.toondeboer.com
-          COGNITO_USER_POOL_ID: us-east-1_liCB4LgDE
-          COGNITO_CLIENT_ID: 3o34bbl92faeo9ljo11eebtim2
+          ENVIRONMENT: !Ref Stage
+          ALLOWED_ORIGINS: !Ref AllowedOrigins
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TableName
+      Events:
+        Microservice:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /microservice
+            Method: any
+
+Outputs:
+  ApiBaseUrl:
+    Description: Base URL of the deployed API stage.
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}'
+  YahooEndpoint:
+    Description: Copy into environment.prod.ts -> yahooLambdaUrl
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/yahoo_finance'
+  MicroserviceEndpoint:
+    Description: Copy into environment.prod.ts -> dynamoDBLambdaUrl
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/microservice'


### PR DESCRIPTION
## Summary

Phase 3 — **IaC migration**. Replaces the code-only `aws lambda update-function-code` deploy (against hand-created Lambdas + hand-configured API Gateways) with a **CloudFormation/SAM stack**, so the API Gateway, Lambdas, CORS behaviour and env vars all live in version control. This removes the console↔repo config drift we hit during the CORS work.

Approach (chosen): a **fresh SAM stack** — new resources, new API URLs, one-time cutover.

## Changes
- **`template.yaml`** — complete, parameterized stack: one API Gateway, both Lambdas (`CodeUri` = the esbuild output), env vars from parameters (`Stage`, `AllowedOrigins`, Cognito IDs), `DynamoDBCrudPolicy` granting access to the **existing** `Investment_Tracker` table (intentionally *not* managed, so a deploy can never replace user data), and `Outputs` with the new endpoint URLs. Both routes use `ANY` so the Lambda answers the CORS preflight.
- **`samconfig.toml`** — dev + prod deploy params (stack name, region, prod CORS origin / Cognito IDs).
- **`buildspec.yml`** — `sam deploy --config-env prod` instead of `update-function-code`; installs the SAM CLI if absent.
- **`README.md`** — updated local-dev (`CodeUri` now points at the esbuild output, so `node build.mjs` replaces `sam build`) and a documented **one-time cutover**.

## Validated locally
- `sam validate --lint` → valid SAM template.
- `sam local invoke YahooFunction` (OPTIONS) → runs from the template's `CodeUri` and returns the expected CORS preflight response.
- `sam deploy` itself needs the AWS account, so it's run by CI / you (see cutover).

> ⚠️ Note: CI here (`nx affected`) won't exercise these files — they're not nx projects — so a green CI check does **not** validate the deploy. The local `sam validate`/`sam local invoke` above are the validation.

## One-time cutover (you run this — needs AWS access)
1. Grant the CodeBuild role permission to manage CloudFormation / IAM / API Gateway / Lambda / S3 (broader than before).
2. `node libs/backend/lambdas/build.mjs && sam deploy --config-env prod` → creates the stack.
3. Copy the stack `YahooEndpoint` / `MicroserviceEndpoint` outputs into `environment.prod.ts`, rebuild + redeploy the frontend.
4. Verify, then delete the old hand-made `yahoo_finance` / `microservice` functions + API Gateways.

The `Investment_Tracker` table is preserved (not managed by the stack); Cognito callbacks point at the unchanged frontend domain. Full steps are in the README's "One-time migration to the SAM stack" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)