### PR TITLE
feat(charts): fluid sizing, grouped sections, nautical card wrappers

### DIFF
--- a/libs/frontend/ui/src/lib/bar-and-line-chart/bar-and-line-chart.component.scss
+++ b/libs/frontend/ui/src/lib/bar-and-line-chart/bar-and-line-chart.component.scss
@@ -1,4 +1,4 @@
 .chart {
-  height: 400px;
-  width: 400px;
+  width: 100%;
+  height: 360px;
 }

--- a/libs/frontend/ui/src/lib/bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component.scss
+++ b/libs/frontend/ui/src/lib/bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component.scss
@@ -1,4 +1,4 @@
 .chart {
-  height: 400px;
-  width: 400px;
+  width: 100%;
+  height: 360px;
 }

--- a/libs/frontend/ui/src/lib/bar-chart/bar-chart.component.scss
+++ b/libs/frontend/ui/src/lib/bar-chart/bar-chart.component.scss
@@ -1,4 +1,4 @@
 .chart {
-  height: 400px;
-  width: 400px;
+  width: 100%;
+  height: 360px;
 }

--- a/libs/frontend/ui/src/lib/chart/chart.component.scss
+++ b/libs/frontend/ui/src/lib/chart/chart.component.scss
@@ -1,4 +1,4 @@
 .chart {
-  height: 400px;
-  width: 400px;
+  width: 100%;
+  height: 360px;
 }

