### PR TITLE
feat(fx): multi-currency portfolio conversion, GBp support, Yahoo CSV currency detection

### DIFF
--- a/libs/frontend/state/src/lib/+state/state.actions.ts
+++ b/libs/frontend/state/src/lib/+state/state.actions.ts
@@ -6,6 +6,7 @@ import {
   Ticker,
   Transaction,
   TransactionKey,
+  TransactionsDbo,
   UserSettingsDbo,
 } from '@aws/util';
 import { createAction, props } from '@ngrx/store';
@@ -120,6 +121,17 @@ export const importDeGiroCsvFailure = createAction(
 export const importYahooCsv = createAction(
   '[State] Import Yahoo CSV',
   props<{ portfolioId: string; rawRows: unknown[]; mode: 'replace' | 'merge' }>()
+);
+// Dispatched after CSV parsing; carries the raw TransactionsDbo before
+// currency resolution. yahoo.effects intercepts this to fill in currencies.
+export const importYahooCsvParsed = createAction(
+  '[State] Import Yahoo CSV Parsed',
+  props<{ portfolioId: string; mode: 'replace' | 'merge'; incoming: TransactionsDbo }>()
+);
+// Dispatched by yahoo.effects after currency resolution; triggers the DB save.
+export const importYahooCsvReady = createAction(
+  '[State] Import Yahoo CSV Ready',
+  props<{ portfolioId: string; mode: 'replace' | 'merge'; incoming: TransactionsDbo }>()
 );
 export const importYahooCsvSuccess = createAction(
   '[State] Import Yahoo CSV Success',

--- a/libs/frontend/state/src/lib/+state/state.effects.ts
+++ b/libs/frontend/state/src/lib/+state/state.effects.ts
@@ -30,6 +30,8 @@ import {
   importDeGiroCsvSuccess,
   importYahooCsv,
   importYahooCsvFailure,
+  importYahooCsvParsed,
+  importYahooCsvReady,
   importYahooCsvSuccess,
   renamePortfolio,
   renamePortfolioFailure,
@@ -281,11 +283,11 @@ export class StateEffects {
     )
   );
 
+  // Parse the CSV and hand off to yahoo.effects for currency resolution.
   public readonly importYahooCsv$ = createEffect(() =>
     this.actions$.pipe(
       ofType(importYahooCsv),
-      withLatestFrom(this.store.select(selectFeature)),
-      switchMap(([{ portfolioId, rawRows, mode }, state]) => {
+      switchMap(({ portfolioId, rawRows, mode }) => {
         let incoming;
         try {
           incoming = parseYahooCsvInput(rawRows);
@@ -294,14 +296,23 @@ export class StateEffects {
             error instanceof Error ? error.message : 'Failed to parse Yahoo Finance CSV';
           return of(importYahooCsvFailure({ error: message }));
         }
+        return of(importYahooCsvParsed({ portfolioId, mode, incoming }));
+      })
+    )
+  );
 
+  // Persist the transactions once currencies have been resolved by yahoo.effects.
+  public readonly importYahooCsvReady$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(importYahooCsvReady),
+      withLatestFrom(this.store.select(selectFeature)),
+      switchMap(([{ portfolioId, mode, incoming }, state]) => {
         const updated = state.portfoliosDbo.map((p) => {
           if (p.id !== portfolioId) return p;
           const transactions =
             mode === 'replace' ? incoming : mergeTransactions(p.transactions, incoming);
           return { ...p, transactions };
         });
-
         return this.service.setData(buildPayload(state, updated)).pipe(
           map((data) => importYahooCsvSuccess({ data })),
           catchError((error: HttpErrorResponse) =>

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -58,9 +58,10 @@ export const selectVisiblePortfoliosDbo = createSelector(
 const selectAggregatePortfolio = createSelector(
   selectVisiblePortfoliosDbo,
   selectTickers,
-  (portfolios, tickers) => {
+  selectBaseCurrency,
+  (portfolios, tickers, baseCurrency) => {
     const merged = mergeTransactionsDbo(portfolios.map((p) => p.transactions));
-    return computePortfolioState(merged, tickers);
+    return computePortfolioState(merged, tickers, baseCurrency);
   }
 );
 
@@ -68,7 +69,8 @@ const selectAggregatePortfolio = createSelector(
 export const selectAllPortfolioStates = createSelector(
   selectPortfoliosDbo,
   selectTickers,
-  (portfolios, tickers) => computeAllPortfolios(portfolios, tickers)
+  selectBaseCurrency,
+  (portfolios, tickers, baseCurrency) => computeAllPortfolios(portfolios, tickers, baseCurrency)
 );
 
 // Public view-model — same shape as before (transactions, stocks, dates, summary,

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -52,16 +52,26 @@ export const selectVisiblePortfoliosDbo = createSelector(
     ids === 'all' ? portfolios : portfolios.filter((p) => ids.includes(p.id))
 );
 
-// Aggregate portfolio state — merges all visible portfolios' transactions and
-// runs computePortfolioState over them. This is the view-model used by the
-// dashboard and as the backward-compat selectState.
-const selectAggregatePortfolio = createSelector(
+// Aggregate portfolio with a separate fxError so the error can be surfaced
+// without crashing the selector chain.
+const selectAggregatePortfolioResult = createSelector(
   selectVisiblePortfoliosDbo,
   selectTickers,
   selectBaseCurrency,
   (portfolios, tickers, baseCurrency) => {
     const merged = mergeTransactionsDbo(portfolios.map((p) => p.transactions));
-    return computePortfolioState(merged, tickers, baseCurrency);
+    try {
+      return {
+        portfolio: computePortfolioState(merged, tickers, baseCurrency),
+        fxError: null as string | null,
+      };
+    } catch (err) {
+      // Fall back to native-currency values and report the FX error to the UI.
+      return {
+        portfolio: computePortfolioState(merged, tickers),
+        fxError: err instanceof Error ? err.message : 'FX conversion failed',
+      };
+    }
   }
 );
 
@@ -70,14 +80,24 @@ export const selectAllPortfolioStates = createSelector(
   selectPortfoliosDbo,
   selectTickers,
   selectBaseCurrency,
-  (portfolios, tickers, baseCurrency) => computeAllPortfolios(portfolios, tickers, baseCurrency)
+  (portfolios, tickers, baseCurrency) => {
+    try {
+      return computeAllPortfolios(portfolios, tickers, baseCurrency);
+    } catch {
+      return computeAllPortfolios(portfolios, tickers);
+    }
+  }
 );
 
 // Public view-model — same shape as before (transactions, stocks, dates, summary,
 // currencies) plus loading/error. Backward compat for existing components.
 export const selectState = createSelector(
-  selectAggregatePortfolio,
+  selectAggregatePortfolioResult,
   selectLoading,
   selectError,
-  (portfolio, loading, error) => ({ ...portfolio, loading, error })
+  ({ portfolio, fxError }, loading, error) => ({
+    ...portfolio,
+    loading,
+    error: error || fxError,
+  })
 );

--- a/libs/frontend/yahoo/src/lib/+state/yahoo.effects.ts
+++ b/libs/frontend/yahoo/src/lib/+state/yahoo.effects.ts
@@ -2,11 +2,18 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { switchMap, catchError, of, withLatestFrom, mergeMap } from 'rxjs';
+import { switchMap, catchError, of, withLatestFrom, mergeMap, map } from 'rxjs';
 import { YahooService } from '../yahoo.service';
 import { getTickerFailure, getTickersSuccess } from './yahoo.actions';
 import { yahooObjectsToTickers } from '@aws/util';
-import { getDataSuccess, selectState, setChartData } from '@aws/state';
+import {
+  getDataSuccess,
+  importYahooCsvFailure,
+  importYahooCsvParsed,
+  importYahooCsvReady,
+  selectState,
+  setChartData,
+} from '@aws/state';
 
 @Injectable()
 export class YahooEffects {
@@ -15,6 +22,59 @@ export class YahooEffects {
     private readonly actions$: Actions,
     private readonly service: YahooService
   ) {}
+
+  // Intercept the parsed Yahoo CSV to fetch each symbol's currency from Yahoo
+  // before handing off to state.effects for the DB save.
+  public readonly importYahooCsvResolveCurrencies$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(importYahooCsvParsed),
+      switchMap(({ portfolioId, mode, incoming }) => {
+        const unknownSymbols = [
+          ...new Set([
+            ...incoming.stock
+              .filter((tx) => tx.currency === 'UNKNOWN')
+              .map((tx) => tx.ticker),
+            ...incoming.commission
+              .filter((tx) => tx.currency === 'UNKNOWN')
+              .map((tx) => tx.ticker),
+          ]),
+        ];
+
+        if (unknownSymbols.length === 0) {
+          return of(importYahooCsvReady({ portfolioId, mode, incoming }));
+        }
+
+        const recentDate = new Date();
+        recentDate.setDate(recentDate.getDate() - 7);
+
+        return this.service.getTickers(unknownSymbols, recentDate, []).pipe(
+          map((yahooObjects) => {
+            const currencyMap: { [symbol: string]: string } = {};
+            for (const yo of yahooObjects) {
+              currencyMap[yo.symbol] = yo.data.chart.result[0].meta.currency;
+            }
+            const resolved = {
+              stock: incoming.stock.map((tx) =>
+                tx.currency === 'UNKNOWN' && currencyMap[tx.ticker]
+                  ? { ...tx, currency: currencyMap[tx.ticker] }
+                  : tx
+              ),
+              dividend: incoming.dividend,
+              commission: incoming.commission.map((tx) =>
+                tx.currency === 'UNKNOWN' && currencyMap[tx.ticker]
+                  ? { ...tx, currency: currencyMap[tx.ticker] }
+                  : tx
+              ),
+            };
+            return importYahooCsvReady({ portfolioId, mode, incoming: resolved });
+          }),
+          catchError((error: HttpErrorResponse) =>
+            of(importYahooCsvFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
 
   // On a fresh data load, fetch the latest prices for the held tickers and feed
   // them into the store. Save/delete/import don't refetch prices — the memoized

--- a/libs/shared/util/src/lib/core.ts
+++ b/libs/shared/util/src/lib/core.ts
@@ -71,6 +71,14 @@ export function subtractLists(list1: number[], list2: number[]): number[] {
   return result;
 }
 
+export function multiplyLists(list1: number[], list2: number[]): number[] {
+  const result = [];
+  for (let i = 0; i < list1.length; i++) {
+    result.push(list1[i] * list2[i]);
+  }
+  return result;
+}
+
 export function addPerQuarterByYearLists(
   list1: { year: string; data: number[] }[],
   list2: { year: string; data: number[] }[]

--- a/libs/shared/util/src/lib/portfolio.spec.ts
+++ b/libs/shared/util/src/lib/portfolio.spec.ts
@@ -187,4 +187,156 @@ describe('computePortfolioState', () => {
     // No FX applied: 2 shares * €150 = €300
     expect(result.summary.portfolioValue).toBe(300);
   });
+
+  it('backward-fills FX rate for portfolio dates before the first FX data point', () => {
+    const usdDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'AAPL',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 1,
+          value: 100,
+          currency: 'USD',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(usdDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'AAPL',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 200),
+      dividends: [],
+    };
+
+    // FX data starts 5 days after the portfolio start: the first 5 dates should
+    // still get the same rate via the backward fill.
+    const fxStartOffset = 5;
+    const fxTicker: Ticker = {
+      name: 'EUR=X',
+      currency: 'EUR',
+      dates: dates.slice(fxStartOffset),
+      values: dates.slice(fxStartOffset).map(() => 0.9),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(
+      usdDbo,
+      { AAPL: stockTicker, 'EUR=X': fxTicker },
+      'EUR'
+    );
+
+    // All portfolio values should use rate 0.9 — backward fill covers the gap.
+    expect(result.summary.portfolioValue).toBeCloseTo(180);
+    const portfolioValues = result.stocks['AAPL'].chartData.portfolioValues;
+    // dates[0] is one day before the transaction (0 shares); dates[1] is when
+    // the 1-share transaction lands. getDailyDates starts one day before start.
+    expect(portfolioValues[1]).toBeCloseTo(200 * 0.9);
+  });
+
+  it('throws when FX ticker has no valid data', () => {
+    const usdDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'AAPL',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 1,
+          value: 100,
+          currency: 'USD',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(usdDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'AAPL',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 200),
+      dividends: [],
+    };
+
+    const emptyFxTicker: Ticker = {
+      name: 'EUR=X',
+      currency: 'EUR',
+      dates: [],
+      values: [],
+      dividends: [],
+    };
+
+    expect(() =>
+      computePortfolioState(
+        usdDbo,
+        { AAPL: stockTicker, 'EUR=X': emptyFxTicker },
+        'EUR'
+      )
+    ).toThrow('No FX rate data available for EUR=X');
+  });
+
+  it('applies GBp (pence) fxMultiplier: divides by 100 before EUR conversion', () => {
+    const gbpDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'LLOY.L',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 100,
+          value: 5000, // 5000 pence = £50
+          currency: 'GBp',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(gbpDbo)),
+      new Date()
+    );
+
+    // Price in pence: 60p per share
+    const stockTicker: Ticker = {
+      name: 'LLOY.L',
+      currency: 'GBp',
+      dates,
+      values: dates.map(() => 60),
+      dividends: [],
+    };
+
+    // GBPEUR=X: 1 GBP = 1.15 EUR
+    const fxTicker: Ticker = {
+      name: 'GBPEUR=X',
+      currency: 'EUR',
+      dates,
+      values: dates.map(() => 1.15),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(
+      gbpDbo,
+      { 'LLOY.L': stockTicker, 'GBPEUR=X': fxTicker },
+      'EUR'
+    );
+
+    // 100 shares * 60p = 6000p = £60; £60 * 1.15 = €69
+    expect(result.summary.portfolioValue).toBeCloseTo(69);
+    expect(result.stocks['LLOY.L'].summary.portfolioValue).toBeCloseTo(69);
+    // Current share price: 60p = £0.60 * 1.15 = €0.69
+    expect(result.stocks['LLOY.L'].summary.currentSharePrice).toBeCloseTo(0.69);
+  });
 });

--- a/libs/shared/util/src/lib/portfolio.spec.ts
+++ b/libs/shared/util/src/lib/portfolio.spec.ts
@@ -97,4 +97,94 @@ describe('computePortfolioState', () => {
     expect(result.summary.totalInvested).toBe(0);
     expect(result.summary.portfolioValue).toBe(0);
   });
+
+  it('applies FX conversion when displayCurrency differs from stock currency', () => {
+    const usdDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'AAPL',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 1,
+          value: 100,
+          currency: 'USD',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(usdDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'AAPL',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 200),
+      dividends: [],
+    };
+
+    // EUR=X represents the USD→EUR conversion rate. A rate of 0.9 means
+    // 1 USD = 0.9 EUR, so a $200 position becomes €180.
+    const fxTicker: Ticker = {
+      name: 'EUR=X',
+      currency: 'EUR',
+      dates,
+      values: dates.map(() => 0.9),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(
+      usdDbo,
+      { AAPL: stockTicker, 'EUR=X': fxTicker },
+      'EUR'
+    );
+
+    // 1 share * $200 * 0.9 fx = €180
+    expect(result.summary.portfolioValue).toBeCloseTo(180);
+    expect(result.stocks['AAPL'].summary.portfolioValue).toBeCloseTo(180);
+    expect(result.stocks['AAPL'].summary.currentSharePrice).toBeCloseTo(180);
+  });
+
+  it('skips FX conversion when displayCurrency matches stock currency', () => {
+    const eurDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'VUSA.AS',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 2,
+          value: 200,
+          currency: 'EUR',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(eurDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'VUSA.AS',
+      currency: 'EUR',
+      dates,
+      values: dates.map(() => 150),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(
+      eurDbo,
+      { 'VUSA.AS': stockTicker },
+      'EUR'
+    );
+
+    // No FX applied: 2 shares * €150 = €300
+    expect(result.summary.portfolioValue).toBe(300);
+  });
 });

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -21,32 +21,56 @@ import {
 } from './util';
 
 /**
- * Returns an array of FX rates aligned to the given portfolio dates by carrying
- * forward the last known rate. Defaults to 1 until the first FX data point
- * arrives, so missing data produces no conversion rather than NaN.
+ * Returns an array of FX rates aligned to the given portfolio dates using the
+ * nearest available rate (forward fill, then backward fill for dates before the
+ * first data point). Treats zero values as missing, matching how Yahoo Finance
+ * omits rates on weekends and holidays.
+ *
+ * Throws when the FX ticker has no valid values at all so callers can surface
+ * the error to the user rather than silently producing wrong numbers.
  */
 function getFxRates(dates: Date[], fxTicker: Ticker): number[] {
-  const rates: number[] = [];
+  const rates = new Array<number>(dates.length).fill(NaN);
   let fxIdx = 0;
-  let lastKnownRate = 1;
+  let lastKnownRate = NaN;
 
-  for (const date of dates) {
+  // Forward pass: carry the last known rate forward.
+  for (let i = 0; i < dates.length; i++) {
     while (
       fxIdx < fxTicker.dates.length &&
-      !isSameDay(fxTicker.dates[fxIdx], date) &&
-      fxTicker.dates[fxIdx] < date
+      !isSameDay(fxTicker.dates[fxIdx], dates[i]) &&
+      fxTicker.dates[fxIdx] < dates[i]
     ) {
       const val = fxTicker.values[fxIdx];
       if (!isNaN(val) && val > 0) lastKnownRate = val;
       fxIdx++;
     }
-    if (fxIdx < fxTicker.dates.length && isSameDay(fxTicker.dates[fxIdx], date)) {
+    if (fxIdx < fxTicker.dates.length && isSameDay(fxTicker.dates[fxIdx], dates[i])) {
       const val = fxTicker.values[fxIdx];
       if (!isNaN(val) && val > 0) lastKnownRate = val;
       fxIdx++;
     }
-    rates.push(lastKnownRate);
+    if (!isNaN(lastKnownRate)) rates[i] = lastKnownRate;
   }
+
+  // Find the first valid rate to fill any NaNs before it.
+  let firstKnown = NaN;
+  for (let i = 0; i < rates.length; i++) {
+    if (!isNaN(rates[i])) { firstKnown = rates[i]; break; }
+  }
+
+  if (isNaN(firstKnown)) {
+    throw new Error(
+      `No FX rate data available for ${fxTicker.name}. ` +
+      `Ensure the symbol is valid and Yahoo Finance data has loaded.`
+    );
+  }
+
+  // Backward pass: fill any NaNs at the start from the first known rate.
+  for (let i = 0; i < rates.length && isNaN(rates[i]); i++) {
+    rates[i] = firstKnown;
+  }
+
   return rates;
 }
 
@@ -236,11 +260,14 @@ export function computePortfolioState(
 
     if (fxTicker) {
       const fxRates = getFxRates(dates, fxTicker);
-      portfolioValues = multiplyLists(portfolioValuesNative, fxRates);
-      investedForProfit = multiplyLists(stock.chartData.stock.aggregatedValues, fxRates);
-      commissionForProfit = multiplyLists(stock.chartData.commission.aggregatedValues, fxRates);
-      const lastFxRate = getMostRecentValueFromList(fxRates).value;
-      currentSharePrice = currentSharePrice * lastFxRate;
+      // fxMultiplier handles sub-unit currencies: GBp (pence) = 0.01 × GBP.
+      const m = stock.currency.fxMultiplier ?? 1;
+      const scaledRates = m === 1 ? fxRates : fxRates.map(r => r * m);
+      portfolioValues = multiplyLists(portfolioValuesNative, scaledRates);
+      investedForProfit = multiplyLists(stock.chartData.stock.aggregatedValues, scaledRates);
+      commissionForProfit = multiplyLists(stock.chartData.commission.aggregatedValues, scaledRates);
+      const lastScaledRate = getMostRecentValueFromList(scaledRates).value;
+      currentSharePrice = currentSharePrice * lastScaledRate;
     }
 
     aggregatedPortfolioValues =

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -12,11 +12,43 @@ import {
   getStartDate,
   getTransactionAmountsAndValues,
   getYieldPerYear,
+  isSameDay,
+  multiplyLists,
   subtractLists,
   transactionsDboToStocks,
   transactionsDboToTransactions,
   updateDividends,
 } from './util';
+
+/**
+ * Returns an array of FX rates aligned to the given portfolio dates by carrying
+ * forward the last known rate. Defaults to 1 until the first FX data point
+ * arrives, so missing data produces no conversion rather than NaN.
+ */
+function getFxRates(dates: Date[], fxTicker: Ticker): number[] {
+  const rates: number[] = [];
+  let fxIdx = 0;
+  let lastKnownRate = 1;
+
+  for (const date of dates) {
+    while (
+      fxIdx < fxTicker.dates.length &&
+      !isSameDay(fxTicker.dates[fxIdx], date) &&
+      fxTicker.dates[fxIdx] < date
+    ) {
+      const val = fxTicker.values[fxIdx];
+      if (!isNaN(val) && val > 0) lastKnownRate = val;
+      fxIdx++;
+    }
+    if (fxIdx < fxTicker.dates.length && isSameDay(fxTicker.dates[fxIdx], date)) {
+      const val = fxTicker.values[fxIdx];
+      if (!isNaN(val) && val > 0) lastKnownRate = val;
+      fxIdx++;
+    }
+    rates.push(lastKnownRate);
+  }
+  return rates;
+}
 
 export interface PortfolioState {
   transactions: Transactions;
@@ -59,7 +91,8 @@ export function createInitialSummary(): Summary {
  */
 export function computePortfolioState(
   transactionsDbo: TransactionsDbo,
-  tickers: { [ticker: string]: Ticker }
+  tickers: { [ticker: string]: Ticker },
+  displayCurrency?: string
 ): PortfolioState {
   const baseStocks = transactionsDboToStocks(transactionsDbo);
   const transactions = transactionsDboToTransactions(transactionsDbo);
@@ -180,11 +213,36 @@ export function computePortfolioState(
       continue;
     }
 
-    const portfolioValues = getPortfolioValues(
+    const portfolioValuesNative = getPortfolioValues(
       dates,
       stock.chartData.stock.aggregatedAmounts,
       ticker
     );
+
+    // Apply FX conversion when the stock is denominated in a currency other
+    // than the display currency and a matching FX ticker is available.
+    const fxSymbol = stock.currency.yahooTicker;
+    const fxTicker =
+      displayCurrency &&
+      stock.currency.value !== displayCurrency &&
+      fxSymbol
+        ? tickers[fxSymbol]
+        : undefined;
+
+    let portfolioValues = portfolioValuesNative;
+    let investedForProfit = stock.chartData.stock.aggregatedValues;
+    let commissionForProfit = stock.chartData.commission.aggregatedValues;
+    let currentSharePrice = getMostRecentValueFromList(ticker.values).value;
+
+    if (fxTicker) {
+      const fxRates = getFxRates(dates, fxTicker);
+      portfolioValues = multiplyLists(portfolioValuesNative, fxRates);
+      investedForProfit = multiplyLists(stock.chartData.stock.aggregatedValues, fxRates);
+      commissionForProfit = multiplyLists(stock.chartData.commission.aggregatedValues, fxRates);
+      const lastFxRate = getMostRecentValueFromList(fxRates).value;
+      currentSharePrice = currentSharePrice * lastFxRate;
+    }
+
     aggregatedPortfolioValues =
       aggregatedPortfolioValues.length > 0
         ? addLists(aggregatedPortfolioValues, portfolioValues)
@@ -193,8 +251,8 @@ export function computePortfolioState(
     portfolioValuesSummary += portfolioValue;
 
     const profit = subtractLists(
-      subtractLists(portfolioValues, stock.chartData.stock.aggregatedValues),
-      stock.chartData.commission.aggregatedValues
+      subtractLists(portfolioValues, investedForProfit),
+      commissionForProfit
     );
     aggregatedProfit =
       aggregatedProfit.length > 0
@@ -226,7 +284,7 @@ export function computePortfolioState(
       summary: {
         ...stock.summary,
         portfolioValue,
-        currentSharePrice: getMostRecentValueFromList(ticker.values).value,
+        currentSharePrice,
         dailyReturn,
         weeklyReturn,
         monthlyReturn,
@@ -266,12 +324,13 @@ export function computePortfolioState(
  */
 export function computeAllPortfolios(
   portfoliosDbo: PortfolioDbo[],
-  tickers: { [ticker: string]: Ticker }
+  tickers: { [ticker: string]: Ticker },
+  baseCurrency?: string
 ): { [id: string]: PortfolioComputedState } {
   const result: { [id: string]: PortfolioComputedState } = {};
   for (const portfolio of portfoliosDbo) {
     result[portfolio.id] = {
-      ...computePortfolioState(portfolio.transactions, tickers),
+      ...computePortfolioState(portfolio.transactions, tickers, baseCurrency),
       portfolioId: portfolio.id,
       portfolioName: portfolio.name,
     };

--- a/libs/shared/util/src/lib/transactions.ts
+++ b/libs/shared/util/src/lib/transactions.ts
@@ -115,18 +115,21 @@ export function transactionsDboToTransactions(
 
 function getCurrency(currency: string): {
   value: string;
-  yahooTicker: string | undefined;
+  yahooTicker?: string;
+  fxMultiplier?: number;
 } {
-  const yahooTicker = (() => {
-    switch (currency) {
-      case 'USD':
-        return 'EUR=X';
-      case 'EUR':
-      default:
-        return undefined;
-    }
-  })();
-  return { value: currency, yahooTicker };
+  switch (currency) {
+    case 'USD':
+      return { value: 'USD', yahooTicker: 'EUR=X' };
+    case 'GBP':
+      return { value: 'GBP', yahooTicker: 'GBPEUR=X' };
+    case 'GBp':
+      // Yahoo prices UK stocks in pence; divide by 100 after applying the GBP→EUR rate.
+      return { value: 'GBp', yahooTicker: 'GBPEUR=X', fxMultiplier: 0.01 };
+    case 'EUR':
+    default:
+      return { value: currency };
+  }
 }
 
 export function transactionsDboToStocks(transactions: TransactionsDbo): {

--- a/libs/shared/util/src/lib/types.ts
+++ b/libs/shared/util/src/lib/types.ts
@@ -37,6 +37,10 @@ export type Stock = {
   currency: {
     value: string;
     yahooTicker?: string;
+    // Multiplier applied after the FX rate conversion. Used for sub-unit
+    // currencies where Yahoo prices differ from the exchange rate unit:
+    // GBp (pence) = 0.01 × GBP, so fxMultiplier is 0.01.
+    fxMultiplier?: number;
   };
 };
 

--- a/libs/shared/util/src/lib/util.spec.ts
+++ b/libs/shared/util/src/lib/util.spec.ts
@@ -416,6 +416,44 @@ describe('transactionsDboToStocks / getStartDate / getCurrencies', () => {
     const stocks = transactionsDboToStocks(input);
     expect(getCurrencies(stocks)).toEqual(['EUR=X']);
   });
+
+  it('resolves GBP to GBPEUR=X', () => {
+    const gbpInput: TransactionsDbo = {
+      stock: [dbo('2023-01-10', 10, 100, 'stock', 'GBP')],
+      dividend: [],
+      commission: [],
+    };
+    const stocks = transactionsDboToStocks(gbpInput);
+    expect(stocks['VUSA.AS'].currency).toEqual({ value: 'GBP', yahooTicker: 'GBPEUR=X' });
+    expect(getCurrencies(stocks)).toEqual(['GBPEUR=X']);
+  });
+
+  it('resolves GBp (pence) to GBPEUR=X with fxMultiplier 0.01', () => {
+    const gbpInput: TransactionsDbo = {
+      stock: [dbo('2023-01-10', 1000, 5000, 'stock', 'GBp')],
+      dividend: [],
+      commission: [],
+    };
+    const stocks = transactionsDboToStocks(gbpInput);
+    expect(stocks['VUSA.AS'].currency).toEqual({
+      value: 'GBp',
+      yahooTicker: 'GBPEUR=X',
+      fxMultiplier: 0.01,
+    });
+  });
+
+  it('getCurrencies deduplicates GBP and GBp under the same GBPEUR=X ticker', () => {
+    const mixed: TransactionsDbo = {
+      stock: [
+        dbo('2023-01-10', 1, 100, 'stock', 'GBP'),
+        { ticker: 'LLOY.L', type: 'stock', date: '2023-01-11', amount: 100, value: 5000, currency: 'GBp' },
+      ],
+      dividend: [],
+      commission: [],
+    };
+    const stocks = transactionsDboToStocks(mixed);
+    expect(getCurrencies(stocks)).toEqual(['GBPEUR=X']);
+  });
 });
 
 describe('yahooObjectToTicker', () => {


### PR DESCRIPTION
## Summary

- **FX rate conversion in `computePortfolioState`**: per-day portfolio values, invested totals, and commission arrays are multiplied by historical FX rates when a stock's native currency differs from the user's `baseCurrency`; `computeAllPortfolios` and both dashboard selectors now pass `baseCurrency` as `displayCurrency`
- **Nearest-rate fill for FX gaps**: `getFxRates` runs a forward pass (carry last known rate) then a backward pass (fill dates before the first FX data point from the nearest available rate), matching the Python portfolio's `__download_exchange_rates` algorithm; throws when the ticker has zero valid values so the error surfaces via `selectState.error`
- **GBP and GBp (pence) support**: `getCurrency` now maps GBP → `GBPEUR=X` and GBp → `GBPEUR=X` with `fxMultiplier: 0.01` (÷100 to convert pence to pounds before the EUR rate is applied); `getCurrencies` picks up `GBPEUR=X` automatically so the Yahoo effect fetches it alongside `EUR=X`
- **Yahoo CSV currency auto-detection**: `importYahooCsv$` now parses the CSV and dispatches `importYahooCsvParsed`; `yahoo.effects` intercepts that, fetches a 1-day ticker for each `UNKNOWN`-currency symbol, fills in the real currency from `meta.currency`, and dispatches `importYahooCsvReady`; `state.effects` persists on `importYahooCsvReady` — the state lib never imports yahoo

## Test plan

- [ ] Import a Yahoo Finance CSV with USD stocks → transactions should have `USD` currency (not `UNKNOWN`) after save
- [ ] Import a Yahoo Finance CSV with GBP/GBp stocks → currencies resolved correctly
- [ ] Dashboard with a USD stock and EUR base currency → portfolio value and chart should be in EUR
- [ ] Dashboard with a GBP stock → portfolio value uses `GBPEUR=X` rate
- [ ] Dashboard with a GBp (pence) stock → portfolio value divides by 100 before applying `GBPEUR=X`
- [ ] If Yahoo returns no FX data for a symbol → error message shown in the UI, portfolio falls back to native-currency values
- [ ] EUR-only portfolio → no FX conversion applied, values unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)