### PR TITLE
chore(frontend): repoint prod API URLs to the SAM stack

### DIFF
--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -8,7 +8,7 @@ export const environment = {
   production: true,
   baseUrl: 'https://investments-tracker.toondeboer.com',
   yahooLambdaUrl:
-    'https://REPLACE_WITH_API_ID.execute-api.us-east-1.amazonaws.com/prod/yahoo_finance',
+    'https://jx9de60m0g.execute-api.us-east-1.amazonaws.com/prod/yahoo_finance',
   dynamoDBLambdaUrl:
-    'https://REPLACE_WITH_API_ID.execute-api.us-east-1.amazonaws.com/prod/microservice',
+    'https://jx9de60m0g.execute-api.us-east-1.amazonaws.com/prod/microservice',
 };

--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -1,8 +1,14 @@
+// TODO(cutover): the SAM stack (investments-tracker-prod) creates a NEW API
+// Gateway, so both URLs below must be repointed before this is deployed.
+// After `sam deploy --config-env prod`, get the new id from the stack outputs:
+//   sam list stack-outputs --stack-name investments-tracker-prod --region us-east-1
+// and replace REPLACE_WITH_API_ID below (both endpoints share the one API Gateway,
+// stage `prod`). DO NOT merge with the placeholder in place.
 export const environment = {
   production: true,
   baseUrl: 'https://investments-tracker.toondeboer.com',
   yahooLambdaUrl:
-    'https://42zobgj5c7.execute-api.us-east-1.amazonaws.com/default/yahoo_finance',
+    'https://REPLACE_WITH_API_ID.execute-api.us-east-1.amazonaws.com/prod/yahoo_finance',
   dynamoDBLambdaUrl:
-    'https://jkp05h7nyi.execute-api.us-east-1.amazonaws.com/prod/microservice',
+    'https://REPLACE_WITH_API_ID.execute-api.us-east-1.amazonaws.com/prod/microservice',
 };


### PR DESCRIPTION
## ⚠️ Draft — fill in the real API id before marking ready

The IaC migration (#35) creates a **fresh** API Gateway, so the frontend's prod endpoints have to move from the two old hand-made gateways to the new single stack gateway (`/prod` stage). This PR stages that change with a **placeholder** so the cutover is a visible, ready-to-fill step.

## What to do
1. (Once, with AWS access) run the first deploy and read the outputs:
   ```bash
   node libs/backend/lambdas/build.mjs
   sam deploy --config-env prod
   sam list stack-outputs --stack-name investments-tracker-prod --region us-east-1
   ```
2. Replace `REPLACE_WITH_API_ID` in `environment.prod.ts` with the real REST API id from `YahooEndpoint` / `MicroserviceEndpoint` (both share the one gateway).
3. Mark this PR **ready for review** and merge — CI then rebuilds the frontend pointing at the new endpoints.

## Notes
- Kept as a **draft** so the placeholder can't be merged by accident. CI will still go green (the placeholder is a valid string; the build doesn't validate URLs) — so the draft state is the real guard.
- Both URLs now use the `/prod` stage on one gateway (the old setup had yahoo on `/default` of a separate gateway).

If you'd rather, paste me the API id once you've deployed and I'll fill it in and un-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)