### PR TITLE
fix(frontend): restore non-standalone AppComponent (fixes JIT error on nx serve)

### DIFF
--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -5,7 +5,8 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent, RouterTestingModule],
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
     }).compileComponents();
   });
 

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -1,11 +1,14 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'aws-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  imports: [RouterOutlet],
+  // The root component is bootstrapped via AppModule (an NgModule), so it must
+  // stay non-standalone — bootstrapping a standalone component from an NgModule
+  // breaks the dev server's JIT path (@angular/compiler gets tree-shaken).
+  // eslint-disable-next-line @angular-eslint/prefer-standalone
+  standalone: false,
 })
 export class AppComponent {
   title = 'frontend';

--- a/apps/frontend/src/app/app.module.ts
+++ b/apps/frontend/src/app/app.module.ts
@@ -18,7 +18,7 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { JwtInterceptor } from '../auth/jwtInterceptor/JwtInterceptor';
 
 @NgModule({
-  declarations: [],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
     HttpClientModule,


### PR DESCRIPTION
## Problem

`nx serve frontend` fails at runtime with:

> Uncaught Error: The NgModule 'AppModule' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.

## Cause

The T2 cleanup (#31) migrated the root `AppComponent` to **standalone** but kept the **NgModule bootstrap** (`AppModule` with `bootstrap: [AppComponent]`, `declarations: []`). Bootstrapping a *standalone* component from an NgModule works under **AOT** — so the production build and the deployed app are fine — but breaks the dev server's **JIT** path: Angular tree-shakes `@angular/compiler` (assuming a standalone app needs no runtime compiler), yet `AppModule` still requires JIT at runtime → the error.

## Fix

Restore `AppComponent` to **non-standalone**, declared in `AppModule` — the classic JIT-friendly pattern it had for the project's whole history. Kept the lint rule satisfied with a scoped `// eslint-disable-next-line @angular-eslint/prefer-standalone` (the root component is intentionally NgModule-based; a full standalone migration would mean `bootstrapApplication`, which is out of scope here).

## Verified
- `nx lint frontend` clean (no `prefer-standalone` error), `nx test frontend` ✅
- **Both** `nx build frontend` (production/AOT) **and** `nx build frontend --configuration development` compile.

This was my regression from #31 — apologies. Recommend merging promptly since it blocks local dev on every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)