### PR TITLE
feat(ui): portfolios page UX overhaul — mobile layout, wider table, portfolio values

### DIFF
--- a/libs/frontend/ui/src/lib/icons.ts
+++ b/libs/frontend/ui/src/lib/icons.ts
@@ -7,6 +7,7 @@ import {
   Plus,
   Pencil,
   Trash2,
+  ChevronLeft,
 } from 'lucide-angular';
 
 export const APP_ICONS = {
@@ -18,4 +19,5 @@ export const APP_ICONS = {
   Plus,
   Pencil,
   Trash2,
+  ChevronLeft,
 };

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.html
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.html
@@ -16,6 +16,9 @@
       <div class="portfolio-info">
         <div class="portfolio-name">{{ portfolio.name }}</div>
         <div class="portfolio-count">{{ transactionCount(portfolio) }} transactions</div>
+        <div class="portfolio-value" *ngIf="portfolioStates?.[portfolio.id]?.summary?.portfolioValue">
+          {{ portfolioStates![portfolio.id].summary.portfolioValue | currency:baseCurrency:'symbol':'1.0-0' }}
+        </div>
       </div>
 
       <div class="portfolio-actions" (click)="$event.stopPropagation()">

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.scss
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.scss
@@ -105,6 +105,13 @@
   margin-top: 2px;
 }
 
+.portfolio-value {
+  font-size: 0.8rem;
+  color: $color-gold;
+  font-weight: 500;
+  margin-top: 2px;
+}
+
 .portfolio-actions {
   display: flex;
   align-items: center;

--- a/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.ts
+++ b/libs/frontend/ui/src/lib/portfolio-list/portfolio-list.component.ts
@@ -1,17 +1,19 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, CurrencyPipe } from '@angular/common';
 import { LucideAngularModule } from 'lucide-angular';
-import { PortfolioDbo } from '@aws/util';
+import { PortfolioDbo, Summary } from '@aws/util';
 
 @Component({
   selector: 'aws-portfolio-list',
   templateUrl: './portfolio-list.component.html',
   styleUrls: ['./portfolio-list.component.scss'],
-  imports: [CommonModule, LucideAngularModule],
+  imports: [CommonModule, LucideAngularModule, CurrencyPipe],
 })
 export class PortfolioListComponent {
   @Input() portfolios: PortfolioDbo[] = [];
   @Input() selectedPortfolioId: string | null = null;
+  @Input() portfolioStates: { [id: string]: { summary: Summary } } | null = null;
+  @Input() baseCurrency = 'EUR';
 
   @Output() selectPortfolio = new EventEmitter<string>();
   @Output() createPortfolio = new EventEmitter<void>();

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.html
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.html
@@ -1,7 +1,9 @@
 <div class="portfolios-layout" *ngIf="{ portfolios: portfolios$ | async, allStates: allPortfolioStates$ | async, baseCurrency: baseCurrency$ | async } as vm">
-  <aside class="portfolios-sidebar">
+  <aside class="portfolios-sidebar" *ngIf="!mobileQuery.matches || !showDetail">
     <aws-portfolio-list
       [portfolios]="vm.portfolios ?? []"
+      [portfolioStates]="vm.allStates"
+      [baseCurrency]="vm.baseCurrency ?? 'EUR'"
       [selectedPortfolioId]="selectedPortfolioId"
       (selectPortfolio)="onSelectPortfolio($event)"
       (createPortfolio)="onCreatePortfolio()"
@@ -10,7 +12,13 @@
     ></aws-portfolio-list>
   </aside>
 
-  <main class="portfolios-main">
+  <main class="portfolios-main" *ngIf="!mobileQuery.matches || showDetail">
+    <div class="mobile-back" *ngIf="mobileQuery.matches">
+      <button class="back-btn" (click)="onBackToList()">
+        <lucide-icon name="ChevronLeft" [size]="18"></lucide-icon>
+        Portfolios
+      </button>
+    </div>
     <aws-portfolio-detail
       [portfolio]="getSelectedPortfolio(vm.portfolios ?? [])"
       [stocks]="getSelectedPortfolioStocks(vm.allStates)"

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.scss
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.scss
@@ -27,3 +27,29 @@
   display: flex;
   flex-direction: column;
 }
+
+.mobile-back {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  border-bottom: 1px solid $color-border;
+  background: $color-bg-surface;
+}
+
+.back-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: $color-gold;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: $radius-sm;
+  transition: $transition-base;
+
+  &:hover {
+    background: rgba($color-gold, 0.08);
+  }
+}

