### PR TITLE
feat: time-range selector, performance overhaul, and dashboard chart fixes

### DIFF
--- a/libs/frontend/state/src/lib/+state/state.actions.ts
+++ b/libs/frontend/state/src/lib/+state/state.actions.ts
@@ -4,6 +4,7 @@ import {
   DatabaseDto,
   PortfolioDbo,
   Ticker,
+  TimeRange,
   Transaction,
   TransactionKey,
   TransactionsDbo,
@@ -146,6 +147,11 @@ export const importYahooCsvFailure = createAction(
 export const setSelectedPortfolios = createAction(
   '[State] Set Selected Portfolios',
   props<{ ids: string[] | 'all' }>()
+);
+
+export const setTimeRange = createAction(
+  '[State] Set Time Range',
+  props<{ range: TimeRange }>()
 );
 
 // --- Settings ---

--- a/libs/frontend/state/src/lib/+state/state.reducer.ts
+++ b/libs/frontend/state/src/lib/+state/state.reducer.ts
@@ -33,11 +33,12 @@ import {
   saveTransactionSuccess,
   setChartData,
   setSelectedPortfolios,
+  setTimeRange,
   updateSettings,
   updateSettingsFailure,
   updateSettingsSuccess,
 } from './state.actions';
-import { PortfolioDbo, Ticker, UserSettingsDbo } from '@aws/util';
+import { PortfolioDbo, Ticker, TimeRange, UserSettingsDbo } from '@aws/util';
 
 export const featureKey = 'state';
 
@@ -51,8 +52,9 @@ export interface FeatureState {
   loading: boolean;
   error: string | null;
   lastFetched: number | null;
-  // UI-only filter: which portfolios are shown on dashboard (not persisted).
+  // UI-only filters: not persisted to the backend.
   selectedPortfolioIds: string[] | 'all';
+  timeRange: TimeRange;
 }
 
 export const initialState: FeatureState = {
@@ -63,6 +65,7 @@ export const initialState: FeatureState = {
   error: null,
   lastFetched: null,
   selectedPortfolioIds: 'all',
+  timeRange: '1Y',
 };
 
 export const reducer = createReducer(
@@ -93,6 +96,10 @@ export const reducer = createReducer(
   on(setSelectedPortfolios, (state, { ids }) => ({
     ...state,
     selectedPortfolioIds: ids,
+  })),
+  on(setTimeRange, (state, { range }) => ({
+    ...state,
+    timeRange: range,
   })),
   // --- loading / error tracking ---
   on(

--- a/libs/frontend/state/src/lib/+state/state.selectors.ts
+++ b/libs/frontend/state/src/lib/+state/state.selectors.ts
@@ -44,6 +44,11 @@ export const selectSelectedPortfolioIds = createSelector(
   (state) => state.selectedPortfolioIds
 );
 
+export const selectTimeRange = createSelector(
+  selectFeature,
+  (state) => state.timeRange
+);
+
 // The portfolios that are currently visible on the dashboard.
 export const selectVisiblePortfoliosDbo = createSelector(
   selectPortfoliosDbo,
@@ -58,17 +63,17 @@ const selectAggregatePortfolioResult = createSelector(
   selectVisiblePortfoliosDbo,
   selectTickers,
   selectBaseCurrency,
-  (portfolios, tickers, baseCurrency) => {
+  selectTimeRange,
+  (portfolios, tickers, baseCurrency, timeRange) => {
     const merged = mergeTransactionsDbo(portfolios.map((p) => p.transactions));
     try {
       return {
-        portfolio: computePortfolioState(merged, tickers, baseCurrency),
+        portfolio: computePortfolioState(merged, tickers, baseCurrency, timeRange),
         fxError: null as string | null,
       };
     } catch (err) {
-      // Fall back to native-currency values and report the FX error to the UI.
       return {
-        portfolio: computePortfolioState(merged, tickers),
+        portfolio: computePortfolioState(merged, tickers, undefined, timeRange),
         fxError: err instanceof Error ? err.message : 'FX conversion failed',
       };
     }
@@ -76,15 +81,16 @@ const selectAggregatePortfolioResult = createSelector(
 );
 
 // Per-portfolio computed states keyed by portfolio ID.
+// Always uses '1Y' range so per-portfolio summary cards show accurate returns.
 export const selectAllPortfolioStates = createSelector(
   selectPortfoliosDbo,
   selectTickers,
   selectBaseCurrency,
   (portfolios, tickers, baseCurrency) => {
     try {
-      return computeAllPortfolios(portfolios, tickers, baseCurrency);
+      return computeAllPortfolios(portfolios, tickers, baseCurrency, '1Y');
     } catch {
-      return computeAllPortfolios(portfolios, tickers);
+      return computeAllPortfolios(portfolios, tickers, undefined, '1Y');
     }
   }
 );

--- a/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.html
+++ b/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.html
@@ -17,4 +17,5 @@
   *ngIf="activeChartData"
   [dates]="dates"
   [chartData]="activeChartData"
+  [currencySymbol]="currencySymbol"
 ></aws-yahoo>

--- a/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.ts
+++ b/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.ts
@@ -18,6 +18,7 @@ import { YahooComponent } from '../yahoo/yahoo.component';
 export class ActiveTickersComponent implements OnChanges {
   @Input() dates: Date[] = [];
   @Input() stocks: { [ticker: string]: Stock } | undefined;
+  @Input() currencySymbol = '€';
 
   tickers: string[] = [];
   activeStocks: string[] = [];

--- a/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.ts
+++ b/libs/frontend/ui/src/lib/active-tickers/active-tickers.component.ts
@@ -64,6 +64,11 @@ export class ActiveTickersComponent implements OnChanges {
     );
     const profit = addLists(chartData1.profit, chartData2.profit);
 
+    // Merge full-history data (same monthly dates for all stocks in the portfolio).
+    const allTimeDates = chartData1.allTimeDates;
+    const allTimePortfolioValues = addLists(chartData1.allTimePortfolioValues, chartData2.allTimePortfolioValues);
+    const allTimeProfit = addLists(chartData1.allTimeProfit, chartData2.allTimeProfit);
+
     return {
       stock: {
         transactionValues: addLists(
@@ -142,7 +147,11 @@ export class ActiveTickersComponent implements OnChanges {
       },
       portfolioValues,
       profit,
-      yieldPerYear: getYieldPerYear(this.dates, portfolioValues, profit),
+      allTimeDates,
+      allTimePortfolioValues,
+      allTimeProfit,
+      // Yield always computed from full-history monthly data regardless of range.
+      yieldPerYear: getYieldPerYear(allTimeDates, allTimePortfolioValues, allTimeProfit),
     };
   }
 }

--- a/libs/frontend/ui/src/lib/bar-and-line-chart/bar-and-line-chart.component.ts
+++ b/libs/frontend/ui/src/lib/bar-and-line-chart/bar-and-line-chart.component.ts
@@ -23,6 +23,7 @@ export class BarAndLineChartComponent implements OnChanges {
     yearQuarters: [],
     dividends: [],
   };
+  @Input() currencySymbol = '€';
 
   chartOptions: EChartsOption | undefined;
 
@@ -65,7 +66,7 @@ export class BarAndLineChartComponent implements OnChanges {
       },
       yAxis: {
         type: 'value',
-        axisLabel: { formatter: '{value} €', color: NAUTICAL_MUTED },
+        axisLabel: { formatter: `{value} ${this.currencySymbol}`, color: NAUTICAL_MUTED },
         axisLine: { lineStyle: { color: NAUTICAL_GRID } },
         splitLine: { lineStyle: { color: NAUTICAL_GRID } },
       },

--- a/libs/frontend/ui/src/lib/bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component.ts
+++ b/libs/frontend/ui/src/lib/bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component.ts
@@ -28,6 +28,7 @@ const colors = [
 })
 export class BarChartPerQuarterByYearComponent implements OnChanges {
   @Input() series: { year: string; data: number[] }[] = [];
+  @Input() currencySymbol = '€';
 
   chartOptions: EChartsOption | undefined;
 
@@ -66,7 +67,7 @@ export class BarChartPerQuarterByYearComponent implements OnChanges {
       },
       yAxis: {
         type: 'value',
-        axisLabel: { formatter: '{value} €', color: NAUTICAL_MUTED },
+        axisLabel: { formatter: `{value} ${this.currencySymbol}`, color: NAUTICAL_MUTED },
         axisLine: { lineStyle: { color: NAUTICAL_GRID } },
         splitLine: { lineStyle: { color: NAUTICAL_GRID } },
       },

--- a/libs/frontend/ui/src/lib/bar-chart/bar-chart.component.ts
+++ b/libs/frontend/ui/src/lib/bar-chart/bar-chart.component.ts
@@ -24,6 +24,7 @@ export class BarChartComponent implements OnChanges {
     yields: [],
     profit: [],
   };
+  @Input() currencySymbol = '€';
 
   chartOptions: EChartsOption | undefined;
 
@@ -69,7 +70,7 @@ export class BarChartComponent implements OnChanges {
         {
           type: 'value',
           position: 'right',
-          axisLabel: { formatter: '{value} €', color: NAUTICAL_MUTED },
+          axisLabel: { formatter: `{value} ${this.currencySymbol}`, color: NAUTICAL_MUTED },
           axisLine: { lineStyle: { color: NAUTICAL_GRID } },
           splitLine: { show: false },
         },

--- a/libs/frontend/ui/src/lib/chart/chart.component.ts
+++ b/libs/frontend/ui/src/lib/chart/chart.component.ts
@@ -20,6 +20,7 @@ export class ChartComponent implements OnChanges {
   @Input() label: string | undefined;
   @Input() money = true;
   @Input() showSymbols = false;
+  @Input() currencySymbol = '€';
 
   chartOptions: EChartsOption | undefined;
 
@@ -80,7 +81,7 @@ export class ChartComponent implements OnChanges {
       yAxis: {
         type: 'value',
         axisLabel: {
-          formatter: `{value}${this.money ? ' €' : ''}`,
+          formatter: `{value}${this.money ? ' ' + this.currencySymbol : ''}`,
           color: NAUTICAL_MUTED,
         },
         axisLine: { lineStyle: { color: NAUTICAL_GRID } },

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -39,6 +39,7 @@
     <aws-active-tickers
       [dates]="vm.state?.dates ?? []"
       [stocks]="vm.state?.stocks ?? {}"
+      [currencySymbol]="vm.currency === 'USD' ? '$' : '€'"
     ></aws-active-tickers>
   </section>
 

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -4,7 +4,9 @@
     state: state$ | async,
     portfolios: portfolios$ | async,
     selectedIds: selectedPortfolioIds$ | async,
-    currency: baseCurrency$ | async
+    currency: baseCurrency$ | async,
+    loading: loading$ | async,
+    timeRange: timeRange$ | async
   } as vm"
 >
 
@@ -31,11 +33,29 @@
     </div>
   </section>
 
+  <!-- Time-range selector -->
+  <section class="page-section range-section">
+    <div class="chips">
+      <button
+        *ngFor="let range of ranges"
+        class="chip"
+        [class.active]="vm.timeRange === range"
+        (click)="selectRange(range)"
+        type="button"
+      >
+        {{ rangeLabels[range] }}
+      </button>
+    </div>
+  </section>
+
+  <!-- Loading overlay while selector recomputes -->
+  <div class="computing-bar" *ngIf="vm.loading"></div>
+
   <section class="page-section">
     <aws-summary [summary]="vm.state?.summary" [currency]="vm.currency ?? 'EUR'"></aws-summary>
   </section>
 
-  <section class="page-section" *ngIf="vm.state?.summary?.portfolioValue">
+  <section class="page-section" *ngIf="(vm.state?.stocks | keyvalue)?.length">
     <aws-active-tickers
       [dates]="vm.state?.dates ?? []"
       [stocks]="vm.state?.stocks ?? {}"

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
@@ -43,6 +43,24 @@
   gap: 8px;
 }
 
+.range-section {
+  margin-top: 16px;
+}
+
+.computing-bar {
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba($color-gold, 0.8), transparent);
+  background-size: 200% 100%;
+  animation: shimmer 1.2s infinite;
+  border-radius: 1px;
+  margin-top: 12px;
+}
+
+@keyframes shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
 .chip {
   padding: 6px 14px;
   border-radius: 20px;

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -1,11 +1,15 @@
 import { Component } from '@angular/core';
 import {
   selectBaseCurrency,
+  selectLoading,
   selectPortfoliosDbo,
   selectSelectedPortfolioIds,
   selectState,
+  selectTimeRange,
   setSelectedPortfolios,
+  setTimeRange,
 } from '@aws/state';
+import { TIME_RANGE_LABELS, TimeRange } from '@aws/util';
 import { Store } from '@ngrx/store';
 import { SummaryComponent } from '../summary/summary.component';
 import { AsyncPipe, CommonModule, DatePipe } from '@angular/common';
@@ -22,6 +26,11 @@ export class DashboardComponent {
   portfolios$ = this.store.select(selectPortfoliosDbo);
   selectedPortfolioIds$ = this.store.select(selectSelectedPortfolioIds);
   baseCurrency$ = this.store.select(selectBaseCurrency);
+  loading$ = this.store.select(selectLoading);
+  timeRange$ = this.store.select(selectTimeRange);
+
+  readonly ranges: TimeRange[] = ['1M', '3M', '6M', 'YTD', '1Y', '5Y', 'ALL'];
+  readonly rangeLabels = TIME_RANGE_LABELS;
 
   constructor(private store: Store) {}
 
@@ -42,5 +51,9 @@ export class DashboardComponent {
     }
     const ids = current.length === allIds.length ? 'all' : current;
     this.store.dispatch(setSelectedPortfolios({ ids }));
+  }
+
+  selectRange(range: TimeRange) {
+    this.store.dispatch(setTimeRange({ range }));
   }
 }

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.html
@@ -9,6 +9,7 @@
   <aws-transactions-table
     [stocks]="stocks"
     [portfolioId]="portfolioId"
+    [baseCurrency]="baseCurrency"
   ></aws-transactions-table>
 </div>
 

--- a/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-detail/portfolio-detail.component.ts
@@ -12,6 +12,7 @@ import { TransactionsTableComponent } from '../transactions-table/transactions-t
 export class PortfolioDetailComponent {
   @Input() portfolio: PortfolioDbo | null = null;
   @Input() stocks: { [ticker: string]: Stock } = {};
+  @Input() baseCurrency = 'EUR';
 
   @Output() importCsv = new EventEmitter<string>();
 

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.html
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.html
@@ -1,4 +1,4 @@
-<div class="portfolios-layout" *ngIf="{ portfolios: portfolios$ | async, allStates: allPortfolioStates$ | async } as vm">
+<div class="portfolios-layout" *ngIf="{ portfolios: portfolios$ | async, allStates: allPortfolioStates$ | async, baseCurrency: baseCurrency$ | async } as vm">
   <aside class="portfolios-sidebar">
     <aws-portfolio-list
       [portfolios]="vm.portfolios ?? []"
@@ -14,6 +14,7 @@
     <aws-portfolio-detail
       [portfolio]="getSelectedPortfolio(vm.portfolios ?? [])"
       [stocks]="getSelectedPortfolioStocks(vm.allStates)"
+      [baseCurrency]="vm.baseCurrency ?? 'EUR'"
       (importCsv)="onImportCsv($event)"
     ></aws-portfolio-detail>
   </main>

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.ts
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.ts
@@ -9,6 +9,7 @@ import {
   importYahooCsv,
   renamePortfolio,
   selectAllPortfolioStates,
+  selectBaseCurrency,
   selectPortfoliosDbo,
 } from '@aws/state';
 import { PortfolioDbo, Stock } from '@aws/util';
@@ -38,6 +39,7 @@ import { DialogService } from '../dialog/dialog.service';
 export class PortfoliosComponent implements OnInit {
   portfolios$ = this.store.select(selectPortfoliosDbo);
   allPortfolioStates$ = this.store.select(selectAllPortfolioStates);
+  baseCurrency$ = this.store.select(selectBaseCurrency);
   selectedPortfolioId: string | null = null;
 
   constructor(private store: Store, private dialog: DialogService) {}

--- a/libs/frontend/ui/src/lib/scrolling-text/scrolling-text.component.html
+++ b/libs/frontend/ui/src/lib/scrolling-text/scrolling-text.component.html
@@ -1,19 +1,19 @@
-<div *ngIf="state$ | async as state" class="ticker-viewport">
-  <ng-container *ngIf="state.summary.totalReturn.absolute !== 0">
+<div *ngIf="{ state: state$ | async, symbol: currencySymbol$ | async } as vm" class="ticker-viewport">
+  <ng-container *ngIf="vm.state?.summary?.totalReturn?.absolute !== 0">
     <div class="ticker-track">
-      <ng-container *ngTemplateOutlet="items; context: { $implicit: state }"></ng-container>
-      <ng-container *ngTemplateOutlet="items; context: { $implicit: state }"></ng-container>
-      <ng-container *ngTemplateOutlet="items; context: { $implicit: state }"></ng-container>
-      <ng-container *ngTemplateOutlet="items; context: { $implicit: state }"></ng-container>
+      <ng-container *ngTemplateOutlet="items; context: { $implicit: vm.state, symbol: vm.symbol }"></ng-container>
+      <ng-container *ngTemplateOutlet="items; context: { $implicit: vm.state, symbol: vm.symbol }"></ng-container>
+      <ng-container *ngTemplateOutlet="items; context: { $implicit: vm.state, symbol: vm.symbol }"></ng-container>
+      <ng-container *ngTemplateOutlet="items; context: { $implicit: vm.state, symbol: vm.symbol }"></ng-container>
     </div>
   </ng-container>
 </div>
 
-<ng-template #items let-state>
+<ng-template #items let-state let-symbol="symbol">
 
   <span class="ticker-item">
     <span class="ticker-label">TOTAL</span>
-    <span class="ticker-value">€{{ state.summary.portfolioValue | number:'1.0-0' }}</span>
+    <span class="ticker-value">{{ symbol }}{{ state.summary.portfolioValue | number:'1.0-0' }}</span>
     <span class="ticker-change"
       [ngClass]="state.summary.totalReturn.absolute >= 0 ? 'ticker-pos' : 'ticker-neg'">
       {{ state.summary.totalReturn.absolute >= 0 ? '▲' : '▼' }}

--- a/libs/frontend/ui/src/lib/scrolling-text/scrolling-text.component.ts
+++ b/libs/frontend/ui/src/lib/scrolling-text/scrolling-text.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
-import { selectState } from '@aws/state';
+import { selectBaseCurrency, selectState } from '@aws/state';
 import { Store } from '@ngrx/store';
 import { AsyncPipe, CommonModule, DecimalPipe, NgClass, NgIf } from '@angular/common';
+import { map } from 'rxjs';
 
 @Component({
   selector: 'aws-scrolling-text',
@@ -16,6 +17,9 @@ import { AsyncPipe, CommonModule, DecimalPipe, NgClass, NgIf } from '@angular/co
 })
 export class ScrollingTextComponent {
   state$ = this.store.select(selectState);
+  currencySymbol$ = this.store.select(selectBaseCurrency).pipe(
+    map(c => c === 'USD' ? '$' : '€')
+  );
 
   constructor(private store: Store) {}
 }

--- a/libs/frontend/ui/src/lib/settings/settings.component.ts
+++ b/libs/frontend/ui/src/lib/settings/settings.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { selectBaseCurrency, updateSettings } from '@aws/state';
 
-const SUPPORTED_CURRENCIES = ['EUR', 'USD', 'GBP', 'CHF', 'JPY', 'AUD', 'CAD'];
+const SUPPORTED_CURRENCIES = ['EUR', 'USD'];
 
 @Component({
   selector: 'aws-settings',

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
@@ -5,6 +5,7 @@
     <details class="ticker-panel">
       <summary class="ticker-header">
         <span class="ticker-name">{{ stocks[key].ticker }}</span>
+        <span class="currency-badge">{{ stocks[key].currency.value }}</span>
         <span class="ticker-arrow">›</span>
       </summary>
 

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.ts
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.ts
@@ -27,6 +27,7 @@ export class TransactionsTableComponent {
   @Input() stocks: { [ticker: string]: Stock } = {};
   @Input() transactions: Transactions | undefined;
   @Input() portfolioId = 'default';
+  @Input() baseCurrency = 'EUR';
 
   constructor(
     private readonly store: Store,

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
@@ -8,6 +8,7 @@
         [x]="dates"
         [y]="chartData?.portfolioValues ?? []"
         label="Portfolio Value"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 
@@ -16,12 +17,14 @@
         [x]="dates"
         [y]="chartData?.profit ?? []"
         label="Profit"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 
     <div class="chart-card">
       <aws-bar-chart
         [series]="chartData?.yieldPerYear ?? { years: [], yields: [], profit: [] }"
+        [currencySymbol]="currencySymbol"
       ></aws-bar-chart>
     </div>
 
@@ -36,12 +39,14 @@
     <div class="chart-card">
       <aws-bar-chart-per-quarter-by-year
         [series]="chartData?.dividend?.perQuarterByYear ?? []"
+        [currencySymbol]="currencySymbol"
       ></aws-bar-chart-per-quarter-by-year>
     </div>
 
     <div class="chart-card">
       <aws-bar-and-line-chart
         [series]="chartData?.dividend?.ttmPerQuarter ?? { yearQuarters: [], dividends: [] }"
+        [currencySymbol]="currencySymbol"
       ></aws-bar-and-line-chart>
     </div>
 
@@ -51,6 +56,7 @@
         [y]="chartData?.dividend?.transactionValues ?? []"
         label="Dividend per Quarter"
         [showSymbols]="true"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 
@@ -59,6 +65,7 @@
         [x]="dates"
         [y]="chartData?.dividend?.aggregatedValues ?? []"
         label="Cumulative Dividend"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 
@@ -92,6 +99,7 @@
         [y]="chartData?.stock?.transactionValues ?? []"
         label="Buy / Sell Values"
         [showSymbols]="true"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 
@@ -100,6 +108,7 @@
         [x]="dates"
         [y]="chartData?.stock?.aggregatedValues ?? []"
         label="Cumulative Invested"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 
@@ -127,6 +136,7 @@
         [x]="dates"
         [y]="chartData?.commission?.aggregatedValues ?? []"
         label="Cumulative Commission"
+        [currencySymbol]="currencySymbol"
       ></aws-chart>
     </div>
 

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.html
@@ -52,7 +52,7 @@
 
     <div class="chart-card">
       <aws-chart
-        [x]="dates"
+        [x]="chartData?.allTimeDates ?? []"
         [y]="chartData?.dividend?.transactionValues ?? []"
         label="Dividend per Quarter"
         [showSymbols]="true"
@@ -62,7 +62,7 @@
 
     <div class="chart-card">
       <aws-chart
-        [x]="dates"
+        [x]="chartData?.allTimeDates ?? []"
         [y]="chartData?.dividend?.aggregatedValues ?? []"
         label="Cumulative Dividend"
         [currencySymbol]="currencySymbol"

--- a/libs/frontend/ui/src/lib/yahoo/yahoo.component.ts
+++ b/libs/frontend/ui/src/lib/yahoo/yahoo.component.ts
@@ -24,6 +24,7 @@ import { AsyncPipe, CommonModule } from '@angular/common';
 export class YahooComponent {
   @Input() dates: Date[] = [];
   @Input() chartData: ChartData | undefined;
+  @Input() currencySymbol = '€';
 
   yahoo$ = this.store.select(selectYahoo);
 

--- a/libs/shared/util/src/lib/core.ts
+++ b/libs/shared/util/src/lib/core.ts
@@ -1,5 +1,7 @@
 // Numeric-list and date primitives shared across the portfolio calculations.
 
+import { ChartGranularity, TimeRange } from './types';
+
 export function getDailyDates(start: Date, end: Date): Date[] {
   const dates: Date[] = [];
   const currentDate = new Date(start);
@@ -77,6 +79,67 @@ export function multiplyLists(list1: number[], list2: number[]): number[] {
     result.push(list1[i] * list2[i]);
   }
   return result;
+}
+
+/** True when d1 is strictly before d2 (ignoring time-of-day). */
+export function isBeforeDay(d1: Date, d2: Date): boolean {
+  if (d1.getFullYear() !== d2.getFullYear()) return d1.getFullYear() < d2.getFullYear();
+  if (d1.getMonth() !== d2.getMonth()) return d1.getMonth() < d2.getMonth();
+  return d1.getDate() < d2.getDate();
+}
+
+/** True when d1 is the same day as or before d2. */
+export function isOnOrBeforeDay(d1: Date, d2: Date): boolean {
+  return isSameDay(d1, d2) || isBeforeDay(d1, d2);
+}
+
+/** Returns the last day of each calendar month from start to end (inclusive). */
+export function getMonthlyDates(start: Date, end: Date): Date[] {
+  const dates: Date[] = [];
+  const cursor = new Date(start.getFullYear(), start.getMonth(), 1);
+  while (cursor <= end) {
+    const lastDay = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0);
+    dates.push(lastDay <= end ? lastDay : new Date(end));
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+  return dates;
+}
+
+/** Returns one date every 7 days from start to end (last point clamped to end). */
+export function getWeeklyDates(start: Date, end: Date): Date[] {
+  const dates: Date[] = [];
+  const cursor = new Date(start);
+  while (cursor <= end) {
+    dates.push(new Date(cursor));
+    cursor.setDate(cursor.getDate() + 7);
+  }
+  if (dates.length > 0 && !isSameDay(dates[dates.length - 1], end)) {
+    dates[dates.length - 1] = new Date(end);
+  }
+  return dates;
+}
+
+export function getGranularityForRange(range: TimeRange): ChartGranularity {
+  if (range === 'ALL') return 'monthly';
+  if (range === '5Y') return 'weekly';
+  return 'daily';
+}
+
+/**
+ * Returns the chart start date for the selected range.
+ * portfolioStart is used for 'ALL' to return the full history.
+ */
+export function getRangeStartDate(range: TimeRange, portfolioStart: Date): Date {
+  const today = new Date();
+  switch (range) {
+    case '1M': return new Date(today.getFullYear(), today.getMonth() - 1, today.getDate());
+    case '3M': return new Date(today.getFullYear(), today.getMonth() - 3, today.getDate());
+    case '6M': return new Date(today.getFullYear(), today.getMonth() - 6, today.getDate());
+    case 'YTD': return new Date(today.getFullYear(), 0, 1);
+    case '1Y': return new Date(today.getFullYear() - 1, today.getMonth(), today.getDate());
+    case '5Y': return new Date(today.getFullYear() - 5, today.getMonth(), today.getDate());
+    case 'ALL': return portfolioStart;
+  }
 }
 
 export function addPerQuarterByYearLists(

--- a/libs/shared/util/src/lib/dividends.ts
+++ b/libs/shared/util/src/lib/dividends.ts
@@ -4,8 +4,8 @@ import {
   Transaction,
   YearQuarter,
 } from './types';
-import { getQuarter } from './core';
-import { getTransactionAmountsAndValues } from './transactions';
+import { getQuarter, isOnOrBeforeDay } from './core';
+import { getTransactionAmountsAndValues, getTransactionAmountsAndValuesByPeriod } from './transactions';
 
 export function getDividendPerQuarterByYear(
   startDate: Date,
@@ -127,25 +127,63 @@ export function updateDividends(
   return result;
 }
 
+/**
+ * Returns the share count from the last period date that is on or before the
+ * given date. Works correctly for both daily dates (exact match) and for
+ * weekly/monthly period dates (last period before the dividend date).
+ */
 function getAmountOfSharesForDate(
   amountOfShares: number[],
   dates: Date[],
   date: Date
 ): number {
-  const targetYear = date.getFullYear();
-  const targetMonth = date.getMonth();
-  const targetDay = date.getDate();
-
+  let result = 0;
   for (let i = 0; i < dates.length; i++) {
-    const d = dates[i];
-    if (
-      d.getFullYear() === targetYear &&
-      d.getMonth() === targetMonth &&
-      d.getDate() === targetDay
-    ) {
-      return amountOfShares[i];
+    if (isOnOrBeforeDay(dates[i], date)) {
+      result = amountOfShares[i];
+    } else {
+      break;
     }
   }
+  return result;
+}
 
-  return 0;
+/**
+ * Period-based variant of updateDividends for weekly/monthly granularity.
+ * Uses getTransactionAmountsAndValuesByPeriod instead of the daily version.
+ */
+export function updateDividendsByPeriod(
+  amountOfShares: number[],
+  ticker: Ticker,
+  periodDates: Date[],
+  rangeStart: Date,
+  startDate: Date
+): DividendTransactionChartData {
+  const transactions: Transaction[] = ticker.dividends.map((div) => {
+    const amount = getAmountOfSharesForDate(amountOfShares, periodDates, div.date);
+    return {
+      ticker: ticker.name,
+      type: 'dividend',
+      date: div.date,
+      amount,
+      value: div.amountPerShare * amount,
+      currency: ticker.currency,
+    };
+  });
+
+  const dividendTransactionAmountsAndValues = getTransactionAmountsAndValuesByPeriod(
+    periodDates,
+    transactions,
+    rangeStart
+  );
+  const dividendPerQuarterByYear = getDividendPerQuarterByYear(startDate, transactions);
+  const dividendPerQuarter = getDividendPerQuarter(startDate, dividendPerQuarterByYear);
+  const dividendTtmPerQuarter = getDividendTtmPerQuarter(dividendPerQuarter);
+
+  return {
+    ...dividendTransactionAmountsAndValues,
+    perQuarterByYear: dividendPerQuarterByYear,
+    perQuarter: dividendPerQuarter,
+    ttmPerQuarter: dividendTtmPerQuarter,
+  };
 }

--- a/libs/shared/util/src/lib/portfolio.spec.ts
+++ b/libs/shared/util/src/lib/portfolio.spec.ts
@@ -288,6 +288,139 @@ describe('computePortfolioState', () => {
     ).toThrow('No FX rate data available for EUR=X');
   });
 
+  it('converts EUR stock to USD display using EURUSD=X', () => {
+    const eurDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'VUSA.AS',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 1,
+          value: 100,
+          currency: 'EUR',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(eurDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'VUSA.AS',
+      currency: 'EUR',
+      dates,
+      values: dates.map(() => 150),
+      dividends: [],
+    };
+
+    // EURUSD=X: 1 EUR = 1.1 USD
+    const fxTicker: Ticker = {
+      name: 'EURUSD=X',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 1.1),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(
+      eurDbo,
+      { 'VUSA.AS': stockTicker, 'EURUSD=X': fxTicker },
+      'USD'
+    );
+
+    // 1 share * €150 * 1.1 EURUSD = $165
+    expect(result.summary.portfolioValue).toBeCloseTo(165);
+    expect(result.stocks['VUSA.AS'].summary.currentSharePrice).toBeCloseTo(165);
+  });
+
+  it('converts GBP stock to USD display using GBPUSD=X', () => {
+    const gbpDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'BP.L',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 10,
+          value: 500,
+          currency: 'GBP',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(gbpDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'BP.L',
+      currency: 'GBP',
+      dates,
+      values: dates.map(() => 60),
+      dividends: [],
+    };
+
+    // GBPUSD=X: 1 GBP = 1.25 USD
+    const fxTicker: Ticker = {
+      name: 'GBPUSD=X',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 1.25),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(
+      gbpDbo,
+      { 'BP.L': stockTicker, 'GBPUSD=X': fxTicker },
+      'USD'
+    );
+
+    // 10 shares * £60 * 1.25 GBPUSD = $750
+    expect(result.summary.portfolioValue).toBeCloseTo(750);
+    expect(result.stocks['BP.L'].summary.currentSharePrice).toBeCloseTo(75);
+  });
+
+  it('skips FX for USD stock when display currency is USD', () => {
+    const usdDbo: TransactionsDbo = {
+      stock: [
+        {
+          ticker: 'AAPL',
+          type: 'stock',
+          date: '2023-01-10',
+          amount: 2,
+          value: 300,
+          currency: 'USD',
+        },
+      ],
+      dividend: [],
+      commission: [],
+    };
+
+    const dates = getDailyDates(
+      getStartDate(transactionsDboToStocks(usdDbo)),
+      new Date()
+    );
+
+    const stockTicker: Ticker = {
+      name: 'AAPL',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 200),
+      dividends: [],
+    };
+
+    const result = computePortfolioState(usdDbo, { AAPL: stockTicker }, 'USD');
+
+    // No FX applied: 2 shares * $200 = $400
+    expect(result.summary.portfolioValue).toBe(400);
+  });
+
   it('applies GBp (pence) fxMultiplier: divides by 100 before EUR conversion', () => {
     const gbpDbo: TransactionsDbo = {
       stock: [

--- a/libs/shared/util/src/lib/portfolio.spec.ts
+++ b/libs/shared/util/src/lib/portfolio.spec.ts
@@ -82,7 +82,8 @@ describe('computePortfolioState', () => {
 
     // Stage-1 totals are preserved through stage 2.
     expect(stock.summary.totalInvested).toBe(200);
-    expect(stock.chartData.portfolioValues).toHaveLength(dates.length);
+    // portfolioValues must always be aligned with the dates array returned.
+    expect(stock.chartData.portfolioValues).toHaveLength(result.dates.length);
   });
 
   it('returns an empty portfolio for no transactions', () => {

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -6,6 +6,7 @@ import {
   getDividendPerQuarter,
   getDividendPerQuarterByYear,
   getDividendTtmPerQuarter,
+  getFxTickerForConversion,
   getMostRecentValueFromList,
   getPortfolioValues,
   getReturn,
@@ -245,13 +246,10 @@ export function computePortfolioState(
 
     // Apply FX conversion when the stock is denominated in a currency other
     // than the display currency and a matching FX ticker is available.
-    const fxSymbol = stock.currency.yahooTicker;
-    const fxTicker =
-      displayCurrency &&
-      stock.currency.value !== displayCurrency &&
-      fxSymbol
-        ? tickers[fxSymbol]
-        : undefined;
+    const { yahooTicker: fxSymbol, fxMultiplier } = displayCurrency
+      ? getFxTickerForConversion(stock.currency.value, displayCurrency)
+      : {};
+    const fxTicker = fxSymbol ? tickers[fxSymbol] : undefined;
 
     let portfolioValues = portfolioValuesNative;
     let investedForProfit = stock.chartData.stock.aggregatedValues;
@@ -261,7 +259,7 @@ export function computePortfolioState(
     if (fxTicker) {
       const fxRates = getFxRates(dates, fxTicker);
       // fxMultiplier handles sub-unit currencies: GBp (pence) = 0.01 × GBP.
-      const m = stock.currency.fxMultiplier ?? 1;
+      const m = fxMultiplier ?? 1;
       const scaledRates = m === 1 ? fxRates : fxRates.map(r => r * m);
       portfolioValues = multiplyLists(portfolioValuesNative, scaledRates);
       investedForProfit = multiplyLists(stock.chartData.stock.aggregatedValues, scaledRates);

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -225,6 +225,8 @@ export function computePortfolioState(
   let aggregatedPortfolioValues: number[] = [];
   let aggregatedProfit: number[] = [];
   let chartTotalDividendSummary = 0;
+  let chartTotalInvestedSummary = 0;
+  let chartTotalCommissionSummary = 0;
 
   const chartedStocks: { [ticker: string]: Stock } = {};
   for (const key of Object.keys(computedStocks)) {
@@ -254,7 +256,19 @@ export function computePortfolioState(
     let portfolioValues = portfolioValuesNative;
     let investedForProfit = stock.chartData.stock.aggregatedValues;
     let commissionForProfit = stock.chartData.commission.aggregatedValues;
+    let stockTransactionValues = stock.chartData.stock.transactionValues;
+    let commissionTransactionValues = stock.chartData.commission.transactionValues;
     let currentSharePrice = getMostRecentValueFromList(ticker.values).value;
+
+    // Compute updated dividends (uses price data for per-share amounts).
+    const updatedDividend = updateDividends(
+      stock.chartData.dividend,
+      stock.chartData.stock.aggregatedAmounts,
+      ticker,
+      dates,
+      startDate
+    );
+    let convertedDividend = updatedDividend;
 
     if (fxTicker) {
       const fxRates = getFxRates(dates, fxTicker);
@@ -264,8 +278,28 @@ export function computePortfolioState(
       portfolioValues = multiplyLists(portfolioValuesNative, scaledRates);
       investedForProfit = multiplyLists(stock.chartData.stock.aggregatedValues, scaledRates);
       commissionForProfit = multiplyLists(stock.chartData.commission.aggregatedValues, scaledRates);
+      stockTransactionValues = multiplyLists(stock.chartData.stock.transactionValues, scaledRates);
+      commissionTransactionValues = multiplyLists(stock.chartData.commission.transactionValues, scaledRates);
       const lastScaledRate = getMostRecentValueFromList(scaledRates).value;
       currentSharePrice = currentSharePrice * lastScaledRate;
+
+      convertedDividend = {
+        ...updatedDividend,
+        transactionValues: multiplyLists(updatedDividend.transactionValues, scaledRates),
+        aggregatedValues: multiplyLists(updatedDividend.aggregatedValues, scaledRates),
+        perQuarter: {
+          ...updatedDividend.perQuarter,
+          dividends: updatedDividend.perQuarter.dividends.map(v => v * lastScaledRate),
+        },
+        ttmPerQuarter: {
+          ...updatedDividend.ttmPerQuarter,
+          dividends: updatedDividend.ttmPerQuarter.dividends.map(v => v * lastScaledRate),
+        },
+        perQuarterByYear: updatedDividend.perQuarterByYear.map(pqby => ({
+          year: pqby.year,
+          data: pqby.data.map(v => v * lastScaledRate),
+        })),
+      };
     }
 
     aggregatedPortfolioValues =
@@ -291,18 +325,15 @@ export function computePortfolioState(
 
     const yieldPerYear = getYieldPerYear(dates, portfolioValues, profit);
 
-    const updatedDividend = updateDividends(
-      stock.chartData.dividend,
-      stock.chartData.stock.aggregatedAmounts,
-      ticker,
-      dates,
-      startDate
-    );
-
     const totalDividend = getMostRecentValueFromList(
-      updatedDividend.aggregatedValues
+      convertedDividend.aggregatedValues
     ).value;
     chartTotalDividendSummary += totalDividend;
+
+    const stockTotalInvested = getMostRecentValueFromList(investedForProfit).value;
+    const stockTotalCommission = getMostRecentValueFromList(commissionForProfit).value;
+    chartTotalInvestedSummary += stockTotalInvested;
+    chartTotalCommissionSummary += stockTotalCommission;
 
     chartedStocks[key] = {
       ...stock,
@@ -310,6 +341,12 @@ export function computePortfolioState(
         ...stock.summary,
         portfolioValue,
         currentSharePrice,
+        totalInvested: stockTotalInvested,
+        totalCommission: stockTotalCommission,
+        averageSharePrice:
+          stock.summary.amountOfShares !== 0
+            ? stockTotalInvested / stock.summary.amountOfShares
+            : 0,
         dailyReturn,
         weeklyReturn,
         monthlyReturn,
@@ -321,7 +358,17 @@ export function computePortfolioState(
         portfolioValues,
         profit,
         yieldPerYear,
-        dividend: updatedDividend,
+        stock: {
+          ...stock.chartData.stock,
+          transactionValues: stockTransactionValues,
+          aggregatedValues: investedForProfit,
+        },
+        commission: {
+          ...stock.chartData.commission,
+          transactionValues: commissionTransactionValues,
+          aggregatedValues: commissionForProfit,
+        },
+        dividend: convertedDividend,
       },
     };
   }
@@ -329,6 +376,9 @@ export function computePortfolioState(
   summary = {
     ...summary,
     portfolioValue: portfolioValuesSummary,
+    totalInvested: chartTotalInvestedSummary,
+    totalCommission: chartTotalCommissionSummary,
+    totalDividend: chartTotalDividendSummary,
     dailyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 1),
     weeklyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 7),
     monthlyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 30),
@@ -337,7 +387,6 @@ export function computePortfolioState(
       aggregatedProfit,
       aggregatedPortfolioValues.length
     ),
-    totalDividend: chartTotalDividendSummary,
   };
 
   return { transactions, stocks: chartedStocks, dates, summary, currencies };

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -1,4 +1,4 @@
-import { PortfolioDbo, Stock, Summary, Ticker, Transactions, TransactionsDbo } from './types';
+import { PortfolioDbo, Stock, Summary, Ticker, TimeRange, Transactions, TransactionsDbo } from './types';
 import {
   addLists,
   getCurrencies,
@@ -7,25 +7,37 @@ import {
   getDividendPerQuarterByYear,
   getDividendTtmPerQuarter,
   getFxTickerForConversion,
+  getGranularityForRange,
+  getMonthlyDates,
   getMostRecentValueFromList,
   getPortfolioValues,
+  getPortfolioValuesByPeriod,
+  getRangeStartDate,
   getReturn,
   getStartDate,
   getTransactionAmountsAndValues,
+  getTransactionAmountsAndValuesByPeriod,
+  getWeeklyDates,
+  computePreRangeSnapshot,
   getYieldPerYear,
+  isBeforeDay,
   isSameDay,
   multiplyLists,
   subtractLists,
   transactionsDboToStocks,
   transactionsDboToTransactions,
-  updateDividends,
+  updateDividendsByPeriod,
 } from './util';
 
 /**
- * Returns an array of FX rates aligned to the given portfolio dates using the
+ * Returns an array of FX rates aligned to the given dates using the
  * nearest available rate (forward fill, then backward fill for dates before the
  * first data point). Treats zero values as missing, matching how Yahoo Finance
  * omits rates on weekends and holidays.
+ *
+ * Works for both daily and period (weekly/monthly) dates: the forward-advance
+ * loop always carries the last known rate up to each date, so period dates that
+ * fall on weekends or holidays still get the most recent prior rate.
  *
  * Throws when the FX ticker has no valid values at all so callers can surface
  * the error to the user rather than silently producing wrong numbers.
@@ -40,7 +52,7 @@ function getFxRates(dates: Date[], fxTicker: Ticker): number[] {
     while (
       fxIdx < fxTicker.dates.length &&
       !isSameDay(fxTicker.dates[fxIdx], dates[i]) &&
-      fxTicker.dates[fxIdx] < dates[i]
+      isBeforeDay(fxTicker.dates[fxIdx], dates[i])
     ) {
       const val = fxTicker.values[fxIdx];
       if (!isNaN(val) && val > 0) lastKnownRate = val;
@@ -106,18 +118,20 @@ export function createInitialSummary(): Summary {
  * Derives the full portfolio view-model from the raw inputs: the stored
  * transactions (DTO) and the fetched Yahoo price tickers.
  *
- * This is a pure, memoizable port of what used to live in the NgRx reducer.
- * It runs in two stages, mirroring the old getDataSuccess and setChartData
- * handlers:
- *   1. transaction-derived data (amounts, values, dividends, invested totals),
- *      available as soon as the transactions load.
- *   2. price-derived data (portfolio value, profit, returns, yield), added once
- *      the Yahoo tickers are available.
+ * The optional `range` parameter controls which time window is visualised:
+ *   - '1M', '3M', '6M', 'YTD', '1Y' → daily data for that window
+ *   - '5Y'                            → weekly data (one point per week)
+ *   - 'ALL'                           → monthly data (one point per month)
+ *
+ * Summary chips (dailyReturn, weeklyReturn, monthlyReturn) are always computed
+ * from a separate 30-day daily window regardless of chart granularity, so they
+ * stay accurate even when the chart is at weekly or monthly resolution.
  */
 export function computePortfolioState(
   transactionsDbo: TransactionsDbo,
   tickers: { [ticker: string]: Ticker },
-  displayCurrency?: string
+  displayCurrency?: string,
+  range: TimeRange = 'ALL'
 ): PortfolioState {
   const baseStocks = transactionsDboToStocks(transactionsDbo);
   const transactions = transactionsDboToTransactions(transactionsDbo);
@@ -136,7 +150,29 @@ export function computePortfolioState(
 
   // --- Stage 1: transaction-derived data ---
   const startDate = getStartDate(baseStocks);
-  const dates = getDailyDates(startDate, new Date());
+  const today = new Date();
+
+  const granularity = getGranularityForRange(range);
+  const rangeStart = getRangeStartDate(range, startDate);
+  // Clamp rangeStart to portfolio start — can't display before first transaction.
+  const effectiveRangeStart = isBeforeDay(startDate, rangeStart) ? rangeStart : startDate;
+
+  let dates: Date[];
+  if (granularity === 'monthly') {
+    dates = getMonthlyDates(effectiveRangeStart, today);
+  } else if (granularity === 'weekly') {
+    dates = getWeeklyDates(effectiveRangeStart, today);
+  } else {
+    dates = getDailyDates(effectiveRangeStart, today);
+  }
+
+  // 30-day daily window used for return calculations (always accurate).
+  const returnWindowStart = new Date(today);
+  returnWindowStart.setDate(returnWindowStart.getDate() - 30);
+  const returnDates = getDailyDates(
+    isBeforeDay(startDate, returnWindowStart) ? returnWindowStart : startDate,
+    today
+  );
 
   let totalInvestedSummary = 0;
   let totalDividendSummary = 0;
@@ -147,39 +183,38 @@ export function computePortfolioState(
     const stock = baseStocks[key];
     const t = stock.transactions;
 
-    const stockAmountsAndValues = getTransactionAmountsAndValues(dates, t.stock);
-    const dividendAmountsAndValues = getTransactionAmountsAndValues(
-      dates,
-      t.dividend
-    );
-    const dividendPerQuarterByYear = getDividendPerQuarterByYear(
-      startDate,
-      t.dividend
-    );
-    const dividendPerQuarter = getDividendPerQuarter(
-      startDate,
-      dividendPerQuarterByYear
-    );
-    const dividendTtmPerQuarter = getDividendTtmPerQuarter(dividendPerQuarter);
-    const commissionAmountsAndValues = getTransactionAmountsAndValues(
-      dates,
-      t.commission
-    );
+    // For daily ranges, pre-compute historical holdings before the range window
+    // so that aggregatedAmounts/aggregatedValues start from the correct baseline.
+    const stockSnapshot = computePreRangeSnapshot(t.stock, effectiveRangeStart);
+    const dividendSnapshot = computePreRangeSnapshot(t.dividend, effectiveRangeStart);
+    const commissionSnapshot = computePreRangeSnapshot(t.commission, effectiveRangeStart);
 
-    const totalInvested = getMostRecentValueFromList(
-      stockAmountsAndValues.aggregatedValues
-    ).value;
+    // Chart-resolution data for this stock.
+    const stockAmountsAndValues = granularity === 'daily'
+      ? getTransactionAmountsAndValues(dates, t.stock, stockSnapshot.amount, stockSnapshot.value)
+      : getTransactionAmountsAndValuesByPeriod(dates, t.stock, effectiveRangeStart);
+
+    const dividendAmountsAndValues = granularity === 'daily'
+      ? getTransactionAmountsAndValues(dates, t.dividend, dividendSnapshot.amount, dividendSnapshot.value)
+      : getTransactionAmountsAndValuesByPeriod(dates, t.dividend, effectiveRangeStart);
+
+    const commissionAmountsAndValues = granularity === 'daily'
+      ? getTransactionAmountsAndValues(dates, t.commission, commissionSnapshot.amount, commissionSnapshot.value)
+      : getTransactionAmountsAndValuesByPeriod(dates, t.commission, effectiveRangeStart);
+
+    const dividendPerQuarterByYear = getDividendPerQuarterByYear(startDate, t.dividend);
+    const dividendPerQuarter = getDividendPerQuarter(startDate, dividendPerQuarterByYear);
+    const dividendTtmPerQuarter = getDividendTtmPerQuarter(dividendPerQuarter);
+
+    // Point-in-time totals: sum all historical transactions (O(transactions)).
+    const totalInvested = t.stock.reduce((s, tx) => s + tx.value, 0);
     totalInvestedSummary += totalInvested;
     const amountOfShares = getMostRecentValueFromList(
       stockAmountsAndValues.aggregatedAmounts
     ).value;
-    const totalDividend = getMostRecentValueFromList(
-      dividendAmountsAndValues.aggregatedValues
-    ).value;
+    const totalDividend = t.dividend.reduce((s, tx) => s + tx.value, 0);
     totalDividendSummary += totalDividend;
-    const totalCommission = getMostRecentValueFromList(
-      commissionAmountsAndValues.aggregatedValues
-    ).value;
+    const totalCommission = t.commission.reduce((s, tx) => s + tx.value, 0);
     totalCommissionSummary += totalCommission;
 
     computedStocks[key] = {
@@ -199,8 +234,7 @@ export function computePortfolioState(
         ...stock.summary,
         totalInvested,
         amountOfShares,
-        averageSharePrice:
-          amountOfShares !== 0 ? totalInvested / amountOfShares : 0,
+        averageSharePrice: amountOfShares !== 0 ? totalInvested / amountOfShares : 0,
         totalDividend,
         totalCommission,
       },
@@ -228,30 +262,36 @@ export function computePortfolioState(
   let chartTotalInvestedSummary = 0;
   let chartTotalCommissionSummary = 0;
 
+  // Aggregated portfolio values over the 30-day return window (always daily).
+  let returnWindowPortfolioValues: number[] = [];
+  let returnWindowProfit: number[] = [];
+
+  // Full-history monthly dates — used for yield and dividend bar charts so they
+  // always display the complete portfolio history regardless of the selected range.
+  const allTimeDates = getMonthlyDates(startDate, today);
+
   const chartedStocks: { [ticker: string]: Stock } = {};
   for (const key of Object.keys(computedStocks)) {
     const stock = computedStocks[key];
     const ticker = tickers[key];
+    const t = stock.transactions; // shorthand for this stock's sorted transactions
 
-    // Prices for this stock haven't arrived (yet) — keep the stage-1 view so a
-    // transient ticker/transaction mismatch can't crash the derivation.
+    // Prices for this stock haven't arrived yet — keep the stage-1 view.
     if (!ticker) {
       chartedStocks[key] = stock;
       continue;
     }
 
-    const portfolioValuesNative = getPortfolioValues(
-      dates,
-      stock.chartData.stock.aggregatedAmounts,
-      ticker
-    );
+    // --- Chart arrays at selected granularity (for performance charts) ---
+    const portfolioValuesNative = granularity === 'daily'
+      ? getPortfolioValues(dates, stock.chartData.stock.aggregatedAmounts, ticker)
+      : getPortfolioValuesByPeriod(dates, stock.chartData.stock.aggregatedAmounts, ticker);
 
-    // Apply FX conversion when the stock is denominated in a currency other
-    // than the display currency and a matching FX ticker is available.
     const { yahooTicker: fxSymbol, fxMultiplier } = displayCurrency
       ? getFxTickerForConversion(stock.currency.value, displayCurrency)
       : {};
     const fxTicker = fxSymbol ? tickers[fxSymbol] : undefined;
+    const m = fxMultiplier ?? 1;
 
     let portfolioValues = portfolioValuesNative;
     let investedForProfit = stock.chartData.stock.aggregatedValues;
@@ -260,20 +300,30 @@ export function computePortfolioState(
     let commissionTransactionValues = stock.chartData.commission.transactionValues;
     let currentSharePrice = getMostRecentValueFromList(ticker.values).value;
 
-    // Compute updated dividends (uses price data for per-share amounts).
-    const updatedDividend = updateDividends(
-      stock.chartData.dividend,
-      stock.chartData.stock.aggregatedAmounts,
-      ticker,
-      dates,
-      startDate
+    // --- All-time monthly data for dividend bar charts and yield (range-independent) ---
+    // These use full history so the dividend/yield charts always show complete data.
+    const allTimeStockData = getTransactionAmountsAndValuesByPeriod(allTimeDates, t.stock, startDate);
+    const allTimePortfolioValuesNative = getPortfolioValuesByPeriod(allTimeDates, allTimeStockData.aggregatedAmounts, ticker);
+    const allTimeCommissionData = getTransactionAmountsAndValuesByPeriod(allTimeDates, t.commission, startDate);
+    const allTimeDividendBase = updateDividendsByPeriod(
+      allTimeStockData.aggregatedAmounts, ticker, allTimeDates, startDate, startDate
     );
-    let convertedDividend = updatedDividend;
+
+    let allTimePortfolioValues = allTimePortfolioValuesNative;
+    let allTimeInvested = allTimeStockData.aggregatedValues;
+    let allTimeCommissionAgg = allTimeCommissionData.aggregatedValues;
+    let allTimeDividendPerQuarterByYear = allTimeDividendBase.perQuarterByYear;
+    let allTimeDividendPerQuarter = allTimeDividendBase.perQuarter;
+    let allTimeDividendTtmPerQuarter = allTimeDividendBase.ttmPerQuarter;
+    // All dividend arrays use full-history monthly data so line charts are range-independent.
+    let dividendTransactionValues = allTimeDividendBase.transactionValues;
+    const dividendTransactionAmounts = allTimeDividendBase.transactionAmounts;
+    let dividendAggregatedValues = allTimeDividendBase.aggregatedValues;
+    const dividendAggregatedAmounts = allTimeDividendBase.aggregatedAmounts;
+    let allTimeTotalDividend = getMostRecentValueFromList(allTimeDividendBase.aggregatedValues).value;
 
     if (fxTicker) {
       const fxRates = getFxRates(dates, fxTicker);
-      // fxMultiplier handles sub-unit currencies: GBp (pence) = 0.01 × GBP.
-      const m = fxMultiplier ?? 1;
       const scaledRates = m === 1 ? fxRates : fxRates.map(r => r * m);
       portfolioValues = multiplyLists(portfolioValuesNative, scaledRates);
       investedForProfit = multiplyLists(stock.chartData.stock.aggregatedValues, scaledRates);
@@ -283,29 +333,45 @@ export function computePortfolioState(
       const lastScaledRate = getMostRecentValueFromList(scaledRates).value;
       currentSharePrice = currentSharePrice * lastScaledRate;
 
-      convertedDividend = {
-        ...updatedDividend,
-        transactionValues: multiplyLists(updatedDividend.transactionValues, scaledRates),
-        aggregatedValues: multiplyLists(updatedDividend.aggregatedValues, scaledRates),
-        perQuarter: {
-          ...updatedDividend.perQuarter,
-          dividends: updatedDividend.perQuarter.dividends.map(v => v * lastScaledRate),
-        },
-        ttmPerQuarter: {
-          ...updatedDividend.ttmPerQuarter,
-          dividends: updatedDividend.ttmPerQuarter.dividends.map(v => v * lastScaledRate),
-        },
-        perQuarterByYear: updatedDividend.perQuarterByYear.map(pqby => ({
-          year: pqby.year,
-          data: pqby.data.map(v => v * lastScaledRate),
-        })),
+      // FX-convert all-time monthly data.
+      const allTimeFxRates = getFxRates(allTimeDates, fxTicker);
+      const allTimeScaledRates = m === 1 ? allTimeFxRates : allTimeFxRates.map(r => r * m);
+      allTimePortfolioValues = multiplyLists(allTimePortfolioValuesNative, allTimeScaledRates);
+      allTimeInvested = multiplyLists(allTimeStockData.aggregatedValues, allTimeScaledRates);
+      allTimeCommissionAgg = multiplyLists(allTimeCommissionData.aggregatedValues, allTimeScaledRates);
+      dividendTransactionValues = multiplyLists(allTimeDividendBase.transactionValues, allTimeScaledRates);
+      dividendAggregatedValues = multiplyLists(allTimeDividendBase.aggregatedValues, allTimeScaledRates);
+      allTimeTotalDividend = getMostRecentValueFromList(dividendAggregatedValues).value;
+      const lastAllTimeRate = getMostRecentValueFromList(allTimeScaledRates).value;
+      allTimeDividendPerQuarterByYear = allTimeDividendBase.perQuarterByYear.map(pqby => ({
+        year: pqby.year,
+        data: pqby.data.map(v => v * lastAllTimeRate),
+      }));
+      allTimeDividendPerQuarter = {
+        ...allTimeDividendBase.perQuarter,
+        dividends: allTimeDividendBase.perQuarter.dividends.map(v => v * lastAllTimeRate),
+      };
+      allTimeDividendTtmPerQuarter = {
+        ...allTimeDividendBase.ttmPerQuarter,
+        dividends: allTimeDividendBase.ttmPerQuarter.dividends.map(v => v * lastAllTimeRate),
       };
     }
+
+    const convertedDividend = {
+      transactionValues: dividendTransactionValues,
+      transactionAmounts: dividendTransactionAmounts,
+      aggregatedValues: dividendAggregatedValues,
+      aggregatedAmounts: dividendAggregatedAmounts,
+      perQuarterByYear: allTimeDividendPerQuarterByYear,
+      perQuarter: allTimeDividendPerQuarter,
+      ttmPerQuarter: allTimeDividendTtmPerQuarter,
+    };
 
     aggregatedPortfolioValues =
       aggregatedPortfolioValues.length > 0
         ? addLists(aggregatedPortfolioValues, portfolioValues)
         : portfolioValues;
+
     const portfolioValue = getMostRecentValueFromList(portfolioValues).value;
     portfolioValuesSummary += portfolioValue;
 
@@ -318,22 +384,71 @@ export function computePortfolioState(
         ? addLists(aggregatedProfit, profit)
         : profit;
 
-    const dailyReturn = getReturn(portfolioValues, profit, 1);
-    const weeklyReturn = getReturn(portfolioValues, profit, 7);
-    const monthlyReturn = getReturn(portfolioValues, profit, 30);
-    const totalReturn = getReturn(portfolioValues, profit, portfolioValues.length);
+    // All-time profit for yield (same monthly granularity as allTimePortfolioValues).
+    const allTimeProfit = subtractLists(
+      subtractLists(allTimePortfolioValues, allTimeInvested),
+      allTimeCommissionAgg
+    );
+    const yieldPerYear = getYieldPerYear(allTimeDates, allTimePortfolioValues, allTimeProfit);
 
-    const yieldPerYear = getYieldPerYear(dates, portfolioValues, profit);
+    // --- 30-day daily return window (always accurate regardless of chart granularity) ---
+    const preReturnStockSnapshot = computePreRangeSnapshot(t.stock, returnDates[0] ?? today);
+    const preReturnCommissionSnapshot = computePreRangeSnapshot(t.commission, returnDates[0] ?? today);
 
-    const totalDividend = getMostRecentValueFromList(
-      convertedDividend.aggregatedValues
-    ).value;
-    chartTotalDividendSummary += totalDividend;
+    const returnWindowStockAmounts = getTransactionAmountsAndValues(
+      returnDates, t.stock, preReturnStockSnapshot.amount, preReturnStockSnapshot.value
+    );
+    const returnWindowCommissionAmounts = getTransactionAmountsAndValues(
+      returnDates, t.commission, 0, preReturnCommissionSnapshot.value
+    );
 
+    const returnPortfolioValuesNative = getPortfolioValues(
+      returnDates, returnWindowStockAmounts.aggregatedAmounts, ticker
+    );
+
+    let returnPortfolioValues = returnPortfolioValuesNative;
+    let returnInvestedForProfit = returnWindowStockAmounts.aggregatedValues;
+    let returnCommissionForProfit = returnWindowCommissionAmounts.aggregatedValues;
+
+    if (fxTicker) {
+      const returnFxRates = getFxRates(returnDates, fxTicker);
+      const returnScaledRates = m === 1 ? returnFxRates : returnFxRates.map(r => r * m);
+      returnPortfolioValues = multiplyLists(returnPortfolioValuesNative, returnScaledRates);
+      returnInvestedForProfit = multiplyLists(returnWindowStockAmounts.aggregatedValues, returnScaledRates);
+      returnCommissionForProfit = multiplyLists(returnWindowCommissionAmounts.aggregatedValues, returnScaledRates);
+    }
+
+    const returnProfit = subtractLists(
+      subtractLists(returnPortfolioValues, returnInvestedForProfit),
+      returnCommissionForProfit
+    );
+
+    returnWindowPortfolioValues =
+      returnWindowPortfolioValues.length > 0
+        ? addLists(returnWindowPortfolioValues, returnPortfolioValues)
+        : returnPortfolioValues;
+    returnWindowProfit =
+      returnWindowProfit.length > 0
+        ? addLists(returnWindowProfit, returnProfit)
+        : returnProfit;
+
+    // --- Per-stock return figures from the 30-day window ---
+    const dailyReturn = getReturn(returnPortfolioValues, returnProfit, 1);
+    const weeklyReturn = getReturn(returnPortfolioValues, returnProfit, 7);
+    const monthlyReturn = getReturn(returnPortfolioValues, returnProfit, 30);
+
+    // Total return: point-in-time (currentValue - totalInvested - totalCommission).
     const stockTotalInvested = getMostRecentValueFromList(investedForProfit).value;
     const stockTotalCommission = getMostRecentValueFromList(commissionForProfit).value;
+    const totalReturnAbsolute = portfolioValue - stockTotalInvested - stockTotalCommission;
+    const totalReturn = {
+      absolute: totalReturnAbsolute,
+      percentage: portfolioValue !== 0 ? (totalReturnAbsolute / portfolioValue) * 100 : 0,
+    };
+
     chartTotalInvestedSummary += stockTotalInvested;
     chartTotalCommissionSummary += stockTotalCommission;
+    chartTotalDividendSummary += allTimeTotalDividend;
 
     chartedStocks[key] = {
       ...stock,
@@ -351,13 +466,16 @@ export function computePortfolioState(
         weeklyReturn,
         monthlyReturn,
         totalReturn,
-        totalDividend,
+        totalDividend: allTimeTotalDividend,
       },
       chartData: {
         ...stock.chartData,
         portfolioValues,
         profit,
         yieldPerYear,
+        allTimeDates,
+        allTimePortfolioValues,
+        allTimeProfit,
         stock: {
           ...stock.chartData.stock,
           transactionValues: stockTransactionValues,
@@ -373,20 +491,27 @@ export function computePortfolioState(
     };
   }
 
+  // Aggregate summary returns from the 30-day daily window.
+  const dailyReturn = getReturn(returnWindowPortfolioValues, returnWindowProfit, 1);
+  const weeklyReturn = getReturn(returnWindowPortfolioValues, returnWindowProfit, 7);
+  const monthlyReturn = getReturn(returnWindowPortfolioValues, returnWindowProfit, 30);
+
+  const totalReturnAbsolute = portfolioValuesSummary - chartTotalInvestedSummary - chartTotalCommissionSummary;
+  const totalReturn = {
+    absolute: totalReturnAbsolute,
+    percentage: portfolioValuesSummary !== 0 ? (totalReturnAbsolute / portfolioValuesSummary) * 100 : 0,
+  };
+
   summary = {
     ...summary,
     portfolioValue: portfolioValuesSummary,
     totalInvested: chartTotalInvestedSummary,
     totalCommission: chartTotalCommissionSummary,
     totalDividend: chartTotalDividendSummary,
-    dailyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 1),
-    weeklyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 7),
-    monthlyReturn: getReturn(aggregatedPortfolioValues, aggregatedProfit, 30),
-    totalReturn: getReturn(
-      aggregatedPortfolioValues,
-      aggregatedProfit,
-      aggregatedPortfolioValues.length
-    ),
+    dailyReturn,
+    weeklyReturn,
+    monthlyReturn,
+    totalReturn,
   };
 
   return { transactions, stocks: chartedStocks, dates, summary, currencies };
@@ -399,12 +524,13 @@ export function computePortfolioState(
 export function computeAllPortfolios(
   portfoliosDbo: PortfolioDbo[],
   tickers: { [ticker: string]: Ticker },
-  baseCurrency?: string
+  baseCurrency?: string,
+  range: TimeRange = 'ALL'
 ): { [id: string]: PortfolioComputedState } {
   const result: { [id: string]: PortfolioComputedState } = {};
   for (const portfolio of portfoliosDbo) {
     result[portfolio.id] = {
-      ...computePortfolioState(portfolio.transactions, tickers, baseCurrency),
+      ...computePortfolioState(portfolio.transactions, tickers, baseCurrency, range),
       portfolioId: portfolio.id,
       portfolioName: portfolio.name,
     };

--- a/libs/shared/util/src/lib/returns.ts
+++ b/libs/shared/util/src/lib/returns.ts
@@ -2,6 +2,8 @@ import { Return, Ticker } from './types';
 import {
   getMostRecentValueAtIndex,
   getMostRecentValueFromList,
+  isBeforeDay,
+  isOnOrBeforeDay,
   isSameDay,
 } from './core';
 
@@ -40,31 +42,57 @@ export function getPortfolioValues(
 ): number[] {
   const values: number[] = [];
   let index = 0;
-  let currentDate: Date = ticker.dates[index];
-  let currentValue: number = ticker.values[index];
+  let lastKnownPrice = 0;
 
   for (let i = 0; i < dates.length; i++) {
-    if (!isSameDay(dates[i], currentDate)) {
-      if (values.length === 0 || values[values.length - 1] === 0) {
-        values.push(0);
-      } else {
-        values.push(NaN);
-      }
-    } else {
-      let newValue = 0;
-      while (isSameDay(dates[i], currentDate)) {
-        newValue += currentValue * aggregatedAmounts[i];
-        index += 1;
-        if (index >= ticker.values.length) {
-          break;
-        }
-        currentDate = ticker.dates[index];
-        currentValue = ticker.values[index];
-      }
+    // Advance past all ticker dates strictly before dates[i], tracking last known price.
+    while (index < ticker.dates.length && isBeforeDay(ticker.dates[index], dates[i])) {
+      if (ticker.values[index] > 0) lastKnownPrice = ticker.values[index];
+      index++;
+    }
 
-      values.push(newValue);
+    if (index < ticker.dates.length && isSameDay(ticker.dates[index], dates[i])) {
+      // Exact date match — use this price.
+      let price = ticker.values[index];
+      index++;
+      // Consume any duplicate entries for the same date (edge case).
+      while (index < ticker.dates.length && isSameDay(ticker.dates[index], dates[i])) {
+        price = ticker.values[index];
+        index++;
+      }
+      if (price > 0) lastKnownPrice = price;
+      values.push(price * aggregatedAmounts[i]);
+    } else {
+      // No ticker entry for this date (weekend / holiday / before ticker starts).
+      values.push(lastKnownPrice === 0 ? 0 : NaN);
     }
   }
+  return values;
+}
+
+/**
+ * Period-based portfolio value computation for weekly/monthly granularity.
+ * For each period date, finds the last available ticker price on or before
+ * that date and multiplies by the aggregated share count.
+ */
+export function getPortfolioValuesByPeriod(
+  periodDates: Date[],
+  aggregatedAmounts: number[],
+  ticker: Ticker
+): number[] {
+  const values: number[] = [];
+  let tickerIdx = 0;
+  let lastKnownPrice = 0;
+
+  for (let i = 0; i < periodDates.length; i++) {
+    const periodDate = periodDates[i];
+    while (tickerIdx < ticker.dates.length && isOnOrBeforeDay(ticker.dates[tickerIdx], periodDate)) {
+      if (ticker.values[tickerIdx] > 0) lastKnownPrice = ticker.values[tickerIdx];
+      tickerIdx++;
+    }
+    values.push(lastKnownPrice * aggregatedAmounts[i]);
+  }
+
   return values;
 }
 

--- a/libs/shared/util/src/lib/transactions.ts
+++ b/libs/shared/util/src/lib/transactions.ts
@@ -113,22 +113,44 @@ export function transactionsDboToTransactions(
   };
 }
 
-function getCurrency(currency: string): {
-  value: string;
-  yahooTicker?: string;
-  fxMultiplier?: number;
-} {
-  switch (currency) {
-    case 'USD':
-      return { value: 'USD', yahooTicker: 'EUR=X' };
-    case 'GBP':
-      return { value: 'GBP', yahooTicker: 'GBPEUR=X' };
-    case 'GBp':
-      // Yahoo prices UK stocks in pence; divide by 100 after applying the GBP→EUR rate.
-      return { value: 'GBp', yahooTicker: 'GBPEUR=X', fxMultiplier: 0.01 };
+function getCurrency(currency: string): { value: string } {
+  return { value: currency };
+}
+
+/**
+ * Returns the Yahoo Finance FX ticker and optional sub-unit multiplier needed
+ * to convert a stock's native currency into the chosen display currency.
+ * Returns an empty object when no conversion is required (same currency) or
+ * the pair is not supported.
+ *
+ * EUR=X  : USD → EUR rate  (multiply USD value to get EUR)
+ * GBPEUR=X: GBP → EUR rate
+ * EURUSD=X: EUR → USD rate
+ * GBPUSD=X: GBP → USD rate
+ * GBp is UK pence — use the GBP ticker then scale by 0.01.
+ */
+export function getFxTickerForConversion(
+  stockCurrency: string,
+  displayCurrency: string
+): { yahooTicker?: string; fxMultiplier?: number } {
+  if (stockCurrency === displayCurrency) return {};
+  switch (displayCurrency) {
     case 'EUR':
+      switch (stockCurrency) {
+        case 'USD': return { yahooTicker: 'EUR=X' };
+        case 'GBP': return { yahooTicker: 'GBPEUR=X' };
+        case 'GBp': return { yahooTicker: 'GBPEUR=X', fxMultiplier: 0.01 };
+        default:    return {};
+      }
+    case 'USD':
+      switch (stockCurrency) {
+        case 'EUR': return { yahooTicker: 'EURUSD=X' };
+        case 'GBP': return { yahooTicker: 'GBPUSD=X' };
+        case 'GBp': return { yahooTicker: 'GBPUSD=X', fxMultiplier: 0.01 };
+        default:    return {};
+      }
     default:
-      return { value: currency };
+      return {};
   }
 }
 
@@ -294,14 +316,14 @@ export function getStartDate(stocks: { [ticker: string]: Stock }): Date {
 }
 
 export function getCurrencies(stocks: { [ticker: string]: Stock }): string[] {
-  const currencies: string[] = [];
-  for (const key of Object.keys(stocks)) {
-    const currency = stocks[key].currency.yahooTicker;
-    if (currency && !currencies.includes(currency)) {
-      currencies.push(currency);
+  const set = new Set<string>();
+  for (const stock of Object.values(stocks)) {
+    for (const dc of ['EUR', 'USD']) {
+      const { yahooTicker } = getFxTickerForConversion(stock.currency.value, dc);
+      if (yahooTicker) set.add(yahooTicker);
     }
   }
-  return currencies;
+  return [...set];
 }
 
 export function transactionToTransactionDbo(tx: Transaction): TransactionDbo {

--- a/libs/shared/util/src/lib/transactions.ts
+++ b/libs/shared/util/src/lib/transactions.ts
@@ -7,7 +7,7 @@ import {
   Transactions,
   TransactionsDbo,
 } from './types';
-import { isSameDay } from './core';
+import { isBeforeDay, isOnOrBeforeDay, isSameDay } from './core';
 
 function initDefaultStock(ticker: string): Stock {
   return {
@@ -67,6 +67,9 @@ function initDefaultStock(ticker: string): Stock {
       portfolioValues: [],
       profit: [],
       yieldPerYear: { years: [], yields: [], profit: [] },
+      allTimeDates: [],
+      allTimePortfolioValues: [],
+      allTimeProfit: [],
     },
     currency: { value: 'EUR' },
   };
@@ -222,7 +225,9 @@ export function sortTransactions(transactions: Transaction[]): Transaction[] {
 
 export function getTransactionAmountsAndValues(
   dates: Date[],
-  transactions: Transaction[]
+  transactions: Transaction[],
+  initialAmount = 0,
+  initialValue = 0
 ): {
   transactionAmounts: number[];
   transactionValues: number[];
@@ -233,27 +238,34 @@ export function getTransactionAmountsAndValues(
   const values: number[] = [];
   const aggregatedAmounts: number[] = [];
   const aggregatedValues: number[] = [];
-  let index = 0;
-  let currentTransaction: Transaction = transactions[index];
 
   if (transactions.length === 0) {
     const nanArray = Array(dates.length).fill(NaN);
-    const zerosArray = Array(dates.length).fill(0);
     return {
       transactionAmounts: nanArray,
       transactionValues: nanArray,
-      aggregatedAmounts: zerosArray,
-      aggregatedValues: zerosArray,
+      aggregatedAmounts: Array(dates.length).fill(initialAmount),
+      aggregatedValues: Array(dates.length).fill(initialValue),
     };
   }
 
+  // Skip pre-range transactions (those before the first date in the window).
+  let index = 0;
+  if (dates.length > 0) {
+    while (index < transactions.length && isBeforeDay(transactions[index].date, dates[0])) {
+      index++;
+    }
+  }
+
+  let currentTransaction: Transaction = transactions[index];
+
   for (const date of dates) {
-    if (!isSameDay(date, currentTransaction.date)) {
+    if (index >= transactions.length || !isSameDay(date, currentTransaction.date)) {
       if (aggregatedAmounts.length === 0) {
         amounts.push(0);
         values.push(0);
-        aggregatedAmounts.push(0);
-        aggregatedValues.push(0);
+        aggregatedAmounts.push(initialAmount);
+        aggregatedValues.push(initialValue);
       } else {
         amounts.push(NaN);
         values.push(NaN);
@@ -263,29 +275,20 @@ export function getTransactionAmountsAndValues(
     } else {
       let newAmount = 0;
       let newValue = 0;
-      while (isSameDay(date, currentTransaction.date)) {
+      while (index < transactions.length && isSameDay(date, currentTransaction.date)) {
         newAmount += currentTransaction.amount;
         newValue += currentTransaction.value;
-
         index += 1;
-        if (index >= transactions.length) {
-          break;
+        if (index < transactions.length) {
+          currentTransaction = transactions[index];
         }
-        currentTransaction = transactions[index];
       }
       amounts.push(newAmount);
       values.push(newValue);
-      if (aggregatedAmounts.length === 0) {
-        aggregatedAmounts.push(newAmount);
-        aggregatedValues.push(newValue);
-      } else {
-        aggregatedAmounts.push(
-          aggregatedAmounts[aggregatedAmounts.length - 1] + newAmount
-        );
-        aggregatedValues.push(
-          aggregatedValues[aggregatedValues.length - 1] + newValue
-        );
-      }
+      const prevAmount = aggregatedAmounts.length === 0 ? initialAmount : aggregatedAmounts[aggregatedAmounts.length - 1];
+      const prevValue = aggregatedValues.length === 0 ? initialValue : aggregatedValues[aggregatedValues.length - 1];
+      aggregatedAmounts.push(prevAmount + newAmount);
+      aggregatedValues.push(prevValue + newValue);
     }
   }
   return {
@@ -294,6 +297,82 @@ export function getTransactionAmountsAndValues(
     aggregatedAmounts,
     aggregatedValues,
   };
+}
+
+/**
+ * Period-based variant of getTransactionAmountsAndValues for weekly/monthly
+ * granularity. Each periodDate is the END of a period; transactions are
+ * accumulated across the whole period rather than matched to an exact day.
+ * Transactions before rangeStart are captured in the initial snapshot so
+ * aggregatedAmounts/Values start from the correct historical baseline.
+ */
+export function getTransactionAmountsAndValuesByPeriod(
+  periodDates: Date[],
+  transactions: Transaction[],
+  rangeStart: Date
+): {
+  transactionAmounts: number[];
+  transactionValues: number[];
+  aggregatedAmounts: number[];
+  aggregatedValues: number[];
+} {
+  const transactionAmounts: number[] = [];
+  const transactionValues: number[] = [];
+  const aggregatedAmounts: number[] = [];
+  const aggregatedValues: number[] = [];
+
+  if (periodDates.length === 0) {
+    return { transactionAmounts, transactionValues, aggregatedAmounts, aggregatedValues };
+  }
+
+  // Accumulate all pre-range transactions into the running snapshot.
+  let runningAmount = 0;
+  let runningValue = 0;
+  let txIdx = 0;
+  while (txIdx < transactions.length && isBeforeDay(transactions[txIdx].date, rangeStart)) {
+    runningAmount += transactions[txIdx].amount;
+    runningValue += transactions[txIdx].value;
+    txIdx++;
+  }
+
+  let prevRunningAmount = runningAmount;
+  let prevRunningValue = runningValue;
+
+  for (const periodDate of periodDates) {
+    while (txIdx < transactions.length && isOnOrBeforeDay(transactions[txIdx].date, periodDate)) {
+      runningAmount += transactions[txIdx].amount;
+      runningValue += transactions[txIdx].value;
+      txIdx++;
+    }
+
+    const periodTxAmount = runningAmount - prevRunningAmount;
+    const periodTxValue = runningValue - prevRunningValue;
+
+    transactionAmounts.push(periodTxAmount !== 0 ? periodTxAmount : NaN);
+    transactionValues.push(periodTxValue !== 0 ? periodTxValue : NaN);
+    aggregatedAmounts.push(runningAmount);
+    aggregatedValues.push(runningValue);
+
+    prevRunningAmount = runningAmount;
+    prevRunningValue = runningValue;
+  }
+
+  return { transactionAmounts, transactionValues, aggregatedAmounts, aggregatedValues };
+}
+
+/** Sums transaction amounts/values for all transactions strictly before asOf. */
+export function computePreRangeSnapshot(
+  transactions: Transaction[],
+  asOf: Date
+): { amount: number; value: number } {
+  let amount = 0, value = 0;
+  for (const tx of transactions) {
+    if (isBeforeDay(tx.date, asOf)) {
+      amount += tx.amount;
+      value += tx.value;
+    }
+  }
+  return { amount, value };
 }
 
 export function getStartDate(stocks: { [ticker: string]: Stock }): Date {

--- a/libs/shared/util/src/lib/types.ts
+++ b/libs/shared/util/src/lib/types.ts
@@ -34,14 +34,7 @@ export type Stock = {
   transactions: Transactions;
   summary: StockSummary;
   chartData: ChartData;
-  currency: {
-    value: string;
-    yahooTicker?: string;
-    // Multiplier applied after the FX rate conversion. Used for sub-unit
-    // currencies where Yahoo prices differ from the exchange rate unit:
-    // GBp (pence) = 0.01 × GBP, so fxMultiplier is 0.01.
-    fxMultiplier?: number;
-  };
+  currency: { value: string };
 };
 
 export type ChartData = {

--- a/libs/shared/util/src/lib/types.ts
+++ b/libs/shared/util/src/lib/types.ts
@@ -44,6 +44,10 @@ export type ChartData = {
   portfolioValues: number[];
   profit: number[];
   yieldPerYear: { years: string[]; yields: number[]; profit: number[] };
+  // Full-history monthly data (independent of selected range) for yield/dividend charts.
+  allTimeDates: Date[];
+  allTimePortfolioValues: number[];
+  allTimeProfit: number[];
 };
 
 export type TransactionChartData = {
@@ -121,6 +125,19 @@ export type TransactionDbo = {
   amount: number;
   value: number;
   currency: string;
+};
+
+export type TimeRange = '1M' | '3M' | '6M' | 'YTD' | '1Y' | '5Y' | 'ALL';
+export type ChartGranularity = 'daily' | 'weekly' | 'monthly';
+
+export const TIME_RANGE_LABELS: Record<TimeRange, string> = {
+  '1M': '1M',
+  '3M': '3M',
+  '6M': '6M',
+  'YTD': 'YTD',
+  '1Y': '1Y',
+  '5Y': '5Y',
+  'ALL': 'All',
 };
 
 export type YahooObject = {

--- a/libs/shared/util/src/lib/util.spec.ts
+++ b/libs/shared/util/src/lib/util.spec.ts
@@ -398,11 +398,7 @@ describe('transactionsDboToStocks / getStartDate / getCurrencies', () => {
     const stocks = transactionsDboToStocks(input);
     expect(Object.keys(stocks)).toEqual(['VUSA.AS']);
     expect(stocks['VUSA.AS'].transactions.stock).toHaveLength(2);
-    // USD maps to the EUR=X FX ticker used to convert prices.
-    expect(stocks['VUSA.AS'].currency).toEqual({
-      value: 'USD',
-      yahooTicker: 'EUR=X',
-    });
+    expect(stocks['VUSA.AS'].currency).toEqual({ value: 'USD' });
   });
 
   it('getStartDate returns the earliest transaction date across stocks', () => {
@@ -412,37 +408,47 @@ describe('transactionsDboToStocks / getStartDate / getCurrencies', () => {
     );
   });
 
-  it('getCurrencies returns the unique FX tickers needed', () => {
-    const stocks = transactionsDboToStocks(input);
+  it('getCurrencies returns EUR=X for a USD stock (only EUR display needs conversion)', () => {
+    const stocks = transactionsDboToStocks(input); // USD stock
+    // EUR display: USD→EUR via EUR=X. USD display: no conversion needed.
     expect(getCurrencies(stocks)).toEqual(['EUR=X']);
   });
 
-  it('resolves GBP to GBPEUR=X', () => {
+  it('getCurrencies returns EURUSD=X for a EUR stock (only USD display needs conversion)', () => {
+    const eurInput: TransactionsDbo = {
+      stock: [dbo('2023-01-10', 1, 100, 'stock', 'EUR')],
+      dividend: [],
+      commission: [],
+    };
+    const stocks = transactionsDboToStocks(eurInput);
+    // EUR display: no conversion. USD display: EUR→USD via EURUSD=X.
+    expect(getCurrencies(stocks)).toEqual(['EURUSD=X']);
+  });
+
+  it('resolves GBP to { value: "GBP" } and returns both GBP FX tickers', () => {
     const gbpInput: TransactionsDbo = {
       stock: [dbo('2023-01-10', 10, 100, 'stock', 'GBP')],
       dividend: [],
       commission: [],
     };
     const stocks = transactionsDboToStocks(gbpInput);
-    expect(stocks['VUSA.AS'].currency).toEqual({ value: 'GBP', yahooTicker: 'GBPEUR=X' });
-    expect(getCurrencies(stocks)).toEqual(['GBPEUR=X']);
+    expect(stocks['VUSA.AS'].currency).toEqual({ value: 'GBP' });
+    // EUR display: GBPEUR=X. USD display: GBPUSD=X.
+    expect(getCurrencies(stocks)).toEqual(expect.arrayContaining(['GBPEUR=X', 'GBPUSD=X']));
+    expect(getCurrencies(stocks)).toHaveLength(2);
   });
 
-  it('resolves GBp (pence) to GBPEUR=X with fxMultiplier 0.01', () => {
+  it('resolves GBp (pence) to { value: "GBp" }', () => {
     const gbpInput: TransactionsDbo = {
       stock: [dbo('2023-01-10', 1000, 5000, 'stock', 'GBp')],
       dividend: [],
       commission: [],
     };
     const stocks = transactionsDboToStocks(gbpInput);
-    expect(stocks['VUSA.AS'].currency).toEqual({
-      value: 'GBp',
-      yahooTicker: 'GBPEUR=X',
-      fxMultiplier: 0.01,
-    });
+    expect(stocks['VUSA.AS'].currency).toEqual({ value: 'GBp' });
   });
 
-  it('getCurrencies deduplicates GBP and GBp under the same GBPEUR=X ticker', () => {
+  it('getCurrencies deduplicates GBP and GBp — both use the same base FX tickers', () => {
     const mixed: TransactionsDbo = {
       stock: [
         dbo('2023-01-10', 1, 100, 'stock', 'GBP'),
@@ -452,7 +458,9 @@ describe('transactionsDboToStocks / getStartDate / getCurrencies', () => {
       commission: [],
     };
     const stocks = transactionsDboToStocks(mixed);
-    expect(getCurrencies(stocks)).toEqual(['GBPEUR=X']);
+    // GBP and GBp share the same FX ticker base — deduplicated to just 2.
+    expect(getCurrencies(stocks)).toEqual(expect.arrayContaining(['GBPEUR=X', 'GBPUSD=X']));
+    expect(getCurrencies(stocks)).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Performance**: adds a 1M / 3M / 6M / YTD / 1Y / 5Y / All time-range picker on the dashboard. Granularity scales automatically (daily → weekly → monthly) so large portfolios (hundreds of stocks, 10+ years) compute 30–60× fewer data points instead of blocking the main thread.
- **Correctness**: fixed three bugs that caused portfolio value, profit, and dividend charts to show 0 or wrong data on ranges shorter than the full history.
- **EUR/USD currency support** from the previous commits is still included.

### What changed

**`shared/util`**
- `TimeRange` / `ChartGranularity` types; `getMonthlyDates`, `getWeeklyDates`, `getRangeStartDate`, `getGranularityForRange` helpers
- `getTransactionAmountsAndValues` now accepts an initial pre-range snapshot so aggregated arrays start from the correct historical baseline
- `getTransactionAmountsAndValuesByPeriod` — accumulates transactions by calendar period (week/month) instead of matching exact dates
- `getPortfolioValues` rewritten with a forward-scan loop; previously started at `ticker.dates[0]` and never advanced past pre-range dates, producing all-zeros for any range shorter than the full history
- `getPortfolioValuesByPeriod` for weekly/monthly granularity
- `computePortfolioState` accepts a `range` parameter; summary chip returns always use a 30-day daily window for accuracy regardless of chart granularity; dividend bar charts and yield chart always use full-history monthly data (`allTimeDates`, `allTimePortfolioValues`, `allTimeProfit` stored in `ChartData`) so they are unaffected by the selected range
- `updateDividendsByPeriod` and fixed `getAmountOfSharesForDate` (was returning 0 for dividends on non-exact dates)

**NgRx state**
- `setTimeRange` action, `timeRange: TimeRange` state field (default `'1Y'`), `selectTimeRange` selector

**Dashboard**
- Time-range chip row: `1M 3M 6M YTD 1Y 5Y All`
- Fixed `*ngIf` that was hiding the holdings section whenever `portfolioValue` was momentarily 0
- Shimmer loading bar while `loading$` is true

## Test plan

- [x] Load dashboard with a portfolio that has transactions older than 1 year — verify portfolio value chip and chart are non-zero on all ranges
- [x] Switch between 1M / 3M / 6M / YTD / 1Y / 5Y / All — verify portfolio value, profit, and invested charts update correctly
- [x] Check dividend bar charts (per-quarter-by-year, TTM) — should show full history on all ranges
- [x] Check yield-per-year bar chart — should show full history on all ranges
- [x] Check "Dividend per Quarter" and "Cumulative Dividend" line charts — should show full history, not reset to 0 on short ranges
- [x] Toggle portfolio filter chips — page should update correctly without freezing
- [x] Verify summary chips (portfolio value, daily/weekly/monthly/total return) are consistent across range changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)