### PR TITLE
feat(util): list currency conversion + Yahoo dividends in list

### DIFF
--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.html
@@ -60,8 +60,14 @@
               <div class="transaction-row" *ngFor="let transaction of stocks[key].transactions?.stock">
                 <span class="col-date">{{ transaction.date | date:'d MMM y' }}</span>
                 <span class="col-num">{{ transaction.amount }}</span>
-                <span class="col-num">{{ transaction.value | currency:baseCurrency:'symbol':'1.2-2' }}</span>
-                <span class="col-num">{{ transaction.value / transaction.amount | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                <span class="col-num">
+                  <span class="val-primary">{{ displayValue(transaction) | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                  <span class="val-native" *ngIf="transaction.convertedValue !== undefined">{{ transaction.value | currency:transaction.currency:'symbol':'1.2-2' }}</span>
+                </span>
+                <span class="col-num">
+                  <span class="val-primary">{{ displayValue(transaction) / transaction.amount | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                  <span class="val-native" *ngIf="transaction.convertedValue !== undefined">{{ transaction.value / transaction.amount | currency:transaction.currency:'symbol':'1.2-2' }}</span>
+                </span>
                 <span class="col-actions">
                   <ng-container *ngTemplateOutlet="rowActions; context: { $implicit: transaction }"></ng-container>
                 </span>
@@ -80,7 +86,10 @@
               </div>
               <div class="transaction-row" *ngFor="let transaction of stocks[key].transactions?.dividend">
                 <span class="col-date">{{ transaction.date | date:'d MMM y' }}</span>
-                <span class="col-num positive">{{ transaction.value | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                <span class="col-num">
+                  <span class="val-primary positive">{{ displayValue(transaction) | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                  <span class="val-native" *ngIf="transaction.convertedValue !== undefined">{{ transaction.value | currency:transaction.currency:'symbol':'1.2-2' }}</span>
+                </span>
                 <span class="col-actions">
                   <ng-container *ngTemplateOutlet="rowActions; context: { $implicit: transaction }"></ng-container>
                 </span>
@@ -99,7 +108,10 @@
               </div>
               <div class="transaction-row" *ngFor="let transaction of stocks[key].transactions?.commission">
                 <span class="col-date">{{ transaction.date | date:'d MMM y' }}</span>
-                <span class="col-num negative">{{ transaction.value | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                <span class="col-num">
+                  <span class="val-primary negative">{{ displayValue(transaction) | currency:baseCurrency:'symbol':'1.2-2' }}</span>
+                  <span class="val-native" *ngIf="transaction.convertedValue !== undefined">{{ transaction.value | currency:transaction.currency:'symbol':'1.2-2' }}</span>
+                </span>
                 <span class="col-actions">
                   <ng-container *ngTemplateOutlet="rowActions; context: { $implicit: transaction }"></ng-container>
                 </span>

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.scss
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.scss
@@ -224,6 +224,17 @@
   color: $color-success;
 }
 
+// Stacked value: converted (base currency) on top, native underneath.
+.val-primary {
+  display: block;
+}
+
+.val-native {
+  display: block;
+  font-size: 0.72rem;
+  color: $color-muted;
+}
+
 // ─── Currency badge ────────────────────────────────────────────────────────────
 .currency-badge {
   font-size: 0.65rem;

--- a/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.ts
+++ b/libs/frontend/ui/src/lib/transactions-table/transactions-table.component.ts
@@ -127,6 +127,11 @@ export class TransactionsTableComponent {
       });
   }
 
+  /** Value shown in the base/display currency: converted when available, else native. */
+  displayValue(transaction: Transaction): number {
+    return transaction.convertedValue ?? transaction.value;
+  }
+
   private openTransactionDialog(data: TransactionDialogData) {
     this.dialog
       .open(TransactionDialogComponent, { data, width: '480px' })

--- a/libs/shared/util/src/lib/dividends.ts
+++ b/libs/shared/util/src/lib/dividends.ts
@@ -152,6 +152,37 @@ function getAmountOfSharesForDate(
  * Period-based variant of updateDividends for weekly/monthly granularity.
  * Uses getTransactionAmountsAndValuesByPeriod instead of the daily version.
  */
+/**
+ * Builds discrete dividend transactions from a ticker's Yahoo dividend events,
+ * multiplying each ex-date's per-share amount by the share count held at that
+ * date. Each transaction's `value` is the native amount (in the ticker's
+ * currency); when `fxConvert` is supplied, `convertedValue` carries the value in
+ * the display currency at the ex-date's rate (spot-at-receipt).
+ *
+ * Used both to feed the dividend charts ({@link updateDividendsByPeriod}) and to
+ * show a dividend list for holdings that have no dividend rows from their CSV.
+ */
+export function buildDividendTransactions(
+  ticker: Ticker,
+  amountOfShares: number[],
+  periodDates: Date[],
+  fxConvert?: (value: number, date: Date) => number
+): Transaction[] {
+  return ticker.dividends.map((div) => {
+    const amount = getAmountOfSharesForDate(amountOfShares, periodDates, div.date);
+    const nativeValue = div.amountPerShare * amount;
+    return {
+      ticker: ticker.name,
+      type: 'dividend',
+      date: div.date,
+      amount,
+      value: nativeValue,
+      currency: ticker.currency,
+      convertedValue: fxConvert ? fxConvert(nativeValue, div.date) : undefined,
+    };
+  });
+}
+
 export function updateDividendsByPeriod(
   amountOfShares: number[],
   ticker: Ticker,
@@ -163,18 +194,15 @@ export function updateDividendsByPeriod(
   // applied when the cash was paid (spot-at-receipt).
   fxConvert?: (value: number, date: Date) => number
 ): DividendTransactionChartData {
-  const transactions: Transaction[] = ticker.dividends.map((div) => {
-    const amount = getAmountOfSharesForDate(amountOfShares, periodDates, div.date);
-    const nativeValue = div.amountPerShare * amount;
-    return {
-      ticker: ticker.name,
-      type: 'dividend',
-      date: div.date,
-      amount,
-      value: fxConvert ? fxConvert(nativeValue, div.date) : nativeValue,
-      currency: ticker.currency,
-    };
-  });
+  // The chart series consume value in the display currency, so collapse
+  // converted → value here (buildDividendTransactions keeps them separate for
+  // the list, which needs both native and converted).
+  const transactions: Transaction[] = buildDividendTransactions(
+    ticker,
+    amountOfShares,
+    periodDates,
+    fxConvert
+  ).map((tx) => ({ ...tx, value: tx.convertedValue ?? tx.value }));
 
   const dividendTransactionAmountsAndValues = getTransactionAmountsAndValuesByPeriod(
     periodDates,

--- a/libs/shared/util/src/lib/portfolio.spec.ts
+++ b/libs/shared/util/src/lib/portfolio.spec.ts
@@ -382,6 +382,48 @@ describe('computePortfolioState', () => {
     expect(result.summary.portfolioValue).toBeCloseTo(180);
     expect(result.stocks['AAPL'].summary.portfolioValue).toBeCloseTo(180);
     expect(result.stocks['AAPL'].summary.currentSharePrice).toBeCloseTo(180);
+
+    // The displayed transaction keeps its native value and gains a
+    // convertedValue at the purchase-date rate (0.9): $100 -> €90.
+    const tx = result.stocks['AAPL'].transactions.stock[0];
+    expect(tx.value).toBe(100);
+    expect(tx.currency).toBe('USD');
+    expect(tx.convertedValue).toBeCloseTo(90);
+  });
+
+  it('leaves convertedValue undefined when no FX conversion is needed', () => {
+    const dates = getDailyDates(getStartDate(transactionsDboToStocks(dbo)), new Date());
+    const ticker: Ticker = {
+      name: 'VUSA.AS', currency: 'EUR', dates, values: dates.map(() => 150), dividends: [],
+    };
+    const result = computePortfolioState(dbo, { 'VUSA.AS': ticker }, 'EUR');
+    expect(result.stocks['VUSA.AS'].transactions.stock[0].convertedValue).toBeUndefined();
+  });
+
+  it('fills the dividend list from Yahoo when the holding has no CSV dividends', () => {
+    const noDivDbo: TransactionsDbo = {
+      stock: [
+        { ticker: 'AAPL', type: 'stock', date: '2023-01-10', amount: 10, value: 1000, currency: 'USD' },
+      ],
+      dividend: [],
+      commission: [],
+    };
+    const dates = getDailyDates(getStartDate(transactionsDboToStocks(noDivDbo)), new Date());
+    const ticker: Ticker = {
+      name: 'AAPL',
+      currency: 'USD',
+      dates,
+      values: dates.map(() => 200),
+      dividends: [{ date: new Date('2023-03-01'), amountPerShare: 0.5 }],
+    };
+
+    const result = computePortfolioState(noDivDbo, { AAPL: ticker }, 'USD');
+    const divs = result.stocks['AAPL'].transactions.dividend;
+
+    // No CSV dividends, so the Yahoo dividend event is surfaced: 10 shares * $0.5.
+    expect(divs).toHaveLength(1);
+    expect(divs[0].value).toBeCloseTo(5);
+    expect(divs[0].currency).toBe('USD');
   });
 
   it('locks cost basis at the purchase-date FX rate (spot-at-purchase)', () => {

--- a/libs/shared/util/src/lib/portfolio.ts
+++ b/libs/shared/util/src/lib/portfolio.ts
@@ -1,6 +1,7 @@
-import { ChartGranularity, PortfolioDbo, Stock, Summary, Ticker, TimeRange, Transactions, TransactionsDbo } from './types';
+import { ChartGranularity, PortfolioDbo, Stock, Summary, Ticker, TimeRange, Transaction, Transactions, TransactionsDbo } from './types';
 import {
   addLists,
+  buildDividendTransactions,
   buildStockSeries,
   createFxConverter,
   getCurrencies,
@@ -20,6 +21,7 @@ import {
   computePreRangeSnapshot,
   getYieldPerYear,
   isBeforeDay,
+  sortTransactions,
   transactionsDboToStocks,
   transactionsDboToTransactions,
   updateDividendsByPeriod,
@@ -417,8 +419,29 @@ function computePriceState(
     chartTotalCommissionSummary += stockTotalCommission;
     chartTotalDividendSummary += allTimeTotalDividend;
 
+    // Display transactions for the list: keep the native value, and attach a
+    // convertedValue (display currency, spot-at-date) when an FX converter is
+    // present. Holdings with no CSV dividend rows fall back to the Yahoo
+    // dividend events so a dividend list is still shown.
+    const withConverted = (txs: Transaction[]): Transaction[] =>
+      fx ? txs.map((d) => ({ ...d, convertedValue: fx.convert(d.value, d.date) })) : txs;
+
+    const displayDividends =
+      t.dividend.length > 0
+        ? withConverted(t.dividend)
+        : sortTransactions(
+            buildDividendTransactions(ticker, allTimeSeries.aggregatedAmounts, allTimeDates, fxConvert)
+          );
+
+    const displayTransactions: Transactions = {
+      stock: withConverted(t.stock),
+      dividend: displayDividends,
+      commission: withConverted(t.commission),
+    };
+
     chartedStocks[key] = {
       ...stock,
+      transactions: displayTransactions,
       summary: {
         ...stock.summary,
         portfolioValue,

--- a/libs/shared/util/src/lib/types.ts
+++ b/libs/shared/util/src/lib/types.ts
@@ -79,8 +79,13 @@ export type Transaction = {
   date: Date;
   time?: string;
   amount: number;
+  // Native value, in the transaction's own `currency`.
   value: number;
   currency: string;
+  // Value converted into the display/base currency at this transaction's own
+  // date's FX rate (spot-at-purchase). Set by the engine when a display currency
+  // differs from the holding currency; undefined means "show the native value".
+  convertedValue?: number;
 };
 
 export type TransactionKey = {

--- a/libs/shared/util/src/lib/util.spec.ts
+++ b/libs/shared/util/src/lib/util.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   addLists,
   applyTransactionEdit,
+  buildDividendTransactions,
   getCurrencies,
   getCurrencySymbol,
   getHoldingCurrency,
@@ -636,6 +637,33 @@ describe('yahooObjectToTicker', () => {
     // Aligned to the shorter length (1) so dates[i] always matches values[i].
     expect(result.values).toEqual([150]);
     expect(result.dates).toEqual([new Date(ts1 * 1000)]);
+  });
+});
+
+describe('buildDividendTransactions', () => {
+  const ticker: Ticker = {
+    name: 'AAPL',
+    currency: 'USD',
+    dates: [],
+    values: [],
+    dividends: [{ date: new Date('2023-06-15'), amountPerShare: 2 }],
+  };
+  // Period boundaries: holding 10 shares from end of May onward.
+  const periodDates = [new Date('2023-05-31'), new Date('2023-06-30')];
+  const amountOfShares = [10, 10];
+
+  it('multiplies per-share dividend by shares held at the ex-date (native value)', () => {
+    const [tx] = buildDividendTransactions(ticker, amountOfShares, periodDates);
+    expect(tx.amount).toBe(10);
+    expect(tx.value).toBe(20); // 2 * 10
+    expect(tx.currency).toBe('USD');
+    expect(tx.convertedValue).toBeUndefined();
+  });
+
+  it('sets convertedValue from the converter at the ex-date', () => {
+    const [tx] = buildDividendTransactions(ticker, amountOfShares, periodDates, (v) => v * 0.9);
+    expect(tx.value).toBe(20);
+    expect(tx.convertedValue).toBeCloseTo(18); // 20 * 0.9
   });
 });
 


### PR DESCRIPTION
## Why

Phase 3 of the portfolios-page work. **Stacks on #63** (which stacks on #62) —
merge those first. Fixes two list-level issues, both in the engine so they're
correct wherever a `Stock` is rendered:

1. Foreign-currency holdings showed their **native** value with the **base**
   currency symbol (no FX applied).
2. Holdings imported without dividend rows showed no dividends, even though
   Yahoo has them (the charts already used them).

## What

- **types**: `Transaction` gains an optional `convertedValue` — the value in the
  display/base currency at the transaction's own date's FX rate (spot-at-date).
  `value`/`currency` stay native.
- **portfolio.ts** (`computePriceState`): attaches `convertedValue` to each listed
  transaction when an FX converter exists (`null` → native shown unchanged).
- **dividends.ts**: extracts `buildDividendTransactions` (the discrete Yahoo
  dividend builder) out of `updateDividendsByPeriod`. When a holding has **no CSV
  dividend rows**, the list is filled from the Yahoo dividend events. Totals and
  charts are unaffected — they already use the Yahoo-derived dividend total.
- **transactions-table**: each value renders the converted (base) amount with the
  native amount beneath it when currencies differ.

## Testing

- `nx run-many -t lint test -p util ui` — green. New tests: `buildDividendTransactions`
  (util.spec); `convertedValue` on transactions, native pass-through, and the
  Yahoo-dividend fallback (portfolio.spec). Golden fixture unchanged (summaries
  use `toBeCloseTo`; only optional fields were added).
- `nx build frontend` — compiles.

### Manual checklist

- [ ] With EUR base, a USD holding (e.g. AAPL) shows €-converted values with `$` native beneath.
- [ ] Switching base currency to USD updates the displayed values.
- [ ] An EUR holding shows a single value (no redundant native line).
- [ ] A holding with no CSV dividends shows a Yahoo dividend list; portfolio totals are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)