### PR TITLE
feat(reliability): HTTP timeouts + retry/backoff and getData caching (Phase 3 / R5+P3)

### DIFF
--- a/libs/backend/lambdas/src/yahoo/index.mjs
+++ b/libs/backend/lambdas/src/yahoo/index.mjs
@@ -66,6 +66,8 @@ export const handler = async (event) => {
         hostname: 'query1.finance.yahoo.com',
         path: apiUrl,
         method: 'GET',
+        // Don't let a hung connection pin the Lambda until its overall timeout.
+        timeout: 10000,
         headers: {
           Accept: '*/*',
           'User-Agent':
@@ -94,6 +96,10 @@ export const handler = async (event) => {
               reject(new Error(`Failed to parse Yahoo response for ${symbol}`));
             }
           });
+        });
+
+        req.on('timeout', () => {
+          req.destroy(new Error(`Yahoo request timed out for ${symbol}`));
         });
 
         req.on('error', (error) => {

--- a/libs/frontend/state/src/lib/+state/state.actions.ts
+++ b/libs/frontend/state/src/lib/+state/state.actions.ts
@@ -16,6 +16,8 @@ export const getDataFailure = createAction(
   '[State] Get Data Failure',
   props<{ error: string }>()
 );
+// Dispatched instead of re-fetching when cached data is still fresh (see P3).
+export const getDataCached = createAction('[State] Get Data Cached');
 
 export const saveTransaction = createAction(
   '[State] Save Transaction',

--- a/libs/frontend/state/src/lib/+state/state.effects.ts
+++ b/libs/frontend/state/src/lib/+state/state.effects.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { switchMap, catchError, of, map, tap } from 'rxjs';
+import { switchMap, catchError, of, map, tap, withLatestFrom } from 'rxjs';
 import {
   deleteAllTransactions,
   deleteAllTransactionsFailure,
@@ -13,6 +13,7 @@ import {
   deleteTransactionFailure,
   deleteTransactionSuccess,
   getData,
+  getDataCached,
   getDataFailure,
   getDataSuccess,
   handleFileInput,
@@ -22,7 +23,13 @@ import {
   saveTransactionFailure,
   saveTransactionSuccess,
 } from './state.actions';
+import { selectLastFetched } from './state.selectors';
 import { Transactions, parseCsvInput, translateToDutch } from '@aws/util';
+
+// How long a successful transactions fetch stays "fresh"; within this window a
+// repeat getData (e.g. navigating back to a route that loads data) is served
+// from the store instead of re-hitting DynamoDB.
+const GET_DATA_CACHE_MS = 30_000;
 
 @Injectable()
 export class StateEffects {
@@ -58,12 +65,18 @@ export class StateEffects {
   public readonly getData$ = createEffect(() =>
     this.actions$.pipe(
       ofType(getData),
-      switchMap(() => {
+      withLatestFrom(this.store.select(selectLastFetched)),
+      switchMap(([, lastFetched]) => {
+        // Serve from cache while still fresh (avoids re-fetching on every
+        // route visit that triggers getData).
+        if (
+          lastFetched !== null &&
+          Date.now() - lastFetched < GET_DATA_CACHE_MS
+        ) {
+          return of(getDataCached());
+        }
         return this.service.getData().pipe(
-          map(({ transactions }) => {
-            console.log('transactions', transactions);
-            return getDataSuccess({ data: transactions });
-          }),
+          map(({ transactions }) => getDataSuccess({ data: transactions })),
           catchError((error: HttpErrorResponse) =>
             of(getDataFailure({ error: error.message }))
           )

--- a/libs/frontend/state/src/lib/+state/state.reducer.ts
+++ b/libs/frontend/state/src/lib/+state/state.reducer.ts
@@ -7,6 +7,7 @@ import {
   deleteTransactionFailure,
   deleteTransactionSuccess,
   getData,
+  getDataCached,
   getDataFailure,
   getDataSuccess,
   handleFileInput,
@@ -31,6 +32,8 @@ export interface FeatureState {
   tickers: { [ticker: string]: Ticker };
   loading: boolean;
   error: string | null;
+  // Epoch ms of the last successful transactions fetch; drives the getData cache.
+  lastFetched: number | null;
 }
 
 export const initialState: FeatureState = {
@@ -38,6 +41,7 @@ export const initialState: FeatureState = {
   tickers: {},
   loading: false,
   error: null,
+  lastFetched: null,
 };
 
 export const reducer = createReducer(
@@ -69,8 +73,11 @@ export const reducer = createReducer(
     deleteTransactionSuccess,
     deleteAllTransactionsSuccess,
     handleFileInputSuccess,
-    (state) => ({ ...state, loading: false })
+    (state) => ({ ...state, loading: false, lastFetched: Date.now() })
   ),
+  // Cache hit: clear loading without touching data (and without re-triggering
+  // the Yahoo fetch, which keys off getDataSuccess).
+  on(getDataCached, (state) => ({ ...state, loading: false })),
   on(
     getDataFailure,
     saveTransactionFailure,

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -24,6 +24,11 @@ export const selectError = createSelector(
   (state: FeatureState) => state.error
 );
 
+export const selectLastFetched = createSelector(
+  selectFeature,
+  (state: FeatureState) => state.lastFetched
+);
+
 // Heavy portfolio derivation. Memoized by NgRx: it recomputes only when the raw
 // transactions or tickers change — NOT on every action or on loading/error
 // toggles. This is the work that previously ran in the reducer on every action.

--- a/libs/frontend/state/src/lib/state.service.ts
+++ b/libs/frontend/state/src/lib/state.service.ts
@@ -1,7 +1,13 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { DatabaseDto, parseDatabaseDto, Transactions } from '@aws/util';
-import { map, Observable } from 'rxjs';
+import {
+  DatabaseDto,
+  DYNAMODB_TIMEOUT_MS,
+  parseDatabaseDto,
+  retryWithBackoff,
+  Transactions,
+} from '@aws/util';
+import { map, Observable, timeout } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -14,9 +20,11 @@ export class StateService {
 
   public getData(): Observable<DatabaseDto> {
     console.log('AWS LAMBDA CALL - Database - get data');
-    return this.http
-      .get<unknown>(`${this.environment.dynamoDBLambdaUrl}`)
-      .pipe(map((response) => parseDatabaseDto(response)));
+    return this.http.get<unknown>(`${this.environment.dynamoDBLambdaUrl}`).pipe(
+      timeout(DYNAMODB_TIMEOUT_MS),
+      retryWithBackoff(),
+      map((response) => parseDatabaseDto(response))
+    );
   }
 
   public setTransactions(transactions: Transactions): Observable<DatabaseDto> {
@@ -24,6 +32,12 @@ export class StateService {
     console.log(transactions);
     return this.http
       .put<unknown>(`${this.environment.dynamoDBLambdaUrl}`, { transactions })
-      .pipe(map((response) => parseDatabaseDto(response)));
+      .pipe(
+        timeout(DYNAMODB_TIMEOUT_MS),
+        // The PUT is an idempotent "set transactions = ...", so retrying a
+        // transient failure can't double-write.
+        retryWithBackoff(),
+        map((response) => parseDatabaseDto(response))
+      );
   }
 }

--- a/libs/frontend/yahoo/src/lib/yahoo.service.ts
+++ b/libs/frontend/yahoo/src/lib/yahoo.service.ts
@@ -1,7 +1,13 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { map, Observable } from 'rxjs';
-import { parseYahooObjects, Stock, YahooObject } from '@aws/util';
+import { map, Observable, timeout } from 'rxjs';
+import {
+  parseYahooObjects,
+  retryWithBackoff,
+  Stock,
+  YahooObject,
+  YAHOO_TIMEOUT_MS,
+} from '@aws/util';
 
 @Injectable({
   providedIn: 'root',
@@ -40,8 +46,10 @@ export class YahooService {
       start: start,
       end: end,
     };
-    return this.http
-      .post<unknown>(this.environment.yahooLambdaUrl, body)
-      .pipe(map((response) => parseYahooObjects(response)));
+    return this.http.post<unknown>(this.environment.yahooLambdaUrl, body).pipe(
+      timeout(YAHOO_TIMEOUT_MS),
+      retryWithBackoff(),
+      map((response) => parseYahooObjects(response))
+    );
   }
 }

--- a/libs/shared/util/src/index.ts
+++ b/libs/shared/util/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/util';
 export * from './lib/types';
 export * from './lib/portfolio';
 export * from './lib/schemas';
+export * from './lib/http-resilience';

--- a/libs/shared/util/src/lib/http-resilience.spec.ts
+++ b/libs/shared/util/src/lib/http-resilience.spec.ts
@@ -1,0 +1,54 @@
+import { defer, lastValueFrom, of, throwError } from 'rxjs';
+import { retryWithBackoff } from './http-resilience';
+
+describe('retryWithBackoff', () => {
+  it('retries a transient (5xx) failure, then succeeds', async () => {
+    let attempts = 0;
+    const source = defer(() => {
+      attempts++;
+      return attempts < 3 ? throwError(() => ({ status: 503 })) : of('ok');
+    });
+
+    const result = await lastValueFrom(source.pipe(retryWithBackoff(3, 1)));
+    expect(result).toBe('ok');
+    expect(attempts).toBe(3);
+  });
+
+  it('retries network/timeout errors (no status)', async () => {
+    let attempts = 0;
+    const source = defer(() => {
+      attempts++;
+      return attempts < 2 ? throwError(() => new Error('timeout')) : of('ok');
+    });
+
+    const result = await lastValueFrom(source.pipe(retryWithBackoff(2, 1)));
+    expect(result).toBe('ok');
+    expect(attempts).toBe(2);
+  });
+
+  it('does NOT retry client errors (e.g. 401)', async () => {
+    let attempts = 0;
+    const source = defer(() => {
+      attempts++;
+      return throwError(() => ({ status: 401 }));
+    });
+
+    await expect(
+      lastValueFrom(source.pipe(retryWithBackoff(3, 1)))
+    ).rejects.toEqual({ status: 401 });
+    expect(attempts).toBe(1);
+  });
+
+  it('gives up after the retry budget is exhausted', async () => {
+    let attempts = 0;
+    const source = defer(() => {
+      attempts++;
+      return throwError(() => ({ status: 500 }));
+    });
+
+    await expect(
+      lastValueFrom(source.pipe(retryWithBackoff(2, 1)))
+    ).rejects.toEqual({ status: 500 });
+    expect(attempts).toBe(3); // initial + 2 retries
+  });
+});

--- a/libs/shared/util/src/lib/http-resilience.ts
+++ b/libs/shared/util/src/lib/http-resilience.ts
@@ -1,0 +1,40 @@
+import { MonoTypeOperatorFunction, retry, timer } from 'rxjs';
+
+// Per-request timeouts (ms). DynamoDB is fast; the Yahoo Lambda fans out to the
+// Yahoo API and is slower (its own Lambda timeout is 30s), so allow a bit more.
+export const DYNAMODB_TIMEOUT_MS = 15_000;
+export const YAHOO_TIMEOUT_MS = 35_000;
+
+// Retry transient failures only: network errors / RxJS TimeoutError (no status),
+// request timeout, rate limiting, and 5xx. Client errors (400/401/403/404/...)
+// won't succeed on retry, so they're rethrown immediately.
+function isRetryable(error: unknown): boolean {
+  const status = (error as { status?: number })?.status;
+  if (status === undefined || status === 0) {
+    return true;
+  }
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * Retry a read-idempotent HTTP stream on transient failures with exponential
+ * backoff + jitter. Non-retryable errors are rethrown without retrying.
+ *
+ * Pipe this AFTER `timeout(...)` and BEFORE any validation/parse `map(...)` so
+ * timeouts are retried but a bad payload fails fast.
+ */
+export function retryWithBackoff<T>(
+  maxRetries = 2,
+  baseDelayMs = 500
+): MonoTypeOperatorFunction<T> {
+  return retry({
+    count: maxRetries,
+    delay: (error, retryCount) => {
+      if (!isRetryable(error)) {
+        throw error;
+      }
+      const backoff = baseDelayMs * 2 ** (retryCount - 1);
+      return timer(backoff + Math.random() * 100);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 — **R5** (timeouts + retries) and **P3** (`getData` caching). Network calls had no timeout and no retry, so a transient blip failed hard; and `getData` re-fetched DynamoDB on every dispatch.

## R5 — timeouts + retry/backoff
- New shared, framework-agnostic **`retryWithBackoff()`** RxJS operator (+ timeout constants) in `@aws/util`. Retries **only transient** failures (network / RxJS `TimeoutError` / 408 / 429 / 5xx) with exponential backoff + jitter, and **rethrows client errors (4xx) immediately** (a 401/400 won't fix itself on retry).
- Wired `timeout()` + `retryWithBackoff()` into `state.service` (`getData`, and the idempotent `setTransactions` PUT) and `yahoo.service` (`getTickers`). Pipe order is `timeout → retry → validate`, so timeouts are retried but a bad payload still fails fast.
- **Yahoo Lambda:** added a 10s per-request socket timeout (`timeout` option + `'timeout'` handler that destroys the request) so a hung Yahoo connection can't pin the function until its 30s ceiling.

## P3 — getData cache
- Stamp `lastFetched` on every successful fetch; the `getData$` effect now serves a `getDataCached` no-op while still fresh (**30s**) instead of re-hitting DynamoDB on every route visit that dispatches `getData`. `getDataCached` clears `loading` **without** re-triggering the Yahoo price fetch (which keys off `getDataSuccess`). `switchMap` already handled in-flight de-dupe.

## Verified
`nx run-many -t lint test build --all` → green (6 projects). util now has **43 tests** (+4 for `retryWithBackoff`: retry-then-succeed, no-retry on 4xx, retry on network/timeout, budget exhaustion). Yahoo Lambda passes `node --check`.

## Notes
- Retrying `setTransactions` (PUT) is safe because the Lambda does an idempotent `set transactions = …` (not an append), so a retried transient failure can't double-write.
- Timeouts: 15s for DynamoDB, 35s for Yahoo (slightly above the Lambda's own 30s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)