### PR TITLE
feat(portfolios): multi-portfolio support, CSV imports, settings, dashboard filter

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -2,6 +2,8 @@ import { Route } from '@angular/router';
 import {
   DashboardComponent,
   PageWrapperComponent,
+  PortfoliosComponent,
+  SettingsComponent,
   TransactionsComponent,
 } from '@aws/ui';
 import { LandingWrapperComponent } from '../auth/landing-wrapper/landing-wrapper.component';
@@ -20,7 +22,9 @@ export const appRoutes: Route[] = [
     canActivate: [AuthGuard],
     children: [
       { path: 'dashboard', component: DashboardComponent },
-      { path: 'transactions', component: TransactionsComponent },
+      { path: 'portfolios', component: PortfoliosComponent },
+      { path: 'settings', component: SettingsComponent },
+      { path: 'transactions', redirectTo: 'portfolios' },
       { path: '**', redirectTo: 'dashboard' },
     ],
   },

--- a/apps/frontend/src/styles/_globals.scss
+++ b/apps/frontend/src/styles/_globals.scss
@@ -124,3 +124,17 @@
   --mdc-snackbar-supporting-text-color: #fff;
   --mat-snack-bar-button-color: #fff;
 }
+
+// ─── Material Dialog — override CDK overlay background to match theme ─────────
+.mat-mdc-dialog-container {
+  --mdc-dialog-container-color: #{$color-bg-elevated};
+  --mdc-dialog-subhead-color: #{$color-cream};
+  --mdc-dialog-supporting-text-color: #{$color-muted};
+
+  .mat-mdc-dialog-surface {
+    background-color: $color-bg-elevated !important;
+    border: 1px solid $color-border-strong;
+    border-radius: $radius-md !important;
+    box-shadow: $shadow-card;
+  }
+}

--- a/libs/frontend/state/src/lib/+state/state.actions.ts
+++ b/libs/frontend/state/src/lib/+state/state.actions.ts
@@ -1,31 +1,76 @@
 import {
   CsvInput,
   CsvInputEnglish,
+  DatabaseDto,
+  PortfolioDbo,
   Ticker,
-  Transactions,
-  TransactionsDbo,
+  Transaction,
+  TransactionKey,
+  UserSettingsDbo,
 } from '@aws/util';
 import { createAction, props } from '@ngrx/store';
 
+// --- Data load ---
 export const getData = createAction('[State] Get Data');
 export const getDataSuccess = createAction(
   '[State] Get Data Success',
-  props<{ data: TransactionsDbo }>()
+  props<{ data: DatabaseDto }>()
 );
 export const getDataFailure = createAction(
   '[State] Get Data Failure',
   props<{ error: string }>()
 );
-// Dispatched instead of re-fetching when cached data is still fresh (see P3).
+// Dispatched instead of re-fetching when cached data is still fresh.
 export const getDataCached = createAction('[State] Get Data Cached');
 