--- a/libs/frontend/ui/src/lib/chart/chart.component.ts
+++ b/libs/frontend/ui/src/lib/chart/chart.component.ts
@@ -38,6 +38,7 @@ export class ChartComponent implements OnChanges {
         textStyle: { color: NAUTICAL_TEXT },
       },
       grid: {
+        top: 48,
         containLabel: true,
       },
       tooltip: {

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
@@ -1,72 +1,134 @@
-<div *ngIf="yahoo$ | async as yahoo" class="grid">
-  <aws-bar-chart-per-quarter-by-year [series]="chartData?.dividend?.perQuarterByYear ?? []">
-  </aws-bar-chart-per-quarter-by-year>
-  <aws-bar-and-line-chart [series]="chartData?.dividend?.ttmPerQuarter ?? {yearQuarters: [], dividends:[]}"></aws-bar-and-line-chart>
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.portfolioValues ?? []"
-    label="Portfolio"
-  ></aws-chart>
+<!-- ─── Performance ──────────────────────────────────────────────────────── -->
+<div class="chart-section">
+  <h3 class="section-title">Performance</h3>
+  <div class="charts-grid">
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.profit ?? []"
-    label="Profit"
-  ></aws-chart>
-  <aws-bar-chart [series]="chartData?.yieldPerYear ?? {years: [], yields: [], profit: []}"></aws-bar-chart>
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.portfolioValues ?? []"
+        label="Portfolio Value"
+      ></aws-chart>
+    </div>
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.dividend?.transactionValues ?? []"
-    label="Dividend (Kwartaal)"
-    [showSymbols]="true"
-  ></aws-chart>
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.profit ?? []"
+        label="Profit"
+      ></aws-chart>
+    </div>
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.dividend?.aggregatedValues ?? []"
-    label="Aggregated Dividend"
-  ></aws-chart>
+    <div class="chart-card">
+      <aws-bar-chart
+        [series]="chartData?.yieldPerYear ?? { years: [], yields: [], profit: [] }"
+      ></aws-bar-chart>
+    </div>
 
-  <ng-container *ngFor="let ticker of Object.keys(yahoo.tickers)">
-    <aws-chart
-      [x]="yahoo.tickers[ticker].dates"
-      [y]="yahoo.tickers[ticker].values"
-      [label]="'Yahoo Data: ' + ticker"
-    ></aws-chart>
-  </ng-container>
+  </div>
+</div>
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.commission?.aggregatedValues ?? []"
-    label="Aggregated Commission"
-  ></aws-chart>
+<!-- ─── Dividends ────────────────────────────────────────────────────────── -->
+<div class="chart-section">
+  <h3 class="section-title">Dividends</h3>
+  <div class="charts-grid">
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.stock?.transactionValues ?? []"
-    label="Transactions Values"
-    [showSymbols]="true"
-  ></aws-chart>
+    <div class="chart-card">
+      <aws-bar-chart-per-quarter-by-year
+        [series]="chartData?.dividend?.perQuarterByYear ?? []"
+      ></aws-bar-chart-per-quarter-by-year>
+    </div>
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.stock?.aggregatedValues ?? []"
-    label="Aggregated Transactions Values"
-  ></aws-chart>
+    <div class="chart-card">
+      <aws-bar-and-line-chart
+        [series]="chartData?.dividend?.ttmPerQuarter ?? { yearQuarters: [], dividends: [] }"
+      ></aws-bar-and-line-chart>
+    </div>
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.stock?.transactionAmounts ?? []"
-    label="Transactions Amounts"
-    [money]="false"
-    [showSymbols]="true"
-  ></aws-chart>
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.dividend?.transactionValues ?? []"
+        label="Dividend per Quarter"
+        [showSymbols]="true"
+      ></aws-chart>
+    </div>
 
-  <aws-chart
-    [x]="dates"
-    [y]="chartData?.stock?.aggregatedAmounts ?? []"
-    label="Aggregated Transactions Amounts"
-    [money]="false"
-  ></aws-chart>
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.dividend?.aggregatedValues ?? []"
+        label="Cumulative Dividend"
+      ></aws-chart>
+    </div>
+
+  </div>
+</div>
+
+<!-- ─── Holdings (live Yahoo prices) ─────────────────────────────────────── -->
+<div class="chart-section" *ngIf="yahoo$ | async as yahoo">
+  <h3 class="section-title">Holdings</h3>
+  <div class="charts-grid">
+
+    <div class="chart-card" *ngFor="let ticker of Object.keys(yahoo.tickers)">
+      <aws-chart
+        [x]="yahoo.tickers[ticker].dates"
+        [y]="yahoo.tickers[ticker].values"
+        [label]="ticker"
+      ></aws-chart>
+    </div>
+
+  </div>
+</div>
+
+<!-- ─── Transactions ──────────────────────────────────────────────────────── -->
+<div class="chart-section">
+  <h3 class="section-title">Transactions</h3>
+  <div class="charts-grid">
+
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.stock?.transactionValues ?? []"
+        label="Buy / Sell Values"
+        [showSymbols]="true"
+      ></aws-chart>
+    </div>
+
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.stock?.aggregatedValues ?? []"
+        label="Cumulative Invested"
+      ></aws-chart>
+    </div>
+
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.stock?.transactionAmounts ?? []"
+        label="Buy / Sell Amounts"
+        [money]="false"
+        [showSymbols]="true"
+      ></aws-chart>
+    </div>
+
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.stock?.aggregatedAmounts ?? []"
+        label="Cumulative Shares Held"
+        [money]="false"
+      ></aws-chart>
+    </div>
+
+    <div class="chart-card">
+      <aws-chart
+        [x]="dates"
+        [y]="chartData?.commission?.aggregatedValues ?? []"
+        label="Cumulative Commission"
+      ></aws-chart>
+    </div>
+
+  </div>
 </div>

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.scss
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.scss
@@ -1,0 +1,34 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.chart-section {
+  margin-bottom: 40px;
+}
+
+.section-title {
+  @include serif-heading;
+  font-size: 1.1rem;
+  margin: 0 0 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid $color-border;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: $color-muted;
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chart-card {
+  @include nautical-card;
+  padding: 16px 8px 8px;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Summary

- **Fluid charts**: all 4 chart components (`aws-chart`, `aws-bar-chart`, `aws-bar-and-line-chart`, `aws-bar-chart-per-quarter-by-year`) changed from hardcoded `400×400px` to `width: 100%; height: 360px` — they now fill their container
- **Grouped layout**: `yahoo.component` replaced flat `.grid` dump with 4 named sections — **Performance**, **Dividends**, **Holdings**, **Transactions** — each with a serif uppercase heading and a 2-column responsive `charts-grid` (collapses to 1 column ≤900px)
- **Nautical card wrappers**: each individual chart sits inside a `.chart-card` with `nautical-card` styling (dark surface, gold border, elevation shadow on hover)
- **Label cleanup**: "Dividend (Kwartaal)" → "Dividend per Quarter"; Yahoo ticker labels simplified to just the ticker symbol; chart names like "Aggregated Transactions Values" → "Cumulative Invested"
- **`yahoo$ | async` scope**: moved to only wrap the Holdings section — Performance, Dividends, and Transactions render immediately without waiting for live price data

## Test plan

- [ ] Dashboard → active tickers → charts render in 4 sections with visible headings
- [ ] Charts fill their card width on wide and narrow viewports
- [ ] Holdings section only appears after Yahoo data loads; other 3 sections render without it
- [ ] Hover over a chart card shows elevated shadow
- [ ] `nx build frontend` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)