### PR TITLE
feat(ui): active route highlight, dashboard polish, ticker chips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,6 @@ covers conventions and gotchas that aren't obvious from the code.
 - Before pushing, run `nx run-many -t lint test build --all` — green across all 6 projects is the bar.
 - `strict` and `noImplicitOverride` are on; **`noUncheckedIndexedAccess` is deliberately off** — it's
   the one remaining (optional) hardening item, best done module-by-module across `libs/shared/util`.
+- **After every set of changes: commit and open a PR.** The user reviews by commenting on the PR or
+  making a separate follow-up commit if they disagree — never hold back a commit waiting for verbal
+  approval.

--- a/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.html
+++ b/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.html
@@ -1,10 +1,15 @@
-<div>
-  <div>Select active tickers</div>
-  <div *ngFor="let ticker of tickers">
-    <label>
-    <input type="checkbox"  [checked]="activeStocks.includes(ticker)"   (change)="onCheckboxChange(ticker, $event )" />
-      {{ticker}}
-    </label>
+<div class="tickers-header">
+  <h2 class="section-title">Holdings</h2>
+  <div class="chips">
+    <button
+      *ngFor="let ticker of tickers"
+      class="chip"
+      [class.active]="activeStocks.includes(ticker)"
+      (click)="toggleTicker(ticker)"
+      type="button"
+    >
+      {{ ticker }}
+    </button>
   </div>
 </div>
 

--- a/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.scss
+++ b/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.scss
@@ -1,0 +1,49 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.tickers-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.section-title {
+  @include serif-heading;
+  font-size: 1.25rem;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  background: transparent;
+  border: 1px solid $color-border-strong;
+  border-radius: $radius-sm;
+  color: $color-muted;
+  cursor: pointer;
+  font-family: $font-sans;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  padding: 4px 12px;
+  text-transform: uppercase;
+  transition: $transition-base;
+
+  &:hover {
+    border-color: $color-gold;
+    color: $color-cream;
+  }
+
+  &.active {
+    background: rgba(201, 168, 76, 0.12);
+    border-color: $color-gold;
+    color: $color-gold;
+  }
+}

--- a/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.ts
+++ b/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.ts
@@ -31,12 +31,11 @@ export class ActiveTickersComponent implements OnChanges {
     }
   }
 
-  onCheckboxChange(value: string, event: Event) {
-    const input = event.target as HTMLInputElement;
-    if (input.checked) {
-      this.activeStocks.push(value);
+  toggleTicker(ticker: string) {
+    if (this.activeStocks.includes(ticker)) {
+      this.activeStocks = this.activeStocks.filter((v) => v !== ticker);
     } else {
-      this.activeStocks = this.activeStocks.filter((v) => v !== value);
+      this.activeStocks = [...this.activeStocks, ticker];
     }
     this.activeChartData = this.getActiveChartData();
   }

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -1,10 +1,21 @@
-<div class="grid" *ngIf="state$ | async as state">
-  <aws-summary [summary]="state.summary"></aws-summary>
+<div class="page" *ngIf="state$ | async as state">
 
-  <aws-active-tickers
-    *ngIf="state.summary.portfolioValue > 0"
-    [dates]="state.dates"
-    [stocks]="state.stocks"
-  ></aws-active-tickers>
+  <header class="page-header">
+    <h1 class="page-title">Portfolio</h1>
+    <p class="page-subtitle" *ngIf="state.summary.startDate">
+      Since {{ state.summary.startDate | date : 'MMM yyyy' }}
+    </p>
+  </header>
+
+  <section class="page-section">
+    <aws-summary [summary]="state.summary"></aws-summary>
+  </section>
+
+  <section class="page-section" *ngIf="state.summary.portfolioValue > 0">
+    <aws-active-tickers
+      [dates]="state.dates"
+      [stocks]="state.stocks"
+    ></aws-active-tickers>
+  </section>
 
 </div>

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
@@ -1,0 +1,30 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.page {
+  padding: 32px 24px;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 8px;
+}
+
+.page-title {
+  @include serif-heading;
+  font-size: 2rem;
+  margin: 0 0 4px;
+}
+
+.page-subtitle {
+  color: $color-muted;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0;
+}
+
+.page-section {
+  margin-top: 24px;
+}

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -1,17 +1,15 @@
 import { Component } from '@angular/core';
 import { selectState } from '@aws/state';
 import { Store } from '@ngrx/store';
-import { YahooComponent } from '../yahoo/yahoo.component';
 import { SummaryComponent } from '../summary/summary.component';
-import { AsyncPipe, CommonModule, NgIf } from '@angular/common';
-import { ChartData } from '@aws/util';
+import { AsyncPipe, CommonModule, DatePipe } from '@angular/common';
 import { ActiveTickersComponent } from '../active-tickers/active-tickers.component';
 
 @Component({
   selector: 'aws-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [SummaryComponent, AsyncPipe, CommonModule, ActiveTickersComponent],
+  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent],
 })
 export class DashboardComponent {
   state$ = this.store.select(selectState);

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
@@ -36,6 +36,7 @@
           <a
             mat-list-item
             class="nav-item"
+            [class.active]="isActive(nav.path)"
             *ngFor="let nav of navigationOptions"
             (click)="routeTo(nav.path, snav)"
           >

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.scss
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.scss
@@ -105,7 +105,7 @@ aws-scrolling-text {
     transition: $transition-base;
   }
 
-  &:hover {
+  &:hover, &.active {
     border-left-color: $color-gold;
     color: $color-cream !important;
     background-color: rgba(201, 168, 76, 0.07);
@@ -113,6 +113,10 @@ aws-scrolling-text {
     mat-icon {
       color: $color-gold;
     }
+  }
+
+  &.active {
+    background-color: rgba(201, 168, 76, 0.12);
   }
 }
 

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
@@ -72,6 +72,10 @@ export class PageWrapperComponent implements OnInit, OnDestroy {
     this.mobileQuery.removeListener(this._mobileQueryListener);
   }
 
+  isActive(path: string): boolean {
+    return this.router.url === '/' + path || this.router.url.startsWith('/' + path + '/');
+  }
+
   routeTo(route: string, snav: MatSidenav) {
     snav.close();
     this.router.navigate([route]);

--- a/libs/frontend/ui/src/lib/summary/summary.component.scss
+++ b/libs/frontend/ui/src/lib/summary/summary.component.scss
@@ -5,10 +5,6 @@
   margin-top: 16px;
   gap: 12px;
   justify-content: flex-start;
-
-  @include respond-to($bp-md) {
-    justify-content: center;
-  }
 }
 
 .box {

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
@@ -1,4 +1,3 @@
-<h1>Charts</h1>
 <div *ngIf="yahoo$ | async as yahoo" class="grid">
   <aws-bar-chart-per-quarter-by-year [series]="chartData?.dividend?.perQuarterByYear ?? []">
   </aws-bar-chart-per-quarter-by-year>

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.scss
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.scss
@@ -1,3 +1,0 @@
-h1 {
-  text-align: center;
-}


### PR DESCRIPTION
## Summary

- **Active route**: `page-wrapper` now calls `isActive()` to bind `.active` on the current sidenav item — gold left-border + stronger background distinguishes it from hover
- **Dashboard polish**: outer container changed from `.grid` (flex-row) to a `.page` wrapper with `32px 24px` padding; added a Playfair Display "Portfolio" heading + muted "Since MMM yyyy" subtitle; summary cards are now left-aligned
- **Active tickers**: raw `<input type="checkbox">` replaced with `<button class="chip">` elements; styled chip toggles (gold when active, muted/transparent when off); `onCheckboxChange` → `toggleTicker`
- **Cleanup**: removed stale `<h1>Charts</h1>` and its CSS from `yahoo.component`
- **CLAUDE.md**: documented the always-commit-and-PR workflow convention

## Test plan

- [x] Navigate between Dashboard and Transactions — active item highlights, inactive items don't
- [x] Dashboard renders "Portfolio" heading with start date subtitle
- [x] Summary cards lay out in a left-aligned row with correct padding
- [x] Clicking a ticker chip toggles it on/off; charts update accordingly
- [x] `nx build frontend` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)