+// --- Portfolio management ---
+export const createPortfolio = createAction(
+  '[State] Create Portfolio',
+  props<{ name: string }>()
+);
+export const createPortfolioSuccess = createAction(
+  '[State] Create Portfolio Success',
+  props<{ data: DatabaseDto }>()
+);
+export const createPortfolioFailure = createAction(
+  '[State] Create Portfolio Failure',
+  props<{ error: string }>()
+);
+
+export const renamePortfolio = createAction(
+  '[State] Rename Portfolio',
+  props<{ portfolioId: string; newName: string }>()
+);
+export const renamePortfolioSuccess = createAction(
+  '[State] Rename Portfolio Success',
+  props<{ data: DatabaseDto }>()
+);
+export const renamePortfolioFailure = createAction(
+  '[State] Rename Portfolio Failure',
+  props<{ error: string }>()
+);
+
+export const deletePortfolio = createAction(
+  '[State] Delete Portfolio',
+  props<{ portfolioId: string }>()
+);
+export const deletePortfolioSuccess = createAction(
+  '[State] Delete Portfolio Success',
+  props<{ data: DatabaseDto }>()
+);
+export const deletePortfolioFailure = createAction(
+  '[State] Delete Portfolio Failure',
+  props<{ error: string }>()
+);
+
+// --- Transaction operations (portfolio-scoped) ---
 export const saveTransaction = createAction(
   '[State] Save Transaction',
-  props<{ transactions: Transactions }>()
+  props<{ portfolioId: string; transaction: Transaction }>()
 );
 export const saveTransactionSuccess = createAction(
   '[State] Save Transaction Success',
-  props<{ transactions: TransactionsDbo }>()
+  props<{ data: DatabaseDto }>()
 );
 export const saveTransactionFailure = createAction(
   '[State] Save Transaction Failure',
@@ -34,11 +79,11 @@ export const saveTransactionFailure = createAction(
 
 export const deleteTransaction = createAction(
   '[State] Delete Transaction',
-  props<{ newTransactions: Transactions }>()
+  props<{ portfolioId: string; transactionKey: TransactionKey }>()
 );
 export const deleteTransactionSuccess = createAction(
   '[State] Delete Transaction Success',
-  props<{ transactions: TransactionsDbo }>()
+  props<{ data: DatabaseDto }>()
 );
 export const deleteTransactionFailure = createAction(
   '[State] Delete Transaction Failure',
@@ -46,29 +91,80 @@ export const deleteTransactionFailure = createAction(
 );
 
 export const deleteAllTransactions = createAction(
-  '[State] Delete All Transactions'
+  '[State] Delete All Transactions',
+  props<{ portfolioId: string }>()
 );
 export const deleteAllTransactionsSuccess = createAction(
   '[State] Delete All Transactions Success',
-  props<{ transactions: TransactionsDbo }>()
+  props<{ data: DatabaseDto }>()
 );
 export const deleteAllTransactionsFailure = createAction(
   '[State] Delete All Transactions Failure',
   props<{ error: string }>()
 );
 
+// --- CSV imports ---
+export const importDeGiroCsv = createAction(
+  '[State] Import DeGiro CSV',
+  props<{ portfolioId: string; data: CsvInput | CsvInputEnglish; mode: 'replace' | 'merge' }>()
+);
+export const importDeGiroCsvSuccess = createAction(
+  '[State] Import DeGiro CSV Success',
+  props<{ data: DatabaseDto }>()
+);
+export const importDeGiroCsvFailure = createAction(
+  '[State] Import DeGiro CSV Failure',
+  props<{ error: string }>()
+);
+
+export const importYahooCsv = createAction(
+  '[State] Import Yahoo CSV',
+  props<{ portfolioId: string; rawRows: unknown[]; mode: 'replace' | 'merge' }>()
+);
+export const importYahooCsvSuccess = createAction(
+  '[State] Import Yahoo CSV Success',
+  props<{ data: DatabaseDto }>()
+);
+export const importYahooCsvFailure = createAction(
+  '[State] Import Yahoo CSV Failure',
+  props<{ error: string }>()
+);
+
+// --- Dashboard UI filter (not persisted) ---
+export const setSelectedPortfolios = createAction(
+  '[State] Set Selected Portfolios',
+  props<{ ids: string[] | 'all' }>()
+);
+
+// --- Settings ---
+export const updateSettings = createAction(
+  '[State] Update Settings',
+  props<{ settings: UserSettingsDbo }>()
+);
+export const updateSettingsSuccess = createAction(
+  '[State] Update Settings Success',
+  props<{ data: DatabaseDto }>()
+);
+export const updateSettingsFailure = createAction(
+  '[State] Update Settings Failure',
+  props<{ error: string }>()
+);
+
+// --- Yahoo price data ---
 export const setChartData = createAction(
   '[State] Set Chart Data',
   props<{ tickers: { [ticker: string]: Ticker } }>()
 );
 
+// Legacy action kept for backward compat with handleFileInput dispatch sites.
+// Internally mapped to importDeGiroCsv for the "default" portfolio.
 export const handleFileInput = createAction(
   '[State] Handle File Input',
   props<{ data: CsvInput | CsvInputEnglish }>()
 );
 export const handleFileInputSuccess = createAction(
   '[State] Handle File InputSuccess',
-  props<{ transactions: TransactionsDbo }>()
+  props<{ data: DatabaseDto }>()
 );
 export const handleFileInputFailure = createAction(
   '[State] Handle File InputFailure',

--- a/libs/frontend/state/src/lib/+state/state.effects.ts
+++ b/libs/frontend/state/src/lib/+state/state.effects.ts
@@ -6,9 +6,15 @@ import { Store } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { switchMap, catchError, of, map, tap, withLatestFrom } from 'rxjs';
 import {
+  createPortfolio,
+  createPortfolioFailure,
+  createPortfolioSuccess,
   deleteAllTransactions,
   deleteAllTransactionsFailure,
   deleteAllTransactionsSuccess,
+  deletePortfolio,
+  deletePortfolioFailure,
+  deletePortfolioSuccess,
   deleteTransaction,
   deleteTransactionFailure,
   deleteTransactionSuccess,
@@ -19,17 +25,37 @@ import {
   handleFileInput,
   handleFileInputFailure,
   handleFileInputSuccess,
+  importDeGiroCsv,
+  importDeGiroCsvFailure,
+  importDeGiroCsvSuccess,
+  importYahooCsv,
+  importYahooCsvFailure,
+  importYahooCsvSuccess,
+  renamePortfolio,
+  renamePortfolioFailure,
+  renamePortfolioSuccess,
   saveTransaction,
   saveTransactionFailure,
   saveTransactionSuccess,
+  updateSettings,
+  updateSettingsFailure,
+  updateSettingsSuccess,
 } from './state.actions';
-import { selectLastFetched } from './state.selectors';
-import { Transactions, parseCsvInput, translateToDutch } from '@aws/util';
+import { selectFeature, selectLastFetched } from './state.selectors';
+import {
+  DatabaseDto,
+  PortfolioDbo,
+  matchesTransactionKey,
+  mergeTransactions,
+  parseCsvInput,
+  parseYahooCsvInput,
+  transactionToTransactionDbo,
+  translateToDutch,
+} from '@aws/util';
 
-// How long a successful transactions fetch stays "fresh"; within this window a
-// repeat getData (e.g. navigating back to a route that loads data) is served
-// from the store instead of re-hitting DynamoDB.
 const GET_DATA_CACHE_MS = 30_000;
+
+const EMPTY_TRANSACTIONS = { stock: [], dividend: [], commission: [] };
 
 @Injectable()
 export class StateEffects {
@@ -40,17 +66,21 @@ export class StateEffects {
     private readonly snackBar: MatSnackBar
   ) {}
 
-  // Surface any failure to the user as a dismissible toast. Without this, the
-  // *Failure actions are dispatched but never shown — a save could fail silently.
   public readonly showError$ = createEffect(
     () =>
       this.actions$.pipe(
         ofType(
           getDataFailure,
+          createPortfolioFailure,
+          renamePortfolioFailure,
+          deletePortfolioFailure,
           saveTransactionFailure,
           deleteTransactionFailure,
           deleteAllTransactionsFailure,
-          handleFileInputFailure
+          importDeGiroCsvFailure,
+          importYahooCsvFailure,
+          handleFileInputFailure,
+          updateSettingsFailure
         ),
         tap(({ error }) =>
           this.snackBar.open(error || 'Something went wrong', 'Dismiss', {
@@ -67,8 +97,6 @@ export class StateEffects {
       ofType(getData),
       withLatestFrom(this.store.select(selectLastFetched)),
       switchMap(([, lastFetched]) => {
-        // Serve from cache while still fresh (avoids re-fetching on every
-        // route visit that triggers getData).
         if (
           lastFetched !== null &&
           Date.now() - lastFetched < GET_DATA_CACHE_MS
@@ -76,9 +104,63 @@ export class StateEffects {
           return of(getDataCached());
         }
         return this.service.getData().pipe(
-          map(({ transactions }) => getDataSuccess({ data: transactions })),
+          map((data) => getDataSuccess({ data })),
           catchError((error: HttpErrorResponse) =>
             of(getDataFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+
+  public readonly createPortfolio$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(createPortfolio),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ name }, state]) => {
+        const newPortfolio: PortfolioDbo = {
+          id: crypto.randomUUID(),
+          name,
+          transactions: EMPTY_TRANSACTIONS,
+        };
+        return this.service.setData(buildPayload(state, state.portfoliosDbo.concat(newPortfolio))).pipe(
+          map((data) => createPortfolioSuccess({ data })),
+          catchError((error: HttpErrorResponse) =>
+            of(createPortfolioFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+
+  public readonly renamePortfolio$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(renamePortfolio),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId, newName }, state]) => {
+        const updated = state.portfoliosDbo.map((p) =>
+          p.id === portfolioId ? { ...p, name: newName } : p
+        );
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => renamePortfolioSuccess({ data })),
+          catchError((error: HttpErrorResponse) =>
+            of(renamePortfolioFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+
+  public readonly deletePortfolio$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(deletePortfolio),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId }, state]) => {
+        const updated = state.portfoliosDbo.filter((p) => p.id !== portfolioId);
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => deletePortfolioSuccess({ data })),
+          catchError((error: HttpErrorResponse) =>
+            of(deletePortfolioFailure({ error: error.message }))
           )
         );
       })
@@ -88,13 +170,22 @@ export class StateEffects {
   public readonly saveTransaction$ = createEffect(() =>
     this.actions$.pipe(
       ofType(saveTransaction),
-      switchMap(({ transactions }) => {
-        return this.service.setTransactions(transactions).pipe(
-          map(({ transactions }) => {
-            return saveTransactionSuccess({
-              transactions,
-            });
-          }),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId, transaction }, state]) => {
+        const dbo = transactionToTransactionDbo(transaction);
+        const updated = state.portfoliosDbo.map((p) => {
+          if (p.id !== portfolioId) return p;
+          const typeKey = transaction.type as 'stock' | 'dividend' | 'commission';
+          return {
+            ...p,
+            transactions: {
+              ...p.transactions,
+              [typeKey]: [...p.transactions[typeKey], dbo],
+            },
+          };
+        });
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => saveTransactionSuccess({ data })),
           catchError((error: HttpErrorResponse) =>
             of(saveTransactionFailure({ error: error.message }))
           )
@@ -106,13 +197,23 @@ export class StateEffects {
   public readonly deleteTransaction$ = createEffect(() =>
     this.actions$.pipe(
       ofType(deleteTransaction),
-      switchMap(({ newTransactions }) => {
-        return this.service.setTransactions(newTransactions).pipe(
-          map(({ transactions }) => {
-            return deleteTransactionSuccess({
-              transactions,
-            });
-          }),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId, transactionKey }, state]) => {
+        const updated = state.portfoliosDbo.map((p) => {
+          if (p.id !== portfolioId) return p;
+          const filterOut = (txs: typeof p.transactions.stock) =>
+            txs.filter((tx) => !matchesTransactionKey(tx, transactionKey));
+          return {
+            ...p,
+            transactions: {
+              stock: filterOut(p.transactions.stock),
+              dividend: filterOut(p.transactions.dividend),
+              commission: filterOut(p.transactions.commission),
+            },
+          };
+        });
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => deleteTransactionSuccess({ data })),
           catchError((error: HttpErrorResponse) =>
             of(deleteTransactionFailure({ error: error.message }))
           )
@@ -124,42 +225,126 @@ export class StateEffects {
   public readonly deleteAllTransactions$ = createEffect(() =>
     this.actions$.pipe(
       ofType(deleteAllTransactions),
-      switchMap(() => {
-        return this.service
-          .setTransactions({ stock: [], commission: [], dividend: [] })
-          .pipe(
-            map(({ transactions }) => {
-              return deleteAllTransactionsSuccess({
-                transactions,
-              });
-            }),
-            catchError((error: HttpErrorResponse) =>
-              of(deleteAllTransactionsFailure({ error: error.message }))
-            )
-          );
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId }, state]) => {
+        const updated = state.portfoliosDbo.map((p) =>
+          p.id === portfolioId
+            ? { ...p, transactions: EMPTY_TRANSACTIONS }
+            : p
+        );
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => deleteAllTransactionsSuccess({ data })),
+          catchError((error: HttpErrorResponse) =>
+            of(deleteAllTransactionsFailure({ error: error.message }))
+          )
+        );
       })
     )
   );
 
+  public readonly importDeGiroCsv$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(importDeGiroCsv),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId, data, mode }, state]) => {
+        let parsed;
+        try {
+          parsed = parseCsvInput(translateToDutch(data));
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Failed to parse CSV file';
+          return of(importDeGiroCsvFailure({ error: message }));
+        }
+
+        const incoming = {
+          stock: parsed.stock.map(transactionToTransactionDbo),
+          dividend: parsed.dividend.map(transactionToTransactionDbo),
+          commission: parsed.commission.map(transactionToTransactionDbo),
+        };
+
+        const updated = state.portfoliosDbo.map((p) => {
+          if (p.id !== portfolioId) return p;
+          const transactions =
+            mode === 'replace'
+              ? incoming
+              : mergeTransactions(p.transactions, incoming);
+          return { ...p, transactions };
+        });
+
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => importDeGiroCsvSuccess({ data })),
+          catchError((error: HttpErrorResponse) =>
+            of(importDeGiroCsvFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+
+  public readonly importYahooCsv$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(importYahooCsv),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId, rawRows, mode }, state]) => {
+        let incoming;
+        try {
+          incoming = parseYahooCsvInput(rawRows);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Failed to parse Yahoo Finance CSV';
+          return of(importYahooCsvFailure({ error: message }));
+        }
+
+        const updated = state.portfoliosDbo.map((p) => {
+          if (p.id !== portfolioId) return p;
+          const transactions =
+            mode === 'replace' ? incoming : mergeTransactions(p.transactions, incoming);
+          return { ...p, transactions };
+        });
+
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((data) => importYahooCsvSuccess({ data })),
+          catchError((error: HttpErrorResponse) =>
+            of(importYahooCsvFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+
+  // Legacy handleFileInput: applies DeGiro CSV to the "default" portfolio in
+  // replace mode. Kept for backward compat with existing dispatch sites.
   public readonly handleFileInput$ = createEffect(() =>
     this.actions$.pipe(
       ofType(handleFileInput),
-      switchMap(({ data }) => {
-        let newTransactions: Transactions;
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ data }, state]) => {
+        let parsed;
         try {
-          newTransactions = parseCsvInput(translateToDutch(data));
+          parsed = parseCsvInput(translateToDutch(data));
         } catch (error) {
           const message =
             error instanceof Error ? error.message : 'Failed to parse CSV file';
           return of(handleFileInputFailure({ error: message }));
         }
 
-        return this.service.setTransactions(newTransactions).pipe(
-          map(({ transactions }) => {
-            return handleFileInputSuccess({
-              transactions,
-            });
-          }),
+        const incoming = {
+          stock: parsed.stock.map(transactionToTransactionDbo),
+          dividend: parsed.dividend.map(transactionToTransactionDbo),
+          commission: parsed.commission.map(transactionToTransactionDbo),
+        };
+
+        // Find "default" portfolio or first one.
+        const targetId =
+          state.portfoliosDbo.find((p) => p.id === 'default')?.id ??
+          state.portfoliosDbo[0]?.id;
+
+        const updated = state.portfoliosDbo.map((p) =>
+          p.id === targetId ? { ...p, transactions: incoming } : p
+        );
+
+        return this.service.setData(buildPayload(state, updated)).pipe(
+          map((d) => handleFileInputSuccess({ data: d })),
           catchError((error: HttpErrorResponse) =>
             of(handleFileInputFailure({ error: error.message }))
           )
@@ -167,4 +352,32 @@ export class StateEffects {
       })
     )
   );
+
+  public readonly updateSettings$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(updateSettings),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ settings }, state]) => {
+        return this.service
+          .setData({ portfolios: state.portfoliosDbo, settings, schemaVersion: 2 })
+          .pipe(
+            map((data) => updateSettingsSuccess({ data })),
+            catchError((error: HttpErrorResponse) =>
+              of(updateSettingsFailure({ error: error.message }))
+            )
+          );
+      })
+    )
+  );
+}
+
+function buildPayload(
+  state: { portfoliosDbo: PortfolioDbo[]; settings: { baseCurrency: string } },
+  portfolios: PortfolioDbo[]
+): DatabaseDto {
+  return {
+    portfolios,
+    settings: state.settings,
+    schemaVersion: 2,
+  };
 }

--- a/libs/frontend/state/src/lib/+state/state.reducer.ts
+++ b/libs/frontend/state/src/lib/+state/state.reducer.ts
@@ -1,8 +1,14 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
 import {
+  createPortfolio,
+  createPortfolioFailure,
+  createPortfolioSuccess,
   deleteAllTransactions,
   deleteAllTransactionsFailure,
   deleteAllTransactionsSuccess,
+  deletePortfolio,
+  deletePortfolioFailure,
+  deletePortfolioSuccess,
   deleteTransaction,
   deleteTransactionFailure,
   deleteTransactionSuccess,
@@ -13,77 +19,123 @@ import {
   handleFileInput,
   handleFileInputFailure,
   handleFileInputSuccess,
+  importDeGiroCsv,
+  importDeGiroCsvFailure,
+  importDeGiroCsvSuccess,
+  importYahooCsv,
+  importYahooCsvFailure,
+  importYahooCsvSuccess,
+  renamePortfolio,
+  renamePortfolioFailure,
+  renamePortfolioSuccess,
   saveTransaction,
   saveTransactionFailure,
   saveTransactionSuccess,
   setChartData,
+  setSelectedPortfolios,
+  updateSettings,
+  updateSettingsFailure,
+  updateSettingsSuccess,
 } from './state.actions';
-import { Ticker, TransactionsDbo } from '@aws/util';
+import { PortfolioDbo, Ticker, UserSettingsDbo } from '@aws/util';
 
 export const featureKey = 'state';
 
-// The reducer stores only RAW inputs: the transactions loaded from the backend
-// and the Yahoo price tickers. Every derived value (stocks, dates, summary,
-// chart data) is computed on demand in memoized selectors — see
-// state.selectors.ts. This keeps the reducer pure and cheap, and means the
-// expensive portfolio math runs only when its inputs actually change.
+// The reducer stores only RAW inputs: the portfolios loaded from the backend,
+// user settings, and the Yahoo price tickers. All derived values (stocks, dates,
+// summary, chart data) are computed on demand in memoized selectors.
 export interface FeatureState {
-  transactionsDbo: TransactionsDbo;
+  portfoliosDbo: PortfolioDbo[];
+  settings: UserSettingsDbo;
   tickers: { [ticker: string]: Ticker };
   loading: boolean;
   error: string | null;
-  // Epoch ms of the last successful transactions fetch; drives the getData cache.
   lastFetched: number | null;
+  // UI-only filter: which portfolios are shown on dashboard (not persisted).
+  selectedPortfolioIds: string[] | 'all';
 }
 
 export const initialState: FeatureState = {
-  transactionsDbo: { stock: [], dividend: [], commission: [] },
+  portfoliosDbo: [],
+  settings: { baseCurrency: 'EUR' },
   tickers: {},
   loading: false,
   error: null,
   lastFetched: null,
+  selectedPortfolioIds: 'all',
 };
 
 export const reducer = createReducer(
   initialState,
   on(getDataSuccess, (state, { data }) => ({
     ...state,
-    transactionsDbo: data,
+    portfoliosDbo: data.portfolios,
+    settings: data.settings,
   })),
   on(
+    createPortfolioSuccess,
+    renamePortfolioSuccess,
+    deletePortfolioSuccess,
     saveTransactionSuccess,
     deleteTransactionSuccess,
     deleteAllTransactionsSuccess,
+    importDeGiroCsvSuccess,
+    importYahooCsvSuccess,
     handleFileInputSuccess,
-    (state, { transactions }) => ({ ...state, transactionsDbo: transactions })
+    updateSettingsSuccess,
+    (state, { data }) => ({
+      ...state,
+      portfoliosDbo: data.portfolios,
+      settings: data.settings,
+    })
   ),
   on(setChartData, (state, { tickers }) => ({ ...state, tickers })),
-  // --- request / success / failure status tracking ---
+  on(setSelectedPortfolios, (state, { ids }) => ({
+    ...state,
+    selectedPortfolioIds: ids,
+  })),
+  // --- loading / error tracking ---
   on(
     getData,
+    createPortfolio,
+    renamePortfolio,
+    deletePortfolio,
     saveTransaction,
     deleteTransaction,
     deleteAllTransactions,
+    importDeGiroCsv,
+    importYahooCsv,
     handleFileInput,
+    updateSettings,
     (state) => ({ ...state, loading: true, error: null })
   ),
   on(
     getDataSuccess,
+    createPortfolioSuccess,
+    renamePortfolioSuccess,
+    deletePortfolioSuccess,
     saveTransactionSuccess,
     deleteTransactionSuccess,
     deleteAllTransactionsSuccess,
+    importDeGiroCsvSuccess,
+    importYahooCsvSuccess,
     handleFileInputSuccess,
+    updateSettingsSuccess,
     (state) => ({ ...state, loading: false, lastFetched: Date.now() })
   ),
-  // Cache hit: clear loading without touching data (and without re-triggering
-  // the Yahoo fetch, which keys off getDataSuccess).
   on(getDataCached, (state) => ({ ...state, loading: false })),
   on(
     getDataFailure,
+    createPortfolioFailure,
+    renamePortfolioFailure,
+    deletePortfolioFailure,
     saveTransactionFailure,
     deleteTransactionFailure,
     deleteAllTransactionsFailure,
+    importDeGiroCsvFailure,
+    importYahooCsvFailure,
     handleFileInputFailure,
+    updateSettingsFailure,
     (state, { error }) => ({ ...state, loading: false, error })
   )
 );

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -1,47 +1,80 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { computePortfolioState } from '@aws/util';
+import { computeAllPortfolios, computePortfolioState, mergeTransactionsDbo } from '@aws/util';
 import { FeatureState, featureKey } from './state.reducer';
 
 export const selectFeature = createFeatureSelector<FeatureState>(featureKey);
 
-const selectTransactionsDbo = createSelector(
+export const selectPortfoliosDbo = createSelector(
   selectFeature,
-  (state: FeatureState) => state.transactionsDbo
+  (state) => state.portfoliosDbo
+);
+
+export const selectSettings = createSelector(
+  selectFeature,
+  (state) => state.settings
+);
+
+export const selectBaseCurrency = createSelector(
+  selectSettings,
+  (settings) => settings.baseCurrency
 );
 
 const selectTickers = createSelector(
   selectFeature,
-  (state: FeatureState) => state.tickers
+  (state) => state.tickers
 );
 
 export const selectLoading = createSelector(
   selectFeature,
-  (state: FeatureState) => state.loading
+  (state) => state.loading
 );
 
 export const selectError = createSelector(
   selectFeature,
-  (state: FeatureState) => state.error
+  (state) => state.error
 );
 
 export const selectLastFetched = createSelector(
   selectFeature,
-  (state: FeatureState) => state.lastFetched
+  (state) => state.lastFetched
 );
 
-// Heavy portfolio derivation. Memoized by NgRx: it recomputes only when the raw
-// transactions or tickers change — NOT on every action or on loading/error
-// toggles. This is the work that previously ran in the reducer on every action.
-const selectPortfolio = createSelector(
-  selectTransactionsDbo,
+export const selectSelectedPortfolioIds = createSelector(
+  selectFeature,
+  (state) => state.selectedPortfolioIds
+);
+
+// The portfolios that are currently visible on the dashboard.
+export const selectVisiblePortfoliosDbo = createSelector(
+  selectPortfoliosDbo,
+  selectSelectedPortfolioIds,
+  (portfolios, ids) =>
+    ids === 'all' ? portfolios : portfolios.filter((p) => ids.includes(p.id))
+);
+
+// Aggregate portfolio state — merges all visible portfolios' transactions and
+// runs computePortfolioState over them. This is the view-model used by the
+// dashboard and as the backward-compat selectState.
+const selectAggregatePortfolio = createSelector(
+  selectVisiblePortfoliosDbo,
   selectTickers,
-  (transactionsDbo, tickers) => computePortfolioState(transactionsDbo, tickers)
+  (portfolios, tickers) => {
+    const merged = mergeTransactionsDbo(portfolios.map((p) => p.transactions));
+    return computePortfolioState(merged, tickers);
+  }
 );
 
-// Public view-model — the same shape components and the Yahoo effect consumed
-// before A1 (transactions, stocks, dates, summary, currencies) plus loading/error.
+// Per-portfolio computed states keyed by portfolio ID.
+export const selectAllPortfolioStates = createSelector(
+  selectPortfoliosDbo,
+  selectTickers,
+  (portfolios, tickers) => computeAllPortfolios(portfolios, tickers)
+);
+
+// Public view-model — same shape as before (transactions, stocks, dates, summary,
+// currencies) plus loading/error. Backward compat for existing components.
 export const selectState = createSelector(
-  selectPortfolio,
+  selectAggregatePortfolio,
   selectLoading,
   selectError,
   (portfolio, loading, error) => ({ ...portfolio, loading, error })

--- a/libs/frontend/state/src/lib/state.service.ts
+++ b/libs/frontend/state/src/lib/state.service.ts
@@ -5,7 +5,6 @@ import {
   DYNAMODB_TIMEOUT_MS,
   parseDatabaseDto,
   retryWithBackoff,
-  Transactions,
 } from '@aws/util';
 import { map, Observable, timeout } from 'rxjs';
 
@@ -26,13 +25,11 @@ export class StateService {
     );
   }
 
-  public setTransactions(transactions: Transactions): Observable<DatabaseDto> {
+  public setData(payload: DatabaseDto): Observable<DatabaseDto> {
     return this.http
-      .put<unknown>(`${this.environment.dynamoDBLambdaUrl}`, { transactions })
+      .put<unknown>(`${this.environment.dynamoDBLambdaUrl}`, payload)
       .pipe(
         timeout(DYNAMODB_TIMEOUT_MS),
-        // The PUT is an idempotent "set transactions = ...", so retrying a
-        // transient failure can't double-write.
         retryWithBackoff(),
         map((response) => parseDatabaseDto(response))
       );

--- a/libs/frontend/ui/src/index.ts
+++ b/libs/frontend/ui/src/index.ts
@@ -2,4 +2,6 @@ export * from './lib/ui.module';
 export * from './lib/dashboard/dashboard.component';
 export * from './lib/page-wrapper/page-wrapper.component';
 export * from './lib/transactions/transactions.component';
+export * from './lib/portfolios/portfolios.component';
+export * from './lib/settings/settings.component';
 export * from './lib/landing-page/landing-page.component';

--- a/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.html
+++ b/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>{{ data.title }}</h2>
+<mat-dialog-content>{{ data.message }}</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="dialogRef.close(false)">Cancel</button>
+  <button mat-flat-button color="warn" (click)="dialogRef.close(true)">
+    {{ data.confirmLabel ?? 'Delete' }}
+  </button>
+</mat-dialog-actions>

--- a/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.html
+++ b/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.html
@@ -1,8 +1,12 @@
-<h2 mat-dialog-title>{{ data.title }}</h2>
-<mat-dialog-content>{{ data.message }}</mat-dialog-content>
-<mat-dialog-actions align="end">
-  <button mat-button (click)="dialogRef.close(false)">Cancel</button>
-  <button mat-flat-button color="warn" (click)="dialogRef.close(true)">
+<h2 class="dialog-title">{{ data.title }}</h2>
+
+<mat-dialog-content class="dialog-content">
+  <p class="dialog-message">{{ data.message }}</p>
+</mat-dialog-content>
+
+<div class="dialog-actions">
+  <button class="btn btn-secondary" (click)="dialogRef.close(false)">Cancel</button>
+  <button class="btn btn-danger" (click)="dialogRef.close(true)">
     {{ data.confirmLabel ?? 'Delete' }}
   </button>
-</mat-dialog-actions>
+</div>

--- a/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
+++ b/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,48 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.dialog-title {
+  @include serif-heading;
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 24px 24px 0;
+  margin: 0;
+}
+
+.dialog-content {
+  padding: 16px 24px 4px !important;
+  min-width: 320px;
+}
+
+.dialog-message {
+  color: $color-muted;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 24px 20px;
+}
+
+.btn-danger {
+  padding: 0.75rem 1.5rem;
+  border-radius: $radius-sm;
+  font-weight: 600;
+  font-size: 0.9rem;
+  font-family: $font-sans;
+  border: none;
+  cursor: pointer;
+  background: rgba($color-error, 0.15);
+  color: $color-error;
+  border: 1px solid rgba($color-error, 0.3);
+  transition: $transition-base;
+
+  &:hover {
+    background: rgba($color-error, 0.25);
+    border-color: $color-error;
+  }
+}

--- a/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
@@ -1,7 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { MatButtonModule } from '@angular/material/button';
 
 export type ConfirmDialogData = {
   title: string;
@@ -12,7 +11,8 @@ export type ConfirmDialogData = {
 @Component({
   selector: 'aws-confirm-dialog',
   templateUrl: './confirm-dialog.component.html',
-  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  styleUrls: ['./confirm-dialog.component.scss'],
+  imports: [CommonModule, MatDialogModule],
 })
 export class ConfirmDialogComponent {
   constructor(

--- a/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/frontend/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,22 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+export type ConfirmDialogData = {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+};
+
+@Component({
+  selector: 'aws-confirm-dialog',
+  templateUrl: './confirm-dialog.component.html',
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+})
+export class ConfirmDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmDialogComponent, boolean>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmDialogData
+  ) {}
+}

--- a/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.html
+++ b/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.html
@@ -1,0 +1,37 @@
+<h2 mat-dialog-title>Import CSV</h2>
+
+<mat-dialog-content class="csv-dialog-content">
+
+  <div class="field-group">
+    <div class="field-label">Format</div>
+    <mat-radio-group [(ngModel)]="format" class="radio-group">
+      <mat-radio-button value="degiro">DeGiro CSV</mat-radio-button>
+      <mat-radio-button value="yahoo">Yahoo Finance CSV</mat-radio-button>
+    </mat-radio-group>
+  </div>
+
+  <div class="field-group">
+    <div class="field-label">Import mode</div>
+    <mat-radio-group [(ngModel)]="mode" class="radio-group">
+      <mat-radio-button value="replace">Replace existing transactions</mat-radio-button>
+      <mat-radio-button value="merge">Add to existing (deduplicate)</mat-radio-button>
+    </mat-radio-group>
+  </div>
+
+  <div class="field-group">
+    <div class="field-label">File</div>
+    <label class="file-upload-area">
+      <span *ngIf="!fileName" class="upload-hint">Click to select a CSV file</span>
+      <span *ngIf="fileName" class="file-name">{{ fileName }} ({{ rows.length }} rows)</span>
+      <input type="file" accept=".csv" (change)="onFileSelected($event)" class="hidden-input" />
+    </label>
+  </div>
+
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()" [disabled]="rows.length === 0">
+    Import
+  </button>
+</mat-dialog-actions>

--- a/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.html
+++ b/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.html
@@ -1,6 +1,6 @@
-<h2 mat-dialog-title>Import CSV</h2>
+<h2 class="dialog-title">Import CSV</h2>
 
-<mat-dialog-content class="csv-dialog-content">
+<mat-dialog-content class="dialog-content">
 
   <div class="field-group">
     <div class="field-label">Format</div>
@@ -20,18 +20,34 @@
 
   <div class="field-group">
     <div class="field-label">File</div>
-    <label class="file-upload-area">
-      <span *ngIf="!fileName" class="upload-hint">Click to select a CSV file</span>
-      <span *ngIf="fileName" class="file-name">{{ fileName }} ({{ rows.length }} rows)</span>
+    <label
+      class="drop-zone"
+      [class.dragging]="isDragging"
+      [class.has-file]="fileName"
+      (dragover)="onDragOver($event)"
+      (dragleave)="onDragLeave($event)"
+      (drop)="onDrop($event)"
+    >
+      <div class="drop-zone-inner">
+        <span class="drop-icon">⛵</span>
+        <ng-container *ngIf="!fileName">
+          <span class="drop-primary">Drop your CSV here</span>
+          <span class="drop-secondary">or <span class="drop-link">browse files</span></span>
+        </ng-container>
+        <ng-container *ngIf="fileName">
+          <span class="file-name">{{ fileName }}</span>
+          <span class="file-rows">{{ rows.length }} rows ready to import</span>
+        </ng-container>
+      </div>
       <input type="file" accept=".csv" (change)="onFileSelected($event)" class="hidden-input" />
     </label>
   </div>
 
 </mat-dialog-content>
 
-<mat-dialog-actions align="end">
-  <button mat-button (click)="cancel()">Cancel</button>
-  <button mat-flat-button color="primary" (click)="confirm()" [disabled]="rows.length === 0">
+<div class="dialog-actions">
+  <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+  <button class="btn btn-primary" (click)="confirm()" [disabled]="rows.length === 0">
     Import
   </button>
-</mat-dialog-actions>
+</div>

--- a/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.scss
+++ b/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.scss
@@ -1,0 +1,56 @@
+.csv-dialog-content {
+  min-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-top: 8px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-label {
+  font-size: 13px;
+  font-weight: 600;
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.file-upload-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 16px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+}
+
+.upload-hint {
+  opacity: 0.5;
+  font-size: 14px;
+}
+
+.file-name {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.hidden-input {
+  display: none;
+}

--- a/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.scss
+++ b/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.scss
@@ -1,56 +1,144 @@
-.csv-dialog-content {
-  min-width: 380px;
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.dialog-title {
+  @include serif-heading;
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 24px 24px 0;
+  margin: 0;
+}
+
+.dialog-content {
+  padding: 20px 24px 8px !important;
   display: flex;
   flex-direction: column;
   gap: 20px;
-  padding-top: 8px;
+  min-width: 400px;
+  max-height: 70vh;
 }
 
 .field-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .field-label {
-  font-size: 13px;
+  font-size: 0.72rem;
   font-weight: 600;
-  opacity: 0.7;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.08em;
+  color: $color-muted;
 }
 
 .radio-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
-.file-upload-area {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px dashed rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  padding: 16px;
-  cursor: pointer;
-  transition: border-color 0.2s;
+// Override Material radio button colors to match theme
+::ng-deep mat-radio-button {
+  .mdc-radio__outer-circle {
+    border-color: $color-muted !important;
+  }
 
-  &:hover {
-    border-color: rgba(255, 255, 255, 0.5);
+  &.mat-mdc-radio-checked .mdc-radio__outer-circle {
+    border-color: $color-gold !important;
+  }
+
+  &.mat-mdc-radio-checked .mdc-radio__inner-circle {
+    border-color: $color-gold !important;
+    background-color: $color-gold !important;
+  }
+
+  .mdc-label {
+    color: $color-cream;
+    font-size: 0.875rem;
+    font-family: $font-sans;
   }
 }
 
-.upload-hint {
-  opacity: 0.5;
-  font-size: 14px;
+// ─── Drop zone ───────────────────────────────────────────────────────────────
+.drop-zone {
+  display: block;
+  border: 2px dashed $color-border-strong;
+  border-radius: $radius-md;
+  padding: 28px 24px;
+  cursor: pointer;
+  transition: $transition-base;
+  text-align: center;
+
+  &:hover,
+  &.dragging {
+    border-color: $color-gold;
+    background: rgba(201, 168, 76, 0.06);
+
+    .drop-icon { transform: scale(1.1); }
+  }
+
+  &.has-file {
+    border-style: solid;
+    border-color: rgba(201, 168, 76, 0.5);
+    background: rgba(201, 168, 76, 0.06);
+  }
+}
+
+.drop-zone-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.drop-icon {
+  font-size: 1.75rem;
+  display: block;
+  transition: transform 0.2s ease;
+}
+
+.drop-primary {
+  font-size: 0.9rem;
+  color: $color-cream;
+}
+
+.drop-secondary {
+  font-size: 0.8rem;
+  color: $color-muted;
+}
+
+.drop-link {
+  color: $color-gold;
+  text-decoration: underline;
 }
 
 .file-name {
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: $color-gold;
+}
+
+.file-rows {
+  font-size: 0.78rem;
+  color: $color-muted;
 }
 
 .hidden-input {
   display: none;
+}
+
+// ─── Action row ──────────────────────────────────────────────────────────────
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 24px 20px;
+}
+
+.btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
 }

--- a/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.ts
+++ b/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectorRef, Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { Papa } from 'ngx-papaparse';
+
+export type CsvUploadDialogData = { portfolioId: string };
+
+export type CsvUploadResult = {
+  portfolioId: string;
+  format: 'degiro' | 'yahoo';
+  mode: 'replace' | 'merge';
+  rows: unknown[];
+};
+
+@Component({
+  selector: 'aws-csv-upload-dialog',
+  templateUrl: './csv-upload-dialog.component.html',
+  styleUrls: ['./csv-upload-dialog.component.scss'],
+  imports: [CommonModule, FormsModule, MatDialogModule, MatButtonModule, MatRadioModule, MatSelectModule, MatFormFieldModule],
+})
+export class CsvUploadDialogComponent {
+  format: 'degiro' | 'yahoo' = 'degiro';
+  mode: 'replace' | 'merge' = 'replace';
+  fileName = '';
+  rows: unknown[] = [];
+
+  constructor(
+    public dialogRef: MatDialogRef<CsvUploadDialogComponent, CsvUploadResult | undefined>,
+    @Inject(MAT_DIALOG_DATA) public data: CsvUploadDialogData,
+    private papa: Papa,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    this.fileName = file.name;
+    this.papa.parse(file, {
+      header: true,
+      complete: (result) => {
+        this.rows = result.data;
+        this.cdr.detectChanges();
+      },
+    });
+  }
+
+  confirm() {
+    if (this.rows.length === 0) return;
+    this.dialogRef.close({
+      portfolioId: this.data.portfolioId,
+      format: this.format,
+      mode: this.mode,
+      rows: this.rows,
+    });
+  }
+
+  cancel() {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.ts
+++ b/libs/frontend/ui/src/lib/csv-upload-dialog/csv-upload-dialog.component.ts
@@ -4,8 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatSelectModule } from '@angular/material/select';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { Papa } from 'ngx-papaparse';
 
 export type CsvUploadDialogData = { portfolioId: string };
@@ -21,13 +19,14 @@ export type CsvUploadResult = {
   selector: 'aws-csv-upload-dialog',
   templateUrl: './csv-upload-dialog.component.html',
   styleUrls: ['./csv-upload-dialog.component.scss'],
-  imports: [CommonModule, FormsModule, MatDialogModule, MatButtonModule, MatRadioModule, MatSelectModule, MatFormFieldModule],
+  imports: [CommonModule, FormsModule, MatDialogModule, MatButtonModule, MatRadioModule],
 })
 export class CsvUploadDialogComponent {
   format: 'degiro' | 'yahoo' = 'degiro';
   mode: 'replace' | 'merge' = 'replace';
   fileName = '';
   rows: unknown[] = [];
+  isDragging = false;
 
   constructor(
     public dialogRef: MatDialogRef<CsvUploadDialogComponent, CsvUploadResult | undefined>,
@@ -39,7 +38,30 @@ export class CsvUploadDialogComponent {
   onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
-    if (!file) return;
+    if (file) this.parseFile(file);
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = true;
+  }
+
+  onDragLeave(event: DragEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = false;
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = false;
+    const file = event.dataTransfer?.files?.[0];
+    if (file) this.parseFile(file);
+  }
+
+  private parseFile(file: File) {
     this.fileName = file.name;
     this.papa.parse(file, {
       header: true,

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -1,20 +1,44 @@
-<div class="page" *ngIf="state$ | async as state">
+<div
+  class="page"
+  *ngIf="{
+    state: state$ | async,
+    portfolios: portfolios$ | async,
+    selectedIds: selectedPortfolioIds$ | async,
+    currency: baseCurrency$ | async
+  } as vm"
+>
 
   <header class="page-header">
     <h1 class="page-title">Portfolio</h1>
-    <p class="page-subtitle" *ngIf="state.summary.startDate">
-      Since {{ state.summary.startDate | date : 'MMM yyyy' }}
+    <p class="page-subtitle" *ngIf="vm.state?.summary?.startDate">
+      Since {{ vm.state?.summary?.startDate | date : 'MMM yyyy' }}
     </p>
   </header>
 
-  <section class="page-section">
-    <aws-summary [summary]="state.summary"></aws-summary>
+  <!-- Portfolio filter chips (shown only when multiple portfolios exist) -->
+  <section class="page-section" *ngIf="(vm.portfolios?.length ?? 0) > 1">
+    <div class="filter-label">Portfolios</div>
+    <div class="chips">
+      <button
+        *ngFor="let portfolio of vm.portfolios"
+        class="chip"
+        [class.active]="isPortfolioActive(portfolio.id, vm.selectedIds ?? 'all')"
+        (click)="togglePortfolio(portfolio.id, vm.selectedIds ?? 'all', portfolioIds(vm.portfolios ?? []))"
+        type="button"
+      >
+        {{ portfolio.name }}
+      </button>
+    </div>
   </section>
 
-  <section class="page-section" *ngIf="state.summary.portfolioValue > 0">
+  <section class="page-section">
+    <aws-summary [summary]="vm.state?.summary" [currency]="vm.currency ?? 'EUR'"></aws-summary>
+  </section>
+
+  <section class="page-section" *ngIf="vm.state?.summary?.portfolioValue">
     <aws-active-tickers
-      [dates]="state.dates"
-      [stocks]="state.stocks"
+      [dates]="vm.state?.dates ?? []"
+      [stocks]="vm.state?.stocks ?? {}"
     ></aws-active-tickers>
   </section>
 

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
@@ -28,3 +28,37 @@
 .page-section {
   margin-top: 24px;
 }
+
+.filter-label {
+  font-size: 12px;
+  opacity: 0.5;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  color: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+
+  &.active {
+    background: rgba(var(--primary-rgb, 100, 150, 255), 0.2);
+    border-color: rgba(var(--primary-rgb, 100, 150, 255), 0.6);
+  }
+
+  &:hover:not(.active) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+}

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -1,5 +1,11 @@
 import { Component } from '@angular/core';
-import { selectState } from '@aws/state';
+import {
+  selectBaseCurrency,
+  selectPortfoliosDbo,
+  selectSelectedPortfolioIds,
+  selectState,
+  setSelectedPortfolios,
+} from '@aws/state';
 import { Store } from '@ngrx/store';
 import { SummaryComponent } from '../summary/summary.component';
 import { AsyncPipe, CommonModule, DatePipe } from '@angular/common';
@@ -13,6 +19,28 @@ import { ActiveTickersComponent } from '../active-tickers/active-tickers.compone
 })
 export class DashboardComponent {
   state$ = this.store.select(selectState);
+  portfolios$ = this.store.select(selectPortfoliosDbo);
+  selectedPortfolioIds$ = this.store.select(selectSelectedPortfolioIds);
+  baseCurrency$ = this.store.select(selectBaseCurrency);
 
   constructor(private store: Store) {}
+
+  isPortfolioActive(portfolioId: string, selectedIds: string[] | 'all'): boolean {
+    return selectedIds === 'all' || selectedIds.includes(portfolioId);
+  }
+
+  portfolioIds(portfolios: { id: string }[]): string[] {
+    return portfolios.map((p) => p.id);
+  }
+
+  togglePortfolio(portfolioId: string, selectedIds: string[] | 'all', allIds: string[]) {
+    let current = selectedIds === 'all' ? [...allIds] : [...selectedIds];
+    if (current.includes(portfolioId)) {
+      current = current.filter((id) => id !== portfolioId);
+    } else {
+      current = [...current, portfolioId];
+    }
+    const ids = current.length === allIds.length ? 'all' : current;
+    this.store.dispatch(setSelectedPortfolios({ ids }));
+  }
 }

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
@@ -45,8 +45,9 @@ export class PageWrapperComponent implements OnInit, OnDestroy {
   loading$ = this.store.select(selectLoading);
   mobileQuery: MediaQueryList;
   navigationOptions = [
-    { path: 'dashboard',     text: 'Dashboard',     icon: 'dashboard' },
-    { path: 'transactions',  text: 'Transactions',  icon: 'tune' },
+    { path: 'dashboard',  text: 'Dashboard',  icon: 'dashboard' },
+    { path: 'portfolios', text: 'Portfolios', icon: 'folder' },
+    { path: 'settings',   text: 'Settings',   icon: 'settings' },
   ];
 
   private _mobileQueryListener: () => void;

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.html
@@ -1,9 +1,8 @@
 <div class="portfolio-detail" *ngIf="portfolio; else noSelection">
   <div class="detail-header">
     <h2 class="detail-title">{{ portfolio.name }}</h2>
-    <button mat-stroked-button (click)="importCsv.emit(portfolio.id)" class="import-btn">
-      <mat-icon>upload</mat-icon>
-      Import CSV
+    <button class="btn btn-secondary import-btn" (click)="importCsv.emit(portfolio.id)">
+      &#8593; Import CSV
     </button>
   </div>
 
@@ -15,7 +14,7 @@
 
 <ng-template #noSelection>
   <div class="no-selection">
-    <mat-icon class="no-selection-icon">folder_open</mat-icon>
+    <span class="no-selection-icon">&#128193;</span>
     <p>Select a portfolio to view transactions</p>
   </div>
 </ng-template>

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.html
@@ -1,0 +1,21 @@
+<div class="portfolio-detail" *ngIf="portfolio; else noSelection">
+  <div class="detail-header">
+    <h2 class="detail-title">{{ portfolio.name }}</h2>
+    <button mat-stroked-button (click)="importCsv.emit(portfolio.id)" class="import-btn">
+      <mat-icon>upload</mat-icon>
+      Import CSV
+    </button>
+  </div>
+
+  <aws-transactions-table
+    [stocks]="stocks"
+    [portfolioId]="portfolioId"
+  ></aws-transactions-table>
+</div>
+
+<ng-template #noSelection>
+  <div class="no-selection">
+    <mat-icon class="no-selection-icon">folder_open</mat-icon>
+    <p>Select a portfolio to view transactions</p>
+  </div>
+</ng-template>

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.scss
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.scss
@@ -1,0 +1,49 @@
+.portfolio-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+}
+
+.detail-title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.import-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.no-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  opacity: 0.4;
+  gap: 16px;
+}
+
+.no-selection-icon {
+  font-size: 64px;
+  width: 64px;
+  height: 64px;
+}

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.scss
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.scss
@@ -1,35 +1,32 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
 .portfolio-detail {
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
 }
 
 .detail-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 24px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid rgba(201, 168, 76, 0.15);
   flex-shrink: 0;
 }
 
 .detail-title {
-  font-size: 20px;
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 1.5rem;
   font-weight: 600;
+  color: #F5F0E8;
+  letter-spacing: 0.02em;
   margin: 0;
-}
-
-.import-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-
-  mat-icon {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-  }
 }
 
 .no-selection {
@@ -38,12 +35,18 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  opacity: 0.4;
+  color: #8FA8C0;
   gap: 16px;
+  opacity: 0.5;
+
+  p {
+    font-size: 14px;
+    margin: 0;
+  }
 }
 
 .no-selection-icon {
-  font-size: 64px;
-  width: 64px;
-  height: 64px;
+  font-size: 56px;
+  width: 56px;
+  height: 56px;
 }

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { PortfolioDbo, Stock, Transaction, TransactionKey } from '@aws/util';
+import { TransactionsTableComponent } from '../transactions-table/transactions-table.component';
+
+@Component({
+  selector: 'aws-portfolio-detail',
+  templateUrl: './portfolio-detail.component.html',
+  styleUrls: ['./portfolio-detail.component.scss'],
+  imports: [CommonModule, MatButtonModule, MatIconModule, TransactionsTableComponent],
+})
+export class PortfolioDetailComponent {
+  @Input() portfolio: PortfolioDbo | null = null;
+  @Input() stocks: { [ticker: string]: Stock } = {};
+
+  @Output() importCsv = new EventEmitter<string>();
+
+  get portfolioId(): string {
+    return this.portfolio?.id ?? 'default';
+  }
+}

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.ts
@@ -1,15 +1,13 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { PortfolioDbo, Stock, Transaction, TransactionKey } from '@aws/util';
+import { PortfolioDbo, Stock } from '@aws/util';
 import { TransactionsTableComponent } from '../transactions-table/transactions-table.component';
 
 @Component({
   selector: 'aws-portfolio-detail',
   templateUrl: './portfolio-detail.component.html',
   styleUrls: ['./portfolio-detail.component.scss'],
-  imports: [CommonModule, MatButtonModule, MatIconModule, TransactionsTableComponent],
+  imports: [CommonModule, TransactionsTableComponent],
 })
 export class PortfolioDetailComponent {
   @Input() portfolio: PortfolioDbo | null = null;

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.html
@@ -1,7 +1,7 @@
 <div class="portfolio-list">
   <div class="list-header">
-    <h2 class="list-title">Portfolios</h2>
-    <button mat-icon-button (click)="createPortfolio.emit()" matTooltip="New portfolio">
+    <span class="list-title">Portfolios</span>
+    <button mat-icon-button class="add-btn" (click)="createPortfolio.emit()" title="New portfolio">
       <mat-icon>add</mat-icon>
     </button>
   </div>
@@ -17,20 +17,21 @@
         <div class="portfolio-name">{{ portfolio.name }}</div>
         <div class="portfolio-count">{{ transactionCount(portfolio) }} transactions</div>
       </div>
+
       <div class="portfolio-actions" (click)="$event.stopPropagation()">
         <button
           mat-icon-button
           class="action-btn"
+          title="Rename"
           (click)="renamePortfolio.emit(portfolio)"
-          matTooltip="Rename"
         >
           <mat-icon>edit</mat-icon>
         </button>
         <button
           mat-icon-button
           class="action-btn delete-btn"
+          title="Delete"
           (click)="deletePortfolio.emit(portfolio)"
-          matTooltip="Delete"
         >
           <mat-icon>delete</mat-icon>
         </button>
@@ -38,7 +39,7 @@
     </div>
 
     <div *ngIf="portfolios.length === 0" class="empty-state">
-      No portfolios yet. Create one to get started.
+      No portfolios yet.<br />Click + to create one.
     </div>
   </div>
 </div>

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.html
@@ -1,0 +1,44 @@
+<div class="portfolio-list">
+  <div class="list-header">
+    <h2 class="list-title">Portfolios</h2>
+    <button mat-icon-button (click)="createPortfolio.emit()" matTooltip="New portfolio">
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
+
+  <div class="portfolio-items">
+    <div
+      *ngFor="let portfolio of portfolios"
+      class="portfolio-item"
+      [class.selected]="portfolio.id === selectedPortfolioId"
+      (click)="selectPortfolio.emit(portfolio.id)"
+    >
+      <div class="portfolio-info">
+        <div class="portfolio-name">{{ portfolio.name }}</div>
+        <div class="portfolio-count">{{ transactionCount(portfolio) }} transactions</div>
+      </div>
+      <div class="portfolio-actions" (click)="$event.stopPropagation()">
+        <button
+          mat-icon-button
+          class="action-btn"
+          (click)="renamePortfolio.emit(portfolio)"
+          matTooltip="Rename"
+        >
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          class="action-btn delete-btn"
+          (click)="deletePortfolio.emit(portfolio)"
+          matTooltip="Delete"
+        >
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+    </div>
+
+    <div *ngIf="portfolios.length === 0" class="empty-state">
+      No portfolios yet. Create one to get started.
+    </div>
+  </div>
+</div>

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.scss
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.scss
@@ -1,22 +1,47 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .portfolio-list {
   display: flex;
   flex-direction: column;
   height: 100%;
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .list-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 16px 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 20px 16px 12px;
+  border-bottom: 1px solid $color-border;
+  flex-shrink: 0;
+
+  // Override Material icon button colour
+  button {
+    color: $color-muted !important;
+    transition: $transition-base;
+
+    &:hover {
+      color: $color-gold !important;
+    }
+
+    mat-icon { font-size: 20px; }
+  }
 }
 
 .list-title {
-  font-size: 16px;
+  @include serif-heading;
+  font-size: 1rem;
   font-weight: 600;
   margin: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: $color-muted;
 }
 
 .portfolio-items {
@@ -28,15 +53,15 @@
 .portfolio-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
+  padding: 10px 12px 10px 16px;
   cursor: pointer;
-  border-radius: 8px;
-  margin: 2px 8px;
-  transition: background 0.15s;
+  border-left: 3px solid transparent;
+  transition: background 0.15s, border-color 0.15s;
+  gap: 4px;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(201, 168, 76, 0.05);
+    border-left-color: rgba(201, 168, 76, 0.3);
 
     .portfolio-actions {
       opacity: 1;
@@ -44,9 +69,11 @@
   }
 
   &.selected {
-    background: rgba(var(--primary-rgb, 100, 150, 255), 0.15);
+    background: rgba(201, 168, 76, 0.1);
+    border-left-color: $color-gold;
 
     .portfolio-name {
+      color: $color-cream;
       font-weight: 600;
     }
   }
@@ -58,43 +85,55 @@
 }
 
 .portfolio-name {
-  font-size: 14px;
+  font-size: 0.9rem;
+  color: $color-cream;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .portfolio-count {
-  font-size: 12px;
-  opacity: 0.5;
+  font-size: 0.72rem;
+  color: $color-muted;
   margin-top: 2px;
 }
 
 .portfolio-actions {
   display: flex;
+  align-items: center;
+  gap: 0;
   opacity: 0;
   transition: opacity 0.15s;
+  flex-shrink: 0;
 }
 
 .action-btn {
-  width: 28px;
-  height: 28px;
-  line-height: 28px;
+  width: 28px !important;
+  height: 28px !important;
+  line-height: 28px !important;
+  color: $color-muted !important;
+  transition: color 0.15s;
+
+  &:hover {
+    color: $color-gold !important;
+  }
 
   mat-icon {
     font-size: 16px;
     width: 16px;
     height: 16px;
+    line-height: 16px;
   }
 }
 
-.delete-btn {
-  color: rgba(255, 80, 80, 0.8);
+.delete-btn:hover {
+  color: $color-error !important;
 }
 
 .empty-state {
-  padding: 32px 16px;
+  padding: 40px 20px;
   text-align: center;
-  opacity: 0.5;
-  font-size: 14px;
+  color: $color-muted;
+  font-size: 0.875rem;
+  line-height: 1.6;
 }

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.scss
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.scss
@@ -1,0 +1,100 @@
+.portfolio-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.list-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.portfolio-items {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.portfolio-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  cursor: pointer;
+  border-radius: 8px;
+  margin: 2px 8px;
+  transition: background 0.15s;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.06);
+
+    .portfolio-actions {
+      opacity: 1;
+    }
+  }
+
+  &.selected {
+    background: rgba(var(--primary-rgb, 100, 150, 255), 0.15);
+
+    .portfolio-name {
+      font-weight: 600;
+    }
+  }
+}
+
+.portfolio-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.portfolio-name {
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.portfolio-count {
+  font-size: 12px;
+  opacity: 0.5;
+  margin-top: 2px;
+}
+
+.portfolio-actions {
+  display: flex;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.action-btn {
+  width: 28px;
+  height: 28px;
+  line-height: 28px;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.delete-btn {
+  color: rgba(255, 80, 80, 0.8);
+}
+
+.empty-state {
+  padding: 32px 16px;
+  text-align: center;
+  opacity: 0.5;
+  font-size: 14px;
+}

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.ts
@@ -1,15 +1,14 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
 import { PortfolioDbo } from '@aws/util';
 
 @Component({
   selector: 'aws-portfolio-list',
   templateUrl: './portfolio-list.component.html',
   styleUrls: ['./portfolio-list.component.scss'],
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule],
+  imports: [CommonModule, MatIconModule, MatButtonModule],
 })
 export class PortfolioListComponent {
   @Input() portfolios: PortfolioDbo[] = [];

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.ts
@@ -1,0 +1,30 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { PortfolioDbo } from '@aws/util';
+
+@Component({
+  selector: 'aws-portfolio-list',
+  templateUrl: './portfolio-list.component.html',
+  styleUrls: ['./portfolio-list.component.scss'],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule],
+})
+export class PortfolioListComponent {
+  @Input() portfolios: PortfolioDbo[] = [];
+  @Input() selectedPortfolioId: string | null = null;
+
+  @Output() selectPortfolio = new EventEmitter<string>();
+  @Output() createPortfolio = new EventEmitter<void>();
+  @Output() renamePortfolio = new EventEmitter<PortfolioDbo>();
+  @Output() deletePortfolio = new EventEmitter<PortfolioDbo>();
+
+  transactionCount(portfolio: PortfolioDbo): number {
+    return (
+      portfolio.transactions.stock.length +
+      portfolio.transactions.dividend.length +
+      portfolio.transactions.commission.length
+    );
+  }
+}

--- a/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.html
@@ -1,0 +1,11 @@
+<h2 mat-dialog-title>{{ data.title }}</h2>
+<mat-dialog-content>
+  <mat-form-field appearance="outline" style="width: 100%">
+    <mat-label>Portfolio name</mat-label>
+    <input matInput [(ngModel)]="name" (keyup.enter)="confirm()" autofocus />
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()" [disabled]="!name.trim()">Confirm</button>
+</mat-dialog-actions>

--- a/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.html
@@ -1,11 +1,22 @@
-<h2 mat-dialog-title>{{ data.title }}</h2>
-<mat-dialog-content>
-  <mat-form-field appearance="outline" style="width: 100%">
-    <mat-label>Portfolio name</mat-label>
-    <input matInput [(ngModel)]="name" (keyup.enter)="confirm()" autofocus />
-  </mat-form-field>
+<h2 class="dialog-title">{{ data.title }}</h2>
+
+<mat-dialog-content class="dialog-content">
+  <div class="field-group">
+    <label class="field-label">Name</label>
+    <input
+      class="field-input"
+      type="text"
+      [(ngModel)]="name"
+      (keyup.enter)="confirm()"
+      placeholder="e.g. DEGIRO, Long-term, ISA…"
+      autofocus
+    />
+  </div>
 </mat-dialog-content>
-<mat-dialog-actions align="end">
-  <button mat-button (click)="cancel()">Cancel</button>
-  <button mat-flat-button color="primary" (click)="confirm()" [disabled]="!name.trim()">Confirm</button>
-</mat-dialog-actions>
+
+<div class="dialog-actions">
+  <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+  <button class="btn btn-primary" (click)="confirm()" [disabled]="!name.trim()">
+    Confirm
+  </button>
+</div>

--- a/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.scss
+++ b/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.scss
@@ -1,0 +1,65 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.dialog-title {
+  @include serif-heading;
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 24px 24px 0;
+  margin: 0;
+}
+
+.dialog-content {
+  padding: 20px 24px 8px !important;
+  min-width: 340px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: $color-muted;
+}
+
+.field-input {
+  background: $color-bg-surface;
+  border: 1px solid $color-border-strong;
+  border-radius: $radius-sm;
+  padding: 10px 14px;
+  color: $color-cream;
+  font-family: $font-sans;
+  font-size: 0.9rem;
+  width: 100%;
+  box-sizing: border-box;
+  outline: none;
+  transition: $transition-base;
+
+  &::placeholder {
+    color: rgba(143, 168, 192, 0.5);
+  }
+
+  &:focus {
+    border-color: $color-gold;
+    box-shadow: 0 0 0 2px rgba(201, 168, 76, 0.15);
+  }
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 24px 20px;
+}
+
+.btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}

--- a/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.ts
@@ -1,0 +1,38 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+
+export type PortfolioNameDialogData = {
+  title: string;
+  initialName?: string;
+};
+
+@Component({
+  selector: 'aws-portfolio-name-dialog',
+  templateUrl: './portfolio-name-dialog.component.html',
+  imports: [CommonModule, FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+})
+export class PortfolioNameDialogComponent {
+  name: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<PortfolioNameDialogComponent, string>,
+    @Inject(MAT_DIALOG_DATA) public data: PortfolioNameDialogData
+  ) {
+    this.name = data.initialName ?? '';
+  }
+
+  confirm() {
+    if (this.name.trim()) {
+      this.dialogRef.close(this.name.trim());
+    }
+  }
+
+  cancel() {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-name-dialog/portfolio-name-dialog.component.ts
@@ -2,9 +2,6 @@ import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
 
 export type PortfolioNameDialogData = {
   title: string;
@@ -14,7 +11,8 @@ export type PortfolioNameDialogData = {
 @Component({
   selector: 'aws-portfolio-name-dialog',
   templateUrl: './portfolio-name-dialog.component.html',
-  imports: [CommonModule, FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  styleUrls: ['./portfolio-name-dialog.component.scss'],
+  imports: [CommonModule, FormsModule, MatDialogModule],
 })
 export class PortfolioNameDialogComponent {
   name: string;

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.html
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.html
@@ -1,0 +1,20 @@
+<div class="portfolios-layout" *ngIf="{ portfolios: portfolios$ | async, state: state$ | async } as vm">
+  <aside class="portfolios-sidebar">
+    <aws-portfolio-list
+      [portfolios]="vm.portfolios ?? []"
+      [selectedPortfolioId]="selectedPortfolioId"
+      (selectPortfolio)="onSelectPortfolio($event)"
+      (createPortfolio)="onCreatePortfolio()"
+      (renamePortfolio)="onRenamePortfolio($event)"
+      (deletePortfolio)="onDeletePortfolio($event)"
+    ></aws-portfolio-list>
+  </aside>
+
+  <main class="portfolios-main">
+    <aws-portfolio-detail
+      [portfolio]="getSelectedPortfolio(vm.portfolios ?? [])"
+      [stocks]="vm.state?.stocks ?? {}"
+      (importCsv)="onImportCsv($event)"
+    ></aws-portfolio-detail>
+  </main>
+</div>

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.scss
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.scss
@@ -1,0 +1,20 @@
+.portfolios-layout {
+  display: flex;
+  height: calc(100vh - 64px);
+  overflow: hidden;
+}
+
+.portfolios-sidebar {
+  width: 260px;
+  min-width: 260px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.portfolios-main {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.scss
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.scss
@@ -1,20 +1,27 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
 .portfolios-layout {
   display: flex;
-  height: calc(100vh - 64px);
+  height: 100%;
   overflow: hidden;
 }
 
 .portfolios-sidebar {
   width: 260px;
   min-width: 260px;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
+  border-right: 1px solid rgba(201, 168, 76, 0.15);
 }
 
 .portfolios-main {
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.ts
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.ts
@@ -1,0 +1,128 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Store } from '@ngrx/store';
+import { MatDialog } from '@angular/material/dialog';
+import {
+  createPortfolio,
+  deletePortfolio,
+  getData,
+  importDeGiroCsv,
+  importYahooCsv,
+  renamePortfolio,
+  selectPortfoliosDbo,
+  selectState,
+} from '@aws/state';
+import { PortfolioDbo } from '@aws/util';
+import { PortfolioListComponent } from '../portfolio-list/portfolio-list.component';
+import { PortfolioDetailComponent } from '../portfolio-detail/portfolio-detail.component';
+import {
+  PortfolioNameDialogComponent,
+  PortfolioNameDialogData,
+} from '../portfolio-name-dialog/portfolio-name-dialog.component';
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogData,
+} from '../confirm-dialog/confirm-dialog.component';
+import {
+  CsvUploadDialogComponent,
+  CsvUploadDialogData,
+  CsvUploadResult,
+} from '../csv-upload-dialog/csv-upload-dialog.component';
+
+@Component({
+  selector: 'aws-portfolios',
+  templateUrl: './portfolios.component.html',
+  styleUrls: ['./portfolios.component.scss'],
+  imports: [CommonModule, PortfolioListComponent, PortfolioDetailComponent],
+})
+export class PortfoliosComponent implements OnInit {
+  portfolios$ = this.store.select(selectPortfoliosDbo);
+  state$ = this.store.select(selectState);
+  selectedPortfolioId: string | null = null;
+
+  constructor(private store: Store, private dialog: MatDialog) {}
+
+  ngOnInit() {
+    this.store.dispatch(getData());
+    // Auto-select first portfolio when portfolios load.
+    this.portfolios$.subscribe((portfolios) => {
+      if (portfolios.length > 0 && !this.selectedPortfolioId) {
+        this.selectedPortfolioId = portfolios[0].id;
+      }
+    });
+  }
+
+  getSelectedPortfolio(portfolios: PortfolioDbo[]): PortfolioDbo | null {
+    return portfolios.find((p) => p.id === this.selectedPortfolioId) ?? null;
+  }
+
+  onSelectPortfolio(id: string) {
+    this.selectedPortfolioId = id;
+  }
+
+  onCreatePortfolio() {
+    const data: PortfolioNameDialogData = { title: 'New portfolio' };
+    this.dialog
+      .open(PortfolioNameDialogComponent, { data, width: '380px' })
+      .afterClosed()
+      .subscribe((name: string | undefined) => {
+        if (name) {
+          this.store.dispatch(createPortfolio({ name }));
+        }
+      });
+  }
+
+  onRenamePortfolio(portfolio: PortfolioDbo) {
+    const data: PortfolioNameDialogData = {
+      title: 'Rename portfolio',
+      initialName: portfolio.name,
+    };
+    this.dialog
+      .open(PortfolioNameDialogComponent, { data, width: '380px' })
+      .afterClosed()
+      .subscribe((newName: string | undefined) => {
+        if (newName) {
+          this.store.dispatch(
+            renamePortfolio({ portfolioId: portfolio.id, newName })
+          );
+        }
+      });
+  }
+
+  onDeletePortfolio(portfolio: PortfolioDbo) {
+    const data: ConfirmDialogData = {
+      title: 'Delete portfolio',
+      message: `Delete "${portfolio.name}"? This will permanently remove all its transactions.`,
+    };
+    this.dialog
+      .open(ConfirmDialogComponent, { data, width: '380px' })
+      .afterClosed()
+      .subscribe((confirmed: boolean | undefined) => {
+        if (confirmed) {
+          if (this.selectedPortfolioId === portfolio.id) {
+            this.selectedPortfolioId = null;
+          }
+          this.store.dispatch(deletePortfolio({ portfolioId: portfolio.id }));
+        }
+      });
+  }
+
+  onImportCsv(portfolioId: string) {
+    const data: CsvUploadDialogData = { portfolioId };
+    this.dialog
+      .open(CsvUploadDialogComponent, { data, width: '460px' })
+      .afterClosed()
+      .subscribe((result: CsvUploadResult | undefined) => {
+        if (!result) return;
+        if (result.format === 'degiro') {
+          this.store.dispatch(
+            importDeGiroCsv({ portfolioId: result.portfolioId, data: result.rows as any, mode: result.mode })
+          );
+        } else {
+          this.store.dispatch(
+            importYahooCsv({ portfolioId: result.portfolioId, rawRows: result.rows, mode: result.mode })
+          );
+        }
+      });
+  }
+}

--- a/libs/frontend/ui/src/lib/settings/settings.component.html
+++ b/libs/frontend/ui/src/lib/settings/settings.component.html
@@ -4,15 +4,15 @@
   </div>
 
   <div class="settings-card">
-    <h2 class="settings-section-title">Display currency</h2>
-    <p class="settings-description">
-      All portfolio values on the dashboard will be converted to this currency using historical exchange rates.
+    <h2 class="card-title">Display currency</h2>
+    <p class="card-description">
+      All portfolio values on the dashboard will be shown in this currency using historical exchange rates.
     </p>
-    <mat-form-field appearance="outline" class="currency-field">
-      <mat-label>Base currency</mat-label>
-      <mat-select [(ngModel)]="selectedCurrency" (ngModelChange)="onCurrencyChange($event)">
-        <mat-option *ngFor="let c of currencies" [value]="c">{{ c }}</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="field-group">
+      <label class="field-label">Base currency</label>
+      <select class="field-select" [(ngModel)]="selectedCurrency" (ngModelChange)="onCurrencyChange($event)">
+        <option *ngFor="let c of currencies" [value]="c">{{ c }}</option>
+      </select>
+    </div>
   </div>
 </div>

--- a/libs/frontend/ui/src/lib/settings/settings.component.html
+++ b/libs/frontend/ui/src/lib/settings/settings.component.html
@@ -1,0 +1,18 @@
+<div class="settings-page">
+  <div class="page-header">
+    <h1 class="page-title">Settings</h1>
+  </div>
+
+  <div class="settings-card">
+    <h2 class="settings-section-title">Display currency</h2>
+    <p class="settings-description">
+      All portfolio values on the dashboard will be converted to this currency using historical exchange rates.
+    </p>
+    <mat-form-field appearance="outline" class="currency-field">
+      <mat-label>Base currency</mat-label>
+      <mat-select [(ngModel)]="selectedCurrency" (ngModelChange)="onCurrencyChange($event)">
+        <mat-option *ngFor="let c of currencies" [value]="c">{{ c }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+</div>

--- a/libs/frontend/ui/src/lib/settings/settings.component.scss
+++ b/libs/frontend/ui/src/lib/settings/settings.component.scss
@@ -1,0 +1,39 @@
+.settings-page {
+  padding: 24px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 32px;
+}
+
+.page-title {
+  font-size: 28px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.settings-card {
+  background: var(--surface, #1e1e2e);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 16px;
+}
+
+.settings-section-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.settings-description {
+  font-size: 14px;
+  opacity: 0.7;
+  margin: 0 0 20px;
+  line-height: 1.5;
+}
+
+.currency-field {
+  width: 200px;
+}

--- a/libs/frontend/ui/src/lib/settings/settings.component.scss
+++ b/libs/frontend/ui/src/lib/settings/settings.component.scss
@@ -1,39 +1,81 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+:host {
+  display: block;
+  padding: 32px 24px;
+}
+
 .settings-page {
-  padding: 24px;
   max-width: 600px;
-  margin: 0 auto;
 }
 
 .page-header {
   margin-bottom: 32px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid $color-border;
 }
 
 .page-title {
-  font-size: 28px;
-  font-weight: 600;
+  @include serif-heading;
+  font-size: 2rem;
   margin: 0;
 }
 
 .settings-card {
-  background: var(--surface, #1e1e2e);
-  border-radius: 12px;
+  @include nautical-card;
   padding: 24px;
-  margin-bottom: 16px;
 }
 
-.settings-section-title {
-  font-size: 16px;
+.card-title {
+  @include serif-heading;
+  font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0 8px;
 }
 
-.settings-description {
-  font-size: 14px;
-  opacity: 0.7;
+.card-description {
+  font-size: 0.85rem;
+  color: $color-muted;
+  line-height: 1.6;
   margin: 0 0 20px;
-  line-height: 1.5;
 }
 
-.currency-field {
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: $color-muted;
+}
+
+.field-select {
+  background: $color-bg-base;
+  border: 1px solid $color-border-strong;
+  border-radius: $radius-sm;
+  padding: 10px 14px;
+  color: $color-cream;
+  font-family: $font-sans;
+  font-size: 0.9rem;
   width: 200px;
+  outline: none;
+  transition: $transition-base;
+  cursor: pointer;
+  appearance: auto;
+
+  option {
+    background: $color-bg-base;
+    color: $color-cream;
+  }
+
+  &:focus {
+    border-color: $color-gold;
+    box-shadow: 0 0 0 2px rgba(201, 168, 76, 0.15);
+  }
 }

--- a/libs/frontend/ui/src/lib/settings/settings.component.ts
+++ b/libs/frontend/ui/src/lib/settings/settings.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Store } from '@ngrx/store';
+import { selectBaseCurrency, updateSettings } from '@aws/state';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCardModule } from '@angular/material/card';
+
+const SUPPORTED_CURRENCIES = ['EUR', 'USD', 'GBP', 'CHF', 'JPY', 'AUD', 'CAD'];
+
+@Component({
+  selector: 'aws-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss'],
+  imports: [CommonModule, FormsModule, MatFormFieldModule, MatSelectModule, MatCardModule],
+})
+export class SettingsComponent implements OnInit {
+  currencies = SUPPORTED_CURRENCIES;
+  selectedCurrency = 'EUR';
+
+  baseCurrency$ = this.store.select(selectBaseCurrency);
+
+  constructor(private store: Store) {}
+
+  ngOnInit() {
+    this.baseCurrency$.subscribe((currency) => {
+      this.selectedCurrency = currency;
+    });
+  }
+
+  onCurrencyChange(currency: string) {
+    this.store.dispatch(updateSettings({ settings: { baseCurrency: currency } }));
+  }
+}

--- a/libs/frontend/ui/src/lib/settings/settings.component.ts
+++ b/libs/frontend/ui/src/lib/settings/settings.component.ts
@@ -3,9 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { selectBaseCurrency, updateSettings } from '@aws/state';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { MatCardModule } from '@angular/material/card';
 
 const SUPPORTED_CURRENCIES = ['EUR', 'USD', 'GBP', 'CHF', 'JPY', 'AUD', 'CAD'];
 
@@ -13,18 +10,16 @@ const SUPPORTED_CURRENCIES = ['EUR', 'USD', 'GBP', 'CHF', 'JPY', 'AUD', 'CAD'];
   selector: 'aws-settings',
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss'],
-  imports: [CommonModule, FormsModule, MatFormFieldModule, MatSelectModule, MatCardModule],
+  imports: [CommonModule, FormsModule],
 })
 export class SettingsComponent implements OnInit {
   currencies = SUPPORTED_CURRENCIES;
   selectedCurrency = 'EUR';
 
-  baseCurrency$ = this.store.select(selectBaseCurrency);
-
   constructor(private store: Store) {}
 
   ngOnInit() {
-    this.baseCurrency$.subscribe((currency) => {
+    this.store.select(selectBaseCurrency).subscribe((currency) => {
       this.selectedCurrency = currency;
     });
   }

--- a/libs/frontend/ui/src/lib/summary/summary.component.html
+++ b/libs/frontend/ui/src/lib/summary/summary.component.html
@@ -1,67 +1,44 @@
 <div class="grid">
   <div class="box">
-    <div>Portfolio value</div>
+    <div>Portfolio value <span class="currency-badge">{{ currency }}</span></div>
     <div class="number-text bold">
-      {{ summary.portfolioValue | number : '1.2-2' }}
+      {{ safeSummary.portfolioValue | number : '1.2-2' }}
     </div>
   </div>
   <div class="box">
-    <div>Total Invested</div>
-    <div class="bold">{{ summary.totalInvested | number : '1.2-2' }}</div>
+    <div>Total Invested <span class="currency-badge">{{ currency }}</span></div>
+    <div class="bold">{{ safeSummary.totalInvested | number : '1.2-2' }}</div>
   </div>
   <div class="box">
-    <div>Profit (excl. commission)</div>
+    <div>Profit (excl. commission) <span class="currency-badge">{{ currency }}</span></div>
     <div
       [ngClass]="{
-        negative: summary.portfolioValue - summary.totalInvested < 0
+        negative: safeSummary.portfolioValue - safeSummary.totalInvested < 0
       }"
       class="number-text bold"
     >
-      {{ summary.portfolioValue - summary.totalInvested | number : '1.2-2' }}
+      {{ safeSummary.portfolioValue - safeSummary.totalInvested | number : '1.2-2' }}
     </div>
   </div>
   <div class="box">
-    <div>Profit (incl. commission)</div>
+    <div>Profit (incl. commission) <span class="currency-badge">{{ currency }}</span></div>
     <div
-      [ngClass]="{ negative: summary.totalReturn.absolute < 0 }"
+      [ngClass]="{ negative: safeSummary.totalReturn.absolute < 0 }"
       class="number-text bold"
     >
-      {{ summary.totalReturn.absolute | number : '1.2-2' }}
+      {{ safeSummary.totalReturn.absolute | number : '1.2-2' }}
     </div>
   </div>
-<!--  <div class="box">-->
-<!--    <div>Shares</div>-->
-<!--    <div class="bold">-->
-<!--      {{ summary.amountOfShares }}-->
-<!--    </div>-->
-<!--  </div>-->
-<!--  <div class="box">-->
-<!--    <div>Avarage Price paid per share</div>-->
-<!--    <div-->
-<!--      [ngClass]="{-->
-<!--        negative: summary.averageSharePrice > summary.currentSharePrice-->
-<!--      }"-->
-<!--      class="number-text bold"-->
-<!--    >-->
-<!--      {{ summary.averageSharePrice | number : '1.2-2' }}-->
-<!--    </div>-->
-<!--  </div>-->
-<!--  <div class="box">-->
-<!--    <div>Current Share price</div>-->
-<!--    <div class="bold">-->
-<!--      {{ summary.currentSharePrice | number : '1.2-2' }}-->
-<!--    </div>-->
-<!--  </div>-->
   <div class="box">
-    <div>Total Dividend</div>
+    <div>Total Dividend <span class="currency-badge">{{ currency }}</span></div>
     <div class="number-text bold">
-      {{ summary.totalDividend | number : '1.2-2' }}
+      {{ safeSummary.totalDividend | number : '1.2-2' }}
     </div>
   </div>
   <div class="box">
-    <div>Total Commission</div>
+    <div>Total Commission <span class="currency-badge">{{ currency }}</span></div>
     <div class="negative bold">
-      {{ summary.totalCommission | number : '1.2-2' }}
+      {{ safeSummary.totalCommission | number : '1.2-2' }}
     </div>
   </div>
 </div>

--- a/libs/frontend/ui/src/lib/summary/summary.component.scss
+++ b/libs/frontend/ui/src/lib/summary/summary.component.scss
@@ -42,3 +42,15 @@
     color: $color-error;
   }
 }
+
+.currency-badge {
+  display: inline-block;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  vertical-align: middle;
+  margin-left: 4px;
+}

--- a/libs/frontend/ui/src/lib/summary/summary.component.ts
+++ b/libs/frontend/ui/src/lib/summary/summary.component.ts
@@ -9,27 +9,20 @@ import { CommonModule, DecimalPipe, NgClass } from '@angular/common';
   imports: [NgClass, DecimalPipe, CommonModule],
 })
 export class SummaryComponent {
-  @Input() summary: Summary = {
-    portfolioValue: 0,
-    totalInvested: 0,
-    totalDividend: 0,
-    totalCommission: 0,
-    startDate: new Date(),
-    dailyReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-    weeklyReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-    monthlyReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-    totalReturn: {
-      absolute: 0,
-      percentage: 0,
-    },
-  };
+  @Input() currency = 'EUR';
+  @Input() summary: Summary | null | undefined = null;
+
+  get safeSummary(): Summary {
+    return this.summary ?? {
+      portfolioValue: 0,
+      totalInvested: 0,
+      totalDividend: 0,
+      totalCommission: 0,
+      startDate: new Date(),
+      dailyReturn: { absolute: 0, percentage: 0 },
+      weeklyReturn: { absolute: 0, percentage: 0 },
+      monthlyReturn: { absolute: 0, percentage: 0 },
+      totalReturn: { absolute: 0, percentage: 0 },
+    };
+  }
 }

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
@@ -1,20 +1,5 @@
 <div class="transactions-page">
 
-  <!-- Page header -->
-  <div class="page-header">
-    <h1 class="page-title">Transactions</h1>
-  </div>
-
-  <!-- CSV upload card -->
-  <div class="upload-card">
-    <div class="upload-label">Import from DeGiro CSV</div>
-    <label class="file-upload-area">
-      <span class="upload-icon">🌊</span>
-      <span class="upload-text">Drop your DeGiro CSV here, or <span class="upload-link">browse</span></span>
-      <input type="file" (change)="handleFileInput($event)" accept=".csv" class="file-input" />
-    </label>
-  </div>
-
   <!-- Transaction list per ticker -->
   <div class="ticker-section" *ngFor="let key of Object.keys(stocks)">
     <details class="ticker-panel">

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.ts
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.ts
@@ -7,15 +7,15 @@ import {
 } from '@aws/state';
 import {
   Transaction,
+  TransactionKey,
   TransactionType,
   Transactions,
   Stock,
-  TransactionsDbo,
 } from '@aws/util';
 import { Store } from '@ngrx/store';
 import { Papa } from 'ngx-papaparse';
 import { FormsModule } from '@angular/forms';
-import { CommonModule, DecimalPipe, NgForOf, NgIf } from '@angular/common';
+import { CommonModule, DecimalPipe } from '@angular/common';
 
 @Component({
   selector: 'aws-transactions-table',
@@ -26,6 +26,7 @@ import { CommonModule, DecimalPipe, NgForOf, NgIf } from '@angular/common';
 export class TransactionsTableComponent {
   @Input() stocks: { [ticker: string]: Stock } = {};
   @Input() transactions: Transactions | undefined;
+  @Input() portfolioId = 'default';
 
   constructor(
     private readonly store: Store,
@@ -38,16 +39,12 @@ export class TransactionsTableComponent {
   date = new Date();
   amount = 0;
   value = 0;
-  currency: 'EUR' | 'USD' = 'EUR'
+  currency: 'EUR' | 'USD' = 'EUR';
 
   csvData: any[] = [];
 
   saveTransaction() {
-    if (!this.transactions) {
-      console.error('Transactions not initialized.');
-      return;
-    }
-    const newTransaction = {
+    const newTransaction: Transaction = {
       ticker: this.ticker,
       type: this.type,
       date: new Date(this.date),
@@ -55,50 +52,24 @@ export class TransactionsTableComponent {
       value: this.value,
       currency: this.currency,
     };
-    const newTransactions = {
-      stock: [...this.transactions.stock],
-      dividend: [...this.transactions.dividend],
-      commission: [...this.transactions.commission],
-    };
-    switch (newTransaction.type) {
-      case 'stock':
-        if (newTransactions.stock.length > 0) {
-          newTransactions.stock.push(newTransaction);
-        } else {
-          newTransactions.stock = [newTransaction];
-        }
-        break;
-      case 'dividend':
-        if (newTransactions.dividend.length > 0) {
-          newTransactions.dividend.push(newTransaction);
-        } else {
-          newTransactions.dividend = [newTransaction];
-        }
-        break;
-      case 'commission':
-        if (newTransactions.commission.length > 0) {
-          newTransactions.commission.push(newTransaction);
-        } else {
-          newTransactions.commission = [newTransaction];
-        }
-        break;
-      default:
-        return;
-    }
     this.store.dispatch(
-      saveTransaction({
-        transactions: newTransactions,
-      })
+      saveTransaction({ portfolioId: this.portfolioId, transaction: newTransaction })
     );
   }
 
-  deleteTransaction(transactions: Transactions, transaction: Transaction) {
-    // const newTransactions = transactions.filter((t) => t != transaction);
-    // this.store.dispatch(deleteTransaction({ newTransactions }));
+  deleteTransactionEntry(transaction: Transaction) {
+    const key: TransactionKey = {
+      type: transaction.type,
+      ticker: transaction.ticker,
+      date: transaction.date.toISOString().split('T')[0],
+      time: transaction.time,
+      value: transaction.value,
+    };
+    this.store.dispatch(deleteTransaction({ portfolioId: this.portfolioId, transactionKey: key }));
   }
 
   deleteAll() {
-    this.store.dispatch(deleteAllTransactions());
+    this.store.dispatch(deleteAllTransactions({ portfolioId: this.portfolioId }));
   }
 
   handleFileInput(event: Event) {
@@ -108,7 +79,7 @@ export class TransactionsTableComponent {
       this.papa.parse(file, {
         complete: (result) => {
           this.csvData = result.data;
-          this.cdr.detectChanges(); // Trigger change detection to update the view
+          this.cdr.detectChanges();
           this.store.dispatch(handleFileInput({ data: result.data }));
         },
         header: true,

--- a/libs/shared/util/src/lib/csv-import.ts
+++ b/libs/shared/util/src/lib/csv-import.ts
@@ -23,6 +23,7 @@ export function translateToDutch(csv: CsvInput | CsvInputEnglish): CsvInput {
     return csv.map((row) => ({
       Omschrijving: row.Description,
       Datum: row.Date,
+      Tijd: (row as CsvInputEnglish[number] & { Time?: string }).Time,
       '': row[''],
       Product: row.Product,
     }));
@@ -51,15 +52,19 @@ export function parseCsvInput(csv: CsvInput): Transactions {
     const product = row.Product;
     const ticker = getTickerFromGiroProduct(product);
 
+    const parsedDate = new Date(
+      parseInt(row.Datum.split('-')[2]),
+      parseInt(row.Datum.split('-')[1]) - 1,
+      parseInt(row.Datum.split('-')[0])
+    );
+    const time = row.Tijd?.trim() || undefined;
+
     if (row.Omschrijving.startsWith('Koop ')) {
       stock.push({
         ticker,
         type: 'stock',
-        date: new Date(
-          parseInt(row.Datum.split('-')[2]),
-          parseInt(row.Datum.split('-')[1]) - 1,
-          parseInt(row.Datum.split('-')[0])
-        ),
+        date: parsedDate,
+        time,
         amount: parseFloat(
           row.Omschrijving.replace('Koop ', '').split(' @')[0]
         ),
@@ -73,11 +78,8 @@ export function parseCsvInput(csv: CsvInput): Transactions {
       commission.push({
         ticker,
         type: 'commission',
-        date: new Date(
-          parseInt(row.Datum.split('-')[2]),
-          parseInt(row.Datum.split('-')[1]) - 1,
-          parseInt(row.Datum.split('-')[0])
-        ),
+        date: parsedDate,
+        time,
         amount: 1,
         value: Math.abs(parseFloat(row[''])),
         currency: 'EUR',
@@ -87,11 +89,8 @@ export function parseCsvInput(csv: CsvInput): Transactions {
       commission.push({
         ticker,
         type: 'commission',
-        date: new Date(
-          parseInt(row.Datum.split('-')[2]),
-          parseInt(row.Datum.split('-')[1]) - 1,
-          parseInt(row.Datum.split('-')[0])
-        ),
+        date: parsedDate,
+        time,
         amount: 1,
         value: -1 * Math.abs(parseFloat(row[''])),
         currency: 'EUR',
@@ -101,11 +100,8 @@ export function parseCsvInput(csv: CsvInput): Transactions {
       dividend.push({
         ticker,
         type: 'dividend',
-        date: new Date(
-          parseInt(row.Datum.split('-')[2]),
-          parseInt(row.Datum.split('-')[1]) - 1,
-          parseInt(row.Datum.split('-')[0])
-        ),
+        date: parsedDate,
+        time,
         amount: 1,
         value: Math.abs(parseFloat(row[''])),
         currency: 'EUR',

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -1,4 +1,4 @@
-import { Stock, Summary, Ticker, Transactions, TransactionsDbo } from './types';
+import { PortfolioDbo, Stock, Summary, Ticker, Transactions, TransactionsDbo } from './types';
 import {
   addLists,
   getCurrencies,
@@ -24,6 +24,11 @@ export interface PortfolioState {
   dates: Date[];
   summary: Summary;
   currencies: string[];
+}
+
+export interface PortfolioComputedState extends PortfolioState {
+  portfolioId: string;
+  portfolioName: string;
 }
 
 export function createInitialSummary(): Summary {
@@ -253,4 +258,23 @@ export function computePortfolioState(
   };
 
   return { transactions, stocks: chartedStocks, dates, summary, currencies };
+}
+
+/**
+ * Runs computePortfolioState for each portfolio and returns a map keyed by
+ * portfolio ID. Used by per-portfolio selectors and the Portfolios page.
+ */
+export function computeAllPortfolios(
+  portfoliosDbo: PortfolioDbo[],
+  tickers: { [ticker: string]: Ticker }
+): { [id: string]: PortfolioComputedState } {
+  const result: { [id: string]: PortfolioComputedState } = {};
+  for (const portfolio of portfoliosDbo) {
+    result[portfolio.id] = {
+      ...computePortfolioState(portfolio.transactions, tickers),
+      portfolioId: portfolio.id,
+      portfolioName: portfolio.name,
+    };
+  }
+  return result;
 }

--- a/libs/shared/util/src/lib/schemas.spec.ts
+++ b/libs/shared/util/src/lib/schemas.spec.ts
@@ -6,62 +6,95 @@ beforeAll(() => {
 });
 afterAll(() => jest.restoreAllMocks());
 
+const validTransaction = {
+  ticker: 'VUSA.AS',
+  type: 'stock',
+  date: '2023-01-10',
+  amount: 2,
+  value: 200,
+  currency: 'EUR',
+};
+
+const validTransactionsDbo = {
+  stock: [validTransaction],
+  dividend: [],
+  commission: [],
+};
+
 describe('parseDatabaseDto', () => {
-  const valid = {
-    transactions: {
-      stock: [
-        {
-          ticker: 'VUSA.AS',
-          type: 'stock',
-          date: '2023-01-10',
-          amount: 2,
-          value: 200,
-          currency: 'EUR',
-        },
-      ],
-      dividend: [],
-      commission: [],
-    },
-  };
+  describe('v2 input', () => {
+    const validV2 = {
+      schemaVersion: 2,
+      settings: { baseCurrency: 'EUR' },
+      portfolios: [{ id: 'p1', name: 'My Portfolio', transactions: validTransactionsDbo }],
+    };
 
-  it('accepts a well-formed response and defaults startDate', () => {
-    const result = parseDatabaseDto(valid);
-    expect(result.transactions.stock).toHaveLength(1);
-    expect(result.startDate).toBe('');
-  });
-
-  it('keeps startDate and tolerates extra fields', () => {
-    const result = parseDatabaseDto({
-      ...valid,
-      startDate: '2023-01-10',
-      extraneous: 'ignored',
+    it('accepts a well-formed v2 response', () => {
+      const result = parseDatabaseDto(validV2);
+      expect(result.schemaVersion).toBe(2);
+      expect(result.portfolios).toHaveLength(1);
+      expect(result.portfolios[0].transactions.stock).toHaveLength(1);
+      expect(result.settings.baseCurrency).toBe('EUR');
     });
-    expect(result.startDate).toBe('2023-01-10');
-  });
 
-  it('throws when transactions is missing', () => {
-    expect(() => parseDatabaseDto({})).toThrow();
-  });
-
-  it('throws when a numeric field is the wrong type', () => {
-    expect(() =>
-      parseDatabaseDto({
-        transactions: {
-          stock: [
-            {
-              ticker: 'VUSA.AS',
-              type: 'stock',
-              date: '2023-01-10',
-              amount: 2,
-              value: 'not-a-number',
-              currency: 'EUR',
-            },
-          ],
+    it('transaction time field is optional', () => {
+      const withTime = {
+        ...validV2,
+        portfolios: [{ id: 'p1', name: 'My Portfolio', transactions: {
+          stock: [{ ...validTransaction, time: '14:32' }],
           dividend: [],
           commission: [],
-        },
-      })
-    ).toThrow();
+        }}],
+      };
+      const result = parseDatabaseDto(withTime);
+      expect(result.portfolios[0].transactions.stock[0].time).toBe('14:32');
+    });
+
+    it('throws when a numeric field is the wrong type', () => {
+      expect(() =>
+        parseDatabaseDto({
+          ...validV2,
+          portfolios: [{ id: 'p1', name: 'My Portfolio', transactions: {
+            stock: [{ ...validTransaction, value: 'not-a-number' }],
+            dividend: [],
+            commission: [],
+          }}],
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('v1 migration', () => {
+    const validV1 = { transactions: validTransactionsDbo };
+
+    it('migrates v1 to v2 wrapping transactions in Default portfolio', () => {
+      const result = parseDatabaseDto(validV1);
+      expect(result.schemaVersion).toBe(2);
+      expect(result.portfolios).toHaveLength(1);
+      expect(result.portfolios[0].name).toBe('Default');
+      expect(result.portfolios[0].id).toBe('default');
+      expect(result.portfolios[0].transactions.stock).toHaveLength(1);
+      expect(result.settings.baseCurrency).toBe('EUR');
+    });
+
+    it('migrates v1 with extra fields without error', () => {
+      const result = parseDatabaseDto({ ...validV1, startDate: '2023-01-01', extraneous: 'ignored' });
+      expect(result.schemaVersion).toBe(2);
+    });
+  });
+
+  describe('empty / null input', () => {
+    it('returns empty v2 for null', () => {
+      const result = parseDatabaseDto(null);
+      expect(result.schemaVersion).toBe(2);
+      expect(result.portfolios).toHaveLength(1);
+      expect(result.portfolios[0].transactions.stock).toHaveLength(0);
+    });
+
+    it('returns empty v2 for empty object', () => {
+      const result = parseDatabaseDto({});
+      expect(result.schemaVersion).toBe(2);
+    });
   });
 });
 

--- a/libs/shared/util/src/lib/schemas.ts
+++ b/libs/shared/util/src/lib/schemas.ts
@@ -12,11 +12,11 @@ const transactionDboSchema = z
     ticker: z.string(),
     type: z.string(),
     date: z.string(),
+    time: z.string().optional(),
     amount: z.number(),
     value: z.number(),
     currency: z.string(),
   })
-  // Keep any extra columns the backend may add rather than stripping them.
   .passthrough();
 
 const transactionsDboSchema = z.object({
@@ -25,20 +25,60 @@ const transactionsDboSchema = z.object({
   commission: z.array(transactionDboSchema),
 });
 
-const databaseDtoSchema = z
+const userSettingsDboSchema = z.object({
+  baseCurrency: z.string().default('EUR'),
+});
+
+const portfolioDboSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  transactions: transactionsDboSchema,
+});
+
+const databaseDtoV2Schema = z.object({
+  portfolios: z.array(portfolioDboSchema),
+  settings: userSettingsDboSchema,
+  schemaVersion: z.literal(2),
+});
+
+// v1 shape — used only during migration.
+const databaseDtoV1Schema = z
   .object({
     startDate: z.string().optional().default(''),
     transactions: transactionsDboSchema,
   })
   .passthrough();
 
+const EMPTY_TRANSACTIONS = { stock: [], dividend: [], commission: [] };
+const EMPTY_V2: DatabaseDto = {
+  portfolios: [{ id: 'default', name: 'Default', transactions: EMPTY_TRANSACTIONS }],
+  settings: { baseCurrency: 'EUR' },
+  schemaVersion: 2,
+};
+
 /**
- * Validate the DynamoDB response before it enters the store. Throws a ZodError
- * on a malformed shape, which the effect maps to a *Failure action (and a user
- * facing error toast) instead of silently feeding bad data into the reducer.
+ * Validate the DynamoDB response before it enters the store. Migrates v1
+ * payloads (flat transactions) into the v2 multi-portfolio shape transparently.
+ * Throws a ZodError on a malformed shape.
  */
 export function parseDatabaseDto(raw: unknown): DatabaseDto {
-  return databaseDtoSchema.parse(raw) as DatabaseDto;
+  if (raw === null || raw === undefined || (typeof raw === 'object' && Object.keys(raw as object).length === 0)) {
+    return EMPTY_V2;
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (obj['schemaVersion'] === 2) {
+    return databaseDtoV2Schema.parse(raw) as DatabaseDto;
+  }
+
+  // Migrate v1: wrap existing transactions in a "Default" portfolio.
+  const v1 = databaseDtoV1Schema.parse(raw);
+  return {
+    portfolios: [{ id: 'default', name: 'Default', transactions: v1.transactions }],
+    settings: { baseCurrency: 'EUR' },
+    schemaVersion: 2,
+  };
 }
 
 // --- Yahoo Finance (external) ---------------------------------------------

--- a/libs/shared/util/src/lib/transactions.ts
+++ b/libs/shared/util/src/lib/transactions.ts
@@ -1,6 +1,8 @@
 import {
   Stock,
   Transaction,
+  TransactionDbo,
+  TransactionKey,
   TransactionType,
   Transactions,
   TransactionsDbo,
@@ -297,4 +299,63 @@ export function getCurrencies(stocks: { [ticker: string]: Stock }): string[] {
     }
   }
   return currencies;
+}
+
+export function transactionToTransactionDbo(tx: Transaction): TransactionDbo {
+  return {
+    ticker: tx.ticker,
+    type: tx.type,
+    date: tx.date.toISOString().split('T')[0],
+    time: tx.time,
+    amount: tx.amount,
+    value: tx.value,
+    currency: tx.currency,
+  };
+}
+
+function txDboKey(tx: TransactionDbo): string {
+  return `${tx.ticker}|${tx.date}|${tx.time ?? ''}|${tx.value}`;
+}
+
+export function deduplicateTransactions(txs: TransactionDbo[]): TransactionDbo[] {
+  const seen = new Set<string>();
+  return txs.filter((tx) => {
+    const key = txDboKey(tx);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function mergeTransactionsDbo(all: TransactionsDbo[]): TransactionsDbo {
+  const stock: TransactionDbo[] = [];
+  const dividend: TransactionDbo[] = [];
+  const commission: TransactionDbo[] = [];
+  for (const t of all) {
+    stock.push(...t.stock);
+    dividend.push(...t.dividend);
+    commission.push(...t.commission);
+  }
+  return {
+    stock: deduplicateTransactions(stock),
+    dividend: deduplicateTransactions(dividend),
+    commission: deduplicateTransactions(commission),
+  };
+}
+
+export function mergeTransactions(
+  existing: TransactionsDbo,
+  incoming: TransactionsDbo
+): TransactionsDbo {
+  return mergeTransactionsDbo([existing, incoming]);
+}
+
+export function matchesTransactionKey(tx: TransactionDbo, key: TransactionKey): boolean {
+  return (
+    tx.type === key.type &&
+    tx.ticker === key.ticker &&
+    tx.date === key.date &&
+    (tx.time ?? '') === (key.time ?? '') &&
+    tx.value === key.value
+  );
 }

--- a/libs/shared/util/src/lib/types.ts
+++ b/libs/shared/util/src/lib/types.ts
@@ -74,14 +74,40 @@ export type Transaction = {
   ticker: string;
   type: TransactionType;
   date: Date;
+  time?: string;
   amount: number;
   value: number;
   currency: string;
 };
 
-export type DatabaseDto = {
+export type TransactionKey = {
+  type: TransactionType;
+  ticker: string;
+  date: string;
+  time?: string;
+  value: number;
+};
+
+// Legacy v1 shape — kept for schema migration only.
+export type DatabaseDtoV1 = {
   startDate: string;
   transactions: TransactionsDbo;
+};
+
+export type UserSettingsDbo = {
+  baseCurrency: string;
+};
+
+export type PortfolioDbo = {
+  id: string;
+  name: string;
+  transactions: TransactionsDbo;
+};
+
+export type DatabaseDto = {
+  portfolios: PortfolioDbo[];
+  settings: UserSettingsDbo;
+  schemaVersion: 2;
 };
 
 export type TransactionsDbo = {
@@ -94,6 +120,7 @@ export type TransactionDbo = {
   ticker: string;
   type: string;
   date: string;
+  time?: string;
   amount: number;
   value: number;
   currency: string;
@@ -143,6 +170,7 @@ export type Ticker = {
 
 export type CsvInput = {
   Datum: string;
+  Tijd?: string;
   Product: string;
   Omschrijving: string;
   '': string;
@@ -150,6 +178,7 @@ export type CsvInput = {
 
 export type CsvInputEnglish = {
   Date: string;
+  Time?: string;
   Product: string;
   Description: string;
   '': string;

--- a/libs/shared/util/src/lib/util.ts
+++ b/libs/shared/util/src/lib/util.ts
@@ -5,4 +5,5 @@ export * from './csv-import';
 export * from './dividends';
 export * from './returns';
 export * from './transactions';
+export * from './yahoo-csv-import';
 export * from './yahoo-mapping';

--- a/libs/shared/util/src/lib/yahoo-csv-import.ts
+++ b/libs/shared/util/src/lib/yahoo-csv-import.ts
@@ -1,0 +1,93 @@
+import { TransactionsDbo } from './types';
+
+export type YahooCsvRow = {
+  Symbol: string;
+  'Trade Date': string;       // YYYYMMDD
+  'Purchase Price': string;
+  Quantity: string;
+  Commission: string;
+  'Transaction Type': string; // 'BUY' | 'SHORT' (SHORT = SELL)
+};
+
+function parseTradeDate(raw: string): string {
+  // YYYYMMDD → YYYY-MM-DD
+  const s = raw.trim();
+  if (s.length !== 8) {
+    throw new Error(`Unrecognised Trade Date format: "${raw}"`);
+  }
+  return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+}
+
+/**
+ * Parses a Yahoo Finance portfolio CSV export into TransactionsDbo.
+ *
+ * Column mapping:
+ *   Symbol          → ticker (already a Yahoo Finance symbol)
+ *   Trade Date      → date (YYYYMMDD → YYYY-MM-DD)
+ *   Purchase Price  → price per share
+ *   Quantity        → number of shares
+ *   Commission      → commission value (if non-zero, stored as a commission entry)
+ *   Transaction Type:
+ *     BUY   → positive stock transaction
+ *     SHORT → SELL (negative amount / value represents reducing position)
+ *
+ * Note: currency is NOT in the CSV. The caller must fetch it from the Yahoo API
+ * after parsing and fill in the currency field on each transaction.
+ * A placeholder value of 'UNKNOWN' is used until the caller resolves it.
+ */
+export function parseYahooCsvInput(rawRows: unknown[]): TransactionsDbo {
+  const stock = [];
+  const dividend: never[] = [];
+  const commission = [];
+
+  for (const rawRow of rawRows) {
+    const row = rawRow as YahooCsvRow;
+
+    const symbol = (row['Symbol'] ?? '').trim();
+    const tradeDateRaw = (row['Trade Date'] ?? '').trim();
+    const purchasePriceRaw = (row['Purchase Price'] ?? '').trim();
+    const quantityRaw = (row['Quantity'] ?? '').trim();
+    const commissionRaw = (row['Commission'] ?? '').trim();
+    const txType = (row['Transaction Type'] ?? '').trim().toUpperCase();
+
+    if (!symbol || !tradeDateRaw || !purchasePriceRaw || !quantityRaw || !txType) {
+      continue;
+    }
+
+    const date = parseTradeDate(tradeDateRaw);
+    const purchasePrice = parseFloat(purchasePriceRaw);
+    const quantity = parseFloat(quantityRaw);
+
+    if (isNaN(purchasePrice) || isNaN(quantity)) continue;
+
+    const isBuy = txType === 'BUY';
+    const isSell = txType === 'SHORT';
+
+    if (isBuy || isSell) {
+      const amount = isBuy ? quantity : -quantity;
+      const value = Math.abs(purchasePrice * quantity);
+      stock.push({
+        ticker: symbol,
+        type: 'stock',
+        date,
+        amount,
+        value,
+        currency: 'UNKNOWN', // Caller must resolve via Yahoo API
+      });
+    }
+
+    const commissionValue = commissionRaw ? parseFloat(commissionRaw) : 0;
+    if (commissionValue > 0) {
+      commission.push({
+        ticker: symbol,
+        type: 'commission',
+        date,
+        amount: 1,
+        value: commissionValue,
+        currency: 'UNKNOWN',
+      });
+    }
+  }
+
+  return { stock, dividend, commission };
+}

--- a/services/handler_dynamodb.py
+++ b/services/handler_dynamodb.py
@@ -8,7 +8,30 @@ from shared.auth import verify_token
 from shared.cors import build_headers
 
 _TABLE_NAME = 'sailor'
-_CURRENT_SCHEMA_VERSION = 1
+_CURRENT_SCHEMA_VERSION = 2
+
+_EMPTY_V2 = {
+    'schemaVersion': 2,
+    'settings': {'baseCurrency': 'EUR'},
+    'portfolios': [
+        {'id': 'default', 'name': 'Default', 'transactions': {'stock': [], 'dividend': [], 'commission': []}}
+    ],
+}
+
+
+def _migrate_v1_to_v2(item):
+    """Wrap a v1 flat-transactions item into the v2 multi-portfolio shape."""
+    try:
+        legacy_transactions = json.loads(item.get('transactions', '{}'))
+    except (json.JSONDecodeError, TypeError):
+        legacy_transactions = {'stock': [], 'dividend': [], 'commission': []}
+    return {
+        'schemaVersion': 2,
+        'settings': {'baseCurrency': 'EUR'},
+        'portfolios': [
+            {'id': 'default', 'name': 'Default', 'transactions': legacy_transactions}
+        ],
+    }
 
 
 def _get_table():
@@ -60,26 +83,46 @@ def handler(event, context):
             resp = table.query(KeyConditionExpression=Key('userId').eq(user_id))
             items = resp.get('Items', [])
             if not items:
-                # New users have no row yet — return a valid empty DatabaseDto.
-                body = '{"transactions":{"stock":[],"dividend":[],"commission":[]}}'
+                body = json.dumps(_EMPTY_V2)
             else:
                 item = items[0]
-                # schemaVersion is absent on pre-migration items (treat as v0).
-                # Add per-version migration branches here as the schema evolves.
-                _schema_version = int(item.get('schemaVersion', 0))
-                body = item.get('transactions', '{}')
+                schema_version = int(item.get('schemaVersion', 0))
+                if schema_version < 2:
+                    # Migrate: wrap legacy flat transactions in a default portfolio.
+                    body = json.dumps(_migrate_v1_to_v2(item))
+                else:
+                    # v2 data is stored under the 'data' key.
+                    body = item.get('data', json.dumps(_EMPTY_V2))
 
         elif method == 'PUT':
+            try:
+                payload = json.loads(event.get('body', '{}'))
+            except (json.JSONDecodeError, TypeError):
+                return {
+                    'statusCode': 400,
+                    'body': json.dumps({'message': 'Invalid JSON body'}),
+                    'headers': headers,
+                }
+
+            if payload.get('schemaVersion') != 2:
+                return {
+                    'statusCode': 400,
+                    'body': json.dumps({'message': 'Unsupported schema version. Expected schemaVersion: 2.'}),
+                    'headers': headers,
+                }
+
+            body_str = json.dumps(payload)
             resp = table.update_item(
                 Key={'userId': user_id},
-                UpdateExpression='SET transactions = :t, schemaVersion = :v',
+                UpdateExpression='SET #data = :d, schemaVersion = :v',
+                ExpressionAttributeNames={'#data': 'data'},
                 ExpressionAttributeValues={
-                    ':t': event.get('body', '{}'),
+                    ':d': body_str,
                     ':v': _CURRENT_SCHEMA_VERSION,
                 },
                 ReturnValues='ALL_NEW',
             )
-            body = resp['Attributes']['transactions']
+            body = resp['Attributes']['data']
 
         else:
             raise ValueError(f'Unsupported method: {method}')


### PR DESCRIPTION
## Summary

- **Multi-portfolio data model**: Replaces single flat `TransactionsDbo` with `portfolios[]` per user (v2 schema). The Python backend migrates existing v1 records transparently on GET and rejects stale v1 PUTs.
- **Portfolios page** (`/portfolios`): Sidebar portfolio list with create/rename/delete, detail panel with per-portfolio transaction table, CSV import via dialog (replace or merge with deduplication).
- **Yahoo Finance CSV import**: New `parseYahooCsvInput` parser — `BUY` → positive stock transaction, `SHORT` → sell. Currency is auto-resolved from Yahoo API metadata after parse. (Pending: user to confirm SHORT interpretation.)
- **Settings page** (`/settings`): Base currency selector — saved per user in DynamoDB alongside portfolios.
- **Dashboard portfolio filter**: Chip buttons appear when multiple portfolios exist; filters the aggregate chart/summary via `setSelectedPortfolios` action.
- **Currency labels**: `SummaryComponent` now shows the active display currency badge on every monetary value.
- `/transactions` redirects to `/portfolios` for backward compat.

## Test plan

- [x] Existing user (v1 DynamoDB record): first GET returns data wrapped in "Default" portfolio; PUT persists as v2
- [x] New user: starts with empty "Default" portfolio
- [x] Create portfolio → appears in sidebar and dashboard filter
- [x] Rename / delete portfolio via icon buttons
- [x] Upload DeGiro CSV → confirm replace vs. merge modes; re-upload same file deduplicates
- [x] Upload Yahoo Finance CSV → transactions imported with currency from Yahoo API
- [x] Dashboard: select/deselect portfolios → summary and charts update
- [x] Settings: change base currency → label shows on summary cards
- [x] `/transactions` URL redirects to `/portfolios`
- [x] `nx run-many -t lint test build --all` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)