--- a/libs/frontend/ui/src/lib/portfolios/portfolios.component.ts
+++ b/libs/frontend/ui/src/lib/portfolios/portfolios.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MediaMatcher } from '@angular/cdk/layout';
 import { Store } from '@ngrx/store';
 import {
   createPortfolio,
@@ -29,20 +30,34 @@ import {
   CsvUploadResult,
 } from '../csv-upload-dialog/csv-upload-dialog.component';
 import { DialogService } from '../dialog/dialog.service';
+import { LucideAngularModule } from 'lucide-angular';
 
 @Component({
   selector: 'aws-portfolios',
   templateUrl: './portfolios.component.html',
   styleUrls: ['./portfolios.component.scss'],
-  imports: [CommonModule, PortfolioListComponent, PortfolioDetailComponent],
+  imports: [CommonModule, PortfolioListComponent, PortfolioDetailComponent, LucideAngularModule],
 })
-export class PortfoliosComponent implements OnInit {
+export class PortfoliosComponent implements OnInit, OnDestroy {
   portfolios$ = this.store.select(selectPortfoliosDbo);
   allPortfolioStates$ = this.store.select(selectAllPortfolioStates);
   baseCurrency$ = this.store.select(selectBaseCurrency);
   selectedPortfolioId: string | null = null;
+  showDetail = false;
 
-  constructor(private store: Store, private dialog: DialogService) {}
+  mobileQuery: MediaQueryList;
+  private _mobileQueryListener: () => void;
+
+  constructor(
+    private store: Store,
+    private dialog: DialogService,
+    changeDetectorRef: ChangeDetectorRef,
+    media: MediaMatcher,
+  ) {
+    this.mobileQuery = media.matchMedia('(max-width: 768px)');
+    this._mobileQueryListener = () => changeDetectorRef.detectChanges();
+    this.mobileQuery.addListener(this._mobileQueryListener);
+  }
 
   ngOnInit() {
     this.store.dispatch(getData());
@@ -51,6 +66,14 @@ export class PortfoliosComponent implements OnInit {
         this.selectedPortfolioId = portfolios[0].id;
       }
     });
+  }
+
+  ngOnDestroy() {
+    this.mobileQuery.removeListener(this._mobileQueryListener);
+  }
+
+  onBackToList() {
+    this.showDetail = false;
   }
 
   getSelectedPortfolio(portfolios: PortfolioDbo[]): PortfolioDbo | null {
@@ -66,6 +89,7 @@ export class PortfoliosComponent implements OnInit {
 
   onSelectPortfolio(id: string) {
     this.selectedPortfolioId = id;
+    this.showDetail = true;
   }
 
   onCreatePortfolio() {

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
@@ -4,9 +4,17 @@
   <div class="ticker-section" *ngFor="let key of Object.keys(stocks)">
     <details class="ticker-panel">
       <summary class="ticker-header">
-        <span class="ticker-name">{{ stocks[key].ticker }}</span>
-        <span class="currency-badge">{{ stocks[key].currency.value }}</span>
-        <span class="ticker-arrow">›</span>
+        <div class="ticker-header-left">
+          <span class="ticker-name">{{ stocks[key].ticker }}</span>
+          <span class="currency-badge">{{ stocks[key].currency.value }}</span>
+        </div>
+        <div class="ticker-header-right">
+          <div class="ticker-meta" *ngIf="stocks[key].summary.portfolioValue">
+            <span class="holding-value">{{ stocks[key].summary.portfolioValue | currency:baseCurrency:'symbol':'1.0-0' }}</span>
+            <span class="holding-shares">{{ stocks[key].summary.amountOfShares | number:'1.0-2' }} shares</span>
+          </div>
+          <span class="ticker-arrow">›</span>
+        </div>
       </summary>
 
       <div class="ticker-body">
@@ -18,16 +26,16 @@
             <div class="group-label">Stocks</div>
             <div class="transaction-table">
               <div class="table-header">
-                <span>Date</span>
-                <span>Amount</span>
-                <span>Value</span>
-                <span>Price/Share</span>
+                <span class="col-date">Date</span>
+                <span class="col-num">Amount</span>
+                <span class="col-num">Value</span>
+                <span class="col-num">Price/Share</span>
               </div>
               <div class="transaction-row" *ngFor="let transaction of stocks[key].transactions?.stock">
-                <span>{{ transaction.date.getDate() }}/{{ transaction.date.getUTCMonth() + 1 }}/{{ transaction.date.getFullYear() }}</span>
-                <span>{{ transaction.amount }}</span>
-                <span>{{ transaction.value }}</span>
-                <span>{{ transaction.value / transaction.amount | number : '1.2-2' }}</span>
+                <span class="col-date">{{ transaction.date | date:'d MMM y' }}</span>
+                <span class="col-num">{{ transaction.amount }}</span>
+                <span class="col-num">{{ transaction.value | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                <span class="col-num">{{ transaction.value / transaction.amount | currency:baseCurrency:'symbol':'1.2-2' }}</span>
               </div>
             </div>
           </div>
@@ -37,12 +45,12 @@
             <div class="group-label">Dividends</div>
             <div class="transaction-table">
               <div class="table-header">
-                <span>Date</span>
-                <span>Value</span>
+                <span class="col-date">Date</span>
+                <span class="col-num">Value</span>
               </div>
               <div class="transaction-row" *ngFor="let transaction of stocks[key].transactions?.dividend">
-                <span>{{ transaction.date.getDate() }}/{{ transaction.date.getUTCMonth() + 1 }}/{{ transaction.date.getFullYear() }}</span>
-                <span class="number-text">{{ transaction.value }}</span>
+                <span class="col-date">{{ transaction.date | date:'d MMM y' }}</span>
+                <span class="col-num positive">{{ transaction.value | currency:baseCurrency:'symbol':'1.2-2' }}</span>
               </div>
             </div>
           </div>
@@ -52,12 +60,12 @@
             <div class="group-label">Commission</div>
             <div class="transaction-table">
               <div class="table-header">
-                <span>Date</span>
-                <span>Value</span>
+                <span class="col-date">Date</span>
+                <span class="col-num">Value</span>
               </div>
               <div class="transaction-row" *ngFor="let transaction of stocks[key].transactions?.commission">
-                <span>{{ transaction.date.getDate() }}/{{ transaction.date.getUTCMonth() + 1 }}/{{ transaction.date.getFullYear() }}</span>
-                <span class="negative">{{ transaction.value }}</span>
+                <span class="col-date">{{ transaction.date | date:'d MMM y' }}</span>
+                <span class="col-num negative">{{ transaction.value | currency:baseCurrency:'symbol':'1.2-2' }}</span>
               </div>
             </div>
           </div>

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.scss
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.scss
@@ -4,8 +4,6 @@
 :host {
   display: block;
   padding: 24px;
-  max-width: 1000px;
-  margin: 0 auto;
 }
 
 // ─── Page header ─────────────────────────────────────────────────────────────
@@ -92,12 +90,25 @@
   cursor: pointer;
   list-style: none;
   transition: $transition-base;
+  gap: 12px;
 
   &:hover {
     background: rgba($color-gold, 0.06);
   }
 
   &::-webkit-details-marker { display: none; }
+}
+
+.ticker-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ticker-header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .ticker-name {
@@ -113,6 +124,24 @@
   font-size: 1.25rem;
   transition: transform 0.2s ease;
   display: inline-block;
+  flex-shrink: 0;
+}
+
+.ticker-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.holding-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: $color-cream;
+}
+
+.holding-shares {
+  font-size: 0.75rem;
+  color: $color-muted;
 }
 
 .ticker-body {
@@ -146,20 +175,18 @@
 .table-header {
   display: flex;
   gap: 12px;
-  padding: 8px 12px;
+  padding: 8px 16px;
   background: $color-bg-elevated;
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: $color-muted;
-
-  span { flex: 1; }
 }
 
 .transaction-row {
   display: flex;
   gap: 12px;
-  padding: 8px 12px;
+  padding: 9px 16px;
   font-size: 0.875rem;
   color: $color-cream;
   transition: background 0.15s;
@@ -175,8 +202,19 @@
   &:hover {
     background: rgba($color-gold, 0.06);
   }
+}
 
-  span { flex: 1; }
+.col-date {
+  flex: 0 0 100px;
+}
+
+.col-num {
+  flex: 1;
+  text-align: right;
+}
+
+.positive {
+  color: $color-success;
 }
 
 // ─── Add transaction form ─────────────────────────────────────────────────────
@@ -257,6 +295,14 @@ select.form-control {
 
   .transaction-form {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .holding-shares {
+    display: none;
+  }
+
+  .col-date {
+    flex: 0 0 80px;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Mobile-friendly layout**: on screens ≤768px the portfolio list and detail view toggle instead of sitting side-by-side. Selecting a portfolio slides to the detail; a "← Portfolios" back button returns to the list. Uses the same `MediaMatcher` pattern as the existing app sidenav.
- **Wider transactions table**: removed the `max-width: 1000px` constraint so the table fills the available column. Numeric columns are right-aligned via `.col-date` / `.col-num` classes. Dates now use `DatePipe` (`1 Jun 2025`) and values use `CurrencyPipe` (`€1,234.56`). Share count is hidden on narrow viewports.
- **Portfolio values in sidebar**: `portfolioStates` (already computed by `selectAllPortfolioStates`) is now passed into `portfolio-list`. Each sidebar entry shows its current portfolio value in gold below the transaction count.
- **Ticker holding values**: each collapsible ticker panel header now shows the current holding value and share count from the already-computed `StockSummary`, so users can see positions at a glance without opening the panel.

No new selectors, reducers, or backend changes — all data was already available, just not plumbed through.

## Test plan

- [ ] **Desktop (>768px)**: sidebar stays visible alongside detail; portfolio values appear in gold below each portfolio name; ticker panels show value + share count in the header; table fills the full width with right-aligned number columns.
- [ ] **Mobile (<768px)**: portfolio list fills the full screen; tapping a portfolio transitions to the detail view; "← Portfolios" button returns to the list.
- [ ] **Empty / zero-value portfolio**: no value badge shown (guarded by `*ngIf`); no JS errors in console.
- [ ] **Multiple portfolios**: each shows its own independently computed value.
- [ ] `nx run-many -t lint test build --all` passes (confirmed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)