### PR TITLE
feat(ui): chart UI/UX overhaul — time axis, scroll legends, 2-decimal tooltips

### DIFF
--- a/libs/frontend/ui/src/lib/bar-and-line-chart/bar-and-line-chart.component.ts
+++ b/libs/frontend/ui/src/lib/bar-and-line-chart/bar-and-line-chart.component.ts
@@ -2,21 +2,24 @@ import { Component, Input, OnChanges } from '@angular/core';
 import { EChartsOption } from 'echarts';
 import { YearQuarter } from '@aws/util';
 import { NgxEchartsDirective } from 'ngx-echarts';
-
-
-const NAUTICAL_TEXT  = '#F5F0E8';
-const NAUTICAL_MUTED = '#8FA8C0';
-const NAUTICAL_GOLD  = '#C9A84C';
-const NAUTICAL_GRID  = 'rgba(201,168,76,0.1)';
+import {
+  axisStyle,
+  baseGrid,
+  baseTitle,
+  baseTooltip,
+  formatMoney,
+  NAUTICAL_GOLD,
+  NAUTICAL_MUTED,
+  NAUTICAL_TEXT,
+  round2,
+  scrollLegend,
+} from '../chart-theme';
 
 // The bar series is a trailing-twelve-month (annual) dividend figure, so the
 // derived rate lines divide the annual amount down to each interval.
 const MONTHS_PER_YEAR = 12;
 const DAYS_PER_YEAR = 365;
 const HOURS_PER_YEAR = DAYS_PER_YEAR * 24;
-
-/** Round a currency amount to 2 decimals. */
-const round2 = (value: number) => Math.round(value * 100) / 100;
 
 @Component({
   selector: 'aws-bar-and-line-chart',
@@ -43,23 +46,12 @@ export class BarAndLineChartComponent implements OnChanges {
     return {
       backgroundColor: 'transparent',
       textStyle: { color: NAUTICAL_TEXT },
-      title: {
-        left: 'center',
-        text: 'TTM Dividend',
-        textStyle: { color: NAUTICAL_TEXT },
-      },
-      grid: { containLabel: true },
-      tooltip: {
-        trigger: 'axis',
-        backgroundColor: '#0F2035',
-        borderColor: NAUTICAL_GOLD,
-        textStyle: { color: NAUTICAL_TEXT },
-        axisPointer: { type: 'shadow' },
-      },
-      legend: {
-        top: '8%',
-        textStyle: { color: NAUTICAL_MUTED },
-      },
+      title: baseTitle('TTM Dividend'),
+      grid: baseGrid(72),
+      tooltip: baseTooltip('axis', {
+        valueFormatter: (value) => formatMoney(value as number, this.currencySymbol),
+      }),
+      legend: scrollLegend(40),
       xAxis: {
         type: 'category',
         data: this.series.yearQuarters.map((x) => {
@@ -68,15 +60,15 @@ export class BarAndLineChartComponent implements OnChanges {
           }
           return `Q${x.quarter + 1}`;
         }),
-        axisLine: { lineStyle: { color: NAUTICAL_GRID } },
         axisLabel: { color: NAUTICAL_MUTED },
-        axisTick: { lineStyle: { color: NAUTICAL_GRID } },
+        axisLine: axisStyle.axisLine,
+        axisTick: axisStyle.axisTick,
       },
       yAxis: {
         type: 'value',
         axisLabel: { formatter: `{value} ${this.currencySymbol}`, color: NAUTICAL_MUTED },
-        axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-        splitLine: { lineStyle: { color: NAUTICAL_GRID } },
+        axisLine: axisStyle.axisLine,
+        splitLine: axisStyle.splitLine,
       },
       series: [
         {

--- a/libs/frontend/ui/src/lib/bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component.ts
+++ b/libs/frontend/ui/src/lib/bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component.ts
@@ -1,21 +1,18 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { EChartsOption } from 'echarts';
 import { NgxEchartsDirective } from 'ngx-echarts';
-
-
-const NAUTICAL_TEXT  = '#F5F0E8';
-const NAUTICAL_MUTED = '#8FA8C0';
-const NAUTICAL_GOLD  = '#C9A84C';
-const NAUTICAL_GRID  = 'rgba(201,168,76,0.1)';
-
-const colors = [
-  '#C9A84C',  // antique gold
-  '#1E6091',  // ocean blue
-  '#2ECC71',  // success green
-  '#E8D5B7',  // sand
-  '#8FA8C0',  // muted blue
-  '#E74C3C',  // coral red
-];
+import {
+  axisStyle,
+  baseGrid,
+  baseTitle,
+  baseTooltip,
+  formatMoney,
+  NAUTICAL_MUTED,
+  NAUTICAL_TEXT,
+  round2,
+  scrollLegend,
+  SERIES_COLORS,
+} from '../chart-theme';
 
 @Component({
   selector: 'aws-bar-chart-per-quarter-by-year',
@@ -39,43 +36,31 @@ export class BarChartPerQuarterByYearComponent implements OnChanges {
     return {
       backgroundColor: 'transparent',
       textStyle: { color: NAUTICAL_TEXT },
-      title: {
-        left: 'center',
-        text: 'Dividend',
-        textStyle: { color: NAUTICAL_TEXT },
-      },
-      grid: { containLabel: true },
-      tooltip: {
-        trigger: 'axis',
-        backgroundColor: '#0F2035',
-        borderColor: NAUTICAL_GOLD,
-        textStyle: { color: NAUTICAL_TEXT },
-        axisPointer: { type: 'shadow' },
-      },
-      legend: {
-        top: '10%',
-        data: this.series.map((serie) => serie.year),
-        textStyle: { color: NAUTICAL_MUTED },
-      },
+      title: baseTitle('Dividend'),
+      grid: baseGrid(72),
+      tooltip: baseTooltip('axis', {
+        valueFormatter: (value) => formatMoney(value as number, this.currencySymbol),
+      }),
+      legend: scrollLegend(40, this.series.map((serie) => serie.year)),
       xAxis: {
         type: 'category',
         data: ['Q1', 'Q2', 'Q3', 'Q4'],
-        axisLabel: { formatter: (value: string) => `${value}`, color: NAUTICAL_MUTED },
-        axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-        axisTick: { lineStyle: { color: NAUTICAL_GRID } },
+        axisLabel: { color: NAUTICAL_MUTED },
+        axisLine: axisStyle.axisLine,
+        axisTick: axisStyle.axisTick,
       },
       yAxis: {
         type: 'value',
         axisLabel: { formatter: `{value} ${this.currencySymbol}`, color: NAUTICAL_MUTED },
-        axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-        splitLine: { lineStyle: { color: NAUTICAL_GRID } },
+        axisLine: axisStyle.axisLine,
+        splitLine: axisStyle.splitLine,
       },
       series: this.series.map((serie, index) => ({
         name: serie.year,
         type: 'bar' as const,
-        data: serie.data,
+        data: serie.data.map((value) => round2(value)),
         itemStyle: {
-          color: colors[index % colors.length],
+          color: SERIES_COLORS[index % SERIES_COLORS.length],
         },
       })),
     };

--- a/libs/frontend/ui/src/lib/bar-chart/bar-chart.component.ts
+++ b/libs/frontend/ui/src/lib/bar-chart/bar-chart.component.ts
@@ -1,13 +1,18 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { EChartsOption } from 'echarts';
 import { NgxEchartsDirective } from 'ngx-echarts';
-
-
-const NAUTICAL_TEXT  = '#F5F0E8';
-const NAUTICAL_MUTED = '#8FA8C0';
-const NAUTICAL_GOLD  = '#C9A84C';
-const NAUTICAL_OCEAN = '#1E6091';
-const NAUTICAL_GRID  = 'rgba(201,168,76,0.1)';
+import {
+  axisStyle,
+  baseGrid,
+  baseTitle,
+  baseTooltip,
+  NAUTICAL_GOLD,
+  NAUTICAL_MUTED,
+  NAUTICAL_OCEAN,
+  NAUTICAL_TEXT,
+  round2,
+  scrollLegend,
+} from '../chart-theme';
 
 @Component({
   selector: 'aws-bar-chart',
@@ -35,42 +40,44 @@ export class BarChartComponent implements OnChanges {
     return {
       backgroundColor: 'transparent',
       textStyle: { color: NAUTICAL_TEXT },
-      title: {
-        left: 'center',
-        text: 'Annual Return',
-        textStyle: { color: NAUTICAL_TEXT },
-      },
-      grid: { containLabel: true },
-      tooltip: {
-        trigger: 'axis',
-        backgroundColor: '#0F2035',
-        borderColor: NAUTICAL_GOLD,
-        textStyle: { color: NAUTICAL_TEXT },
-        axisPointer: { type: 'shadow' },
-      },
-      legend: {
-        top: '10%',
-        textStyle: { color: NAUTICAL_MUTED },
-      },
+      title: baseTitle('Annual Return'),
+      grid: baseGrid(72),
+      tooltip: baseTooltip('axis', {
+        // Per-series units: '%' for the return bar, currency for the profit line.
+        formatter: (params) => {
+          const list = Array.isArray(params) ? params : [params];
+          if (!list.length) {
+            return '';
+          }
+          const rows = list
+            .map((p) => {
+              const unit = p.seriesName === 'Profit' ? ` ${this.currencySymbol}` : ' %';
+              return `${p.marker ?? ''} ${p.seriesName}: ${round2(p.value as number)}${unit}`;
+            })
+            .join('<br/>');
+          return `${list[0].name}<br/>${rows}`;
+        },
+      }),
+      legend: scrollLegend(40),
       xAxis: {
         type: 'category',
         data: this.series.years,
-        axisLine: { lineStyle: { color: NAUTICAL_GRID } },
         axisLabel: { color: NAUTICAL_MUTED },
-        axisTick: { lineStyle: { color: NAUTICAL_GRID } },
+        axisLine: axisStyle.axisLine,
+        axisTick: axisStyle.axisTick,
       },
       yAxis: [
         {
           type: 'value',
           axisLabel: { formatter: '{value} %', color: NAUTICAL_MUTED },
-          axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-          splitLine: { lineStyle: { color: NAUTICAL_GRID } },
+          axisLine: axisStyle.axisLine,
+          splitLine: axisStyle.splitLine,
         },
         {
           type: 'value',
           position: 'right',
           axisLabel: { formatter: `{value} ${this.currencySymbol}`, color: NAUTICAL_MUTED },
-          axisLine: { lineStyle: { color: NAUTICAL_GRID } },
+          axisLine: axisStyle.axisLine,
           splitLine: { show: false },
         },
       ],
@@ -78,14 +85,14 @@ export class BarChartComponent implements OnChanges {
         {
           name: 'Annual Return %',
           type: 'bar',
-          data: this.series.yields.map((value) => Math.round(value * 100) / 100),
+          data: this.series.yields.map((value) => round2(value)),
           itemStyle: { color: NAUTICAL_GOLD },
         },
         {
           name: 'Profit',
           type: 'line',
           yAxisIndex: 1,
-          data: this.series.profit.map((value) => Math.round(value * 100) / 100),
+          data: this.series.profit.map((value) => round2(value)),
           itemStyle: { color: NAUTICAL_OCEAN },
           lineStyle: { color: NAUTICAL_OCEAN, width: 2 },
           smooth: true,

--- a/libs/frontend/ui/src/lib/chart-theme.spec.ts
+++ b/libs/frontend/ui/src/lib/chart-theme.spec.ts
@@ -1,0 +1,51 @@
+import { formatAxisDate, formatMoney, round2, spanDays } from './chart-theme';
+
+describe('chart-theme helpers', () => {
+  describe('round2', () => {
+    it('rounds to 2 decimals', () => {
+      expect(round2(124.38000000002)).toBe(124.38);
+      expect(round2(124.327)).toBe(124.33);
+      expect(round2(124.324)).toBe(124.32);
+      expect(round2(10)).toBe(10);
+    });
+  });
+
+  describe('formatMoney', () => {
+    it('appends the symbol when provided', () => {
+      expect(formatMoney(124.38000000002, '€')).toBe('124.38 €');
+    });
+
+    it('omits the symbol when not provided', () => {
+      expect(formatMoney(124.38000000002)).toBe('124.38');
+    });
+
+    it('returns empty string for NaN', () => {
+      expect(formatMoney(NaN, '€')).toBe('');
+    });
+  });
+
+  describe('formatAxisDate', () => {
+    const ms = Date.UTC(2024, 5, 28); // 28 Jun 2024
+
+    it('shows the day for short spans (<= 1 year)', () => {
+      expect(formatAxisDate(ms, 90)).toBe('28 Jun 2024');
+    });
+
+    it("collapses to month-year for long spans", () => {
+      expect(formatAxisDate(ms, 1000)).toBe("Jun '24");
+    });
+  });
+
+  describe('spanDays', () => {
+    it('returns 0 for fewer than 2 dates', () => {
+      expect(spanDays([])).toBe(0);
+      expect(spanDays([new Date()])).toBe(0);
+    });
+
+    it('returns the day span between first and last date', () => {
+      const start = new Date(Date.UTC(2024, 0, 1));
+      const end = new Date(Date.UTC(2024, 0, 11));
+      expect(spanDays([start, new Date(Date.UTC(2024, 0, 5)), end])).toBe(10);
+    });
+  });
+});

--- a/libs/frontend/ui/src/lib/chart-theme.ts
+++ b/libs/frontend/ui/src/lib/chart-theme.ts
@@ -1,0 +1,123 @@
+import { EChartsOption, TooltipComponentOption } from 'echarts';
+
+/**
+ * Shared echarts theme for the dashboard charts. Centralises the nautical
+ * palette and the tooltip/grid/legend boilerplate that was previously
+ * copy-pasted across every chart component. Colours mirror the design tokens
+ * in `apps/frontend/tailwind.config.js`.
+ */
+
+export const NAUTICAL_TEXT = '#F5F0E8';
+export const NAUTICAL_MUTED = '#8FA8C0';
+export const NAUTICAL_GOLD = '#C9A84C';
+export const NAUTICAL_OCEAN = '#1E6091';
+export const NAUTICAL_GRID = 'rgba(201,168,76,0.1)';
+export const NAUTICAL_SURFACE = '#0F2035';
+
+/** Multi-series palette (one colour per series), cycled by index. */
+export const SERIES_COLORS = [
+  '#C9A84C', // antique gold
+  '#1E6091', // ocean blue
+  '#2ECC71', // success green
+  '#E8D5B7', // sand
+  '#8FA8C0', // muted blue
+  '#E74C3C', // coral red
+];
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/** Round a number to 2 decimals. */
+export const round2 = (value: number): number => Math.round(value * 100) / 100;
+
+/**
+ * Format a numeric value for a tooltip: rounded to 2 decimals with an optional
+ * currency/unit suffix. Empty string for NaN so hidden points read cleanly.
+ */
+export function formatMoney(value: number, symbol?: string): string {
+  if (value == null || Number.isNaN(value)) {
+    return '';
+  }
+  const rounded = round2(value);
+  return symbol ? `${rounded} ${symbol}` : `${rounded}`;
+}
+
+/**
+ * Readable date label for a time axis / tooltip header. Short spans get the day
+ * ("28 Jun 2024"); long spans collapse to month-year ("Jun '24").
+ */
+export function formatAxisDate(ms: number, spanDays: number): string {
+  const d = new Date(ms);
+  const month = d.toLocaleString('en-US', { month: 'short' });
+  if (spanDays <= 366) {
+    return `${d.getUTCDate()} ${month} ${d.getUTCFullYear()}`;
+  }
+  return `${month} '${d.getUTCFullYear().toString().slice(2, 4)}`;
+}
+
+/** Span in days between the first and last date of a series (0 if <2 points). */
+export function spanDays(dates: Date[]): number {
+  if (dates.length < 2) {
+    return 0;
+  }
+  const first = dates[0].getTime();
+  const last = dates[dates.length - 1].getTime();
+  return Math.abs(last - first) / MS_PER_DAY;
+}
+
+type Trigger = 'item' | 'axis';
+
+/** Shared tooltip config (dark surface, gold border, cream text). */
+export function baseTooltip(
+  trigger: Trigger,
+  extra: Partial<TooltipComponentOption> = {}
+): TooltipComponentOption {
+  return {
+    trigger,
+    backgroundColor: NAUTICAL_SURFACE,
+    borderColor: NAUTICAL_GOLD,
+    textStyle: { color: NAUTICAL_TEXT },
+    axisPointer: { type: 'shadow' },
+    ...extra,
+  };
+}
+
+/** Tight grid with explicit margins so the plot fills the card. */
+export function baseGrid(top: number): EChartsOption['grid'] {
+  return {
+    top,
+    left: 12,
+    right: 20,
+    bottom: 8,
+    containLabel: true,
+  };
+}
+
+/** Scrollable single-row legend that never wraps into the plot. */
+export function scrollLegend(top: number, data?: string[]): EChartsOption['legend'] {
+  return {
+    type: 'scroll',
+    top,
+    data,
+    textStyle: { color: NAUTICAL_MUTED },
+    pageTextStyle: { color: NAUTICAL_MUTED },
+    pageIconColor: NAUTICAL_GOLD,
+    pageIconInactiveColor: NAUTICAL_GRID,
+  };
+}
+
+/** Shared chart title config (centred, cream serif-ish heading). */
+export function baseTitle(text: string | undefined): EChartsOption['title'] {
+  return {
+    left: 'center',
+    text,
+    textStyle: { color: NAUTICAL_TEXT },
+  };
+}
+
+/** Shared axis line/label/tick styling for a category or value axis. */
+export const axisStyle = {
+  axisLine: { lineStyle: { color: NAUTICAL_GRID } },
+  axisLabel: { color: NAUTICAL_MUTED },
+  axisTick: { lineStyle: { color: NAUTICAL_GRID } },
+  splitLine: { lineStyle: { color: NAUTICAL_GRID } },
+};

--- a/libs/frontend/ui/src/lib/chart/chart.component.ts
+++ b/libs/frontend/ui/src/lib/chart/chart.component.ts
@@ -1,12 +1,19 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { EChartsOption } from 'echarts';
 import { NgxEchartsDirective } from 'ngx-echarts';
-
-
-const NAUTICAL_TEXT  = '#F5F0E8';
-const NAUTICAL_MUTED = '#8FA8C0';
-const NAUTICAL_GOLD  = '#C9A84C';
-const NAUTICAL_GRID  = 'rgba(201,168,76,0.1)';
+import {
+  axisStyle,
+  baseGrid,
+  baseTitle,
+  baseTooltip,
+  formatAxisDate,
+  formatMoney,
+  NAUTICAL_GOLD,
+  NAUTICAL_MUTED,
+  NAUTICAL_TEXT,
+  round2,
+  spanDays,
+} from '../chart-theme';
 
 @Component({
   selector: 'aws-chart',
@@ -29,67 +36,54 @@ export class ChartComponent implements OnChanges {
   }
 
   getChartOptions(): EChartsOption {
+    const symbol = this.money ? this.currencySymbol : undefined;
+    const span = spanDays(this.x);
+    // [timestamp, value] pairs let echarts' time axis pick relevant, period-aware
+    // ticks. NaN values (hidden quarters / gaps) keep their slot but draw nothing.
+    const data: [number, number][] = this.x.map((d, i) => [
+      d.getTime(),
+      round2(this.y[i]),
+    ]);
+
     return {
       backgroundColor: 'transparent',
       color: [NAUTICAL_GOLD, '#1E6091', '#2ECC71', '#E8D5B7', NAUTICAL_MUTED, '#E74C3C'],
       textStyle: { color: NAUTICAL_TEXT },
-      title: {
-        left: 'center',
-        text: this.label,
-        textStyle: { color: NAUTICAL_TEXT },
-      },
-      grid: {
-        top: 48,
-        containLabel: true,
-      },
-      tooltip: {
-        trigger: this.showSymbols ? 'item' : 'axis',
-        backgroundColor: '#0F2035',
-        borderColor: NAUTICAL_GOLD,
-        textStyle: { color: NAUTICAL_TEXT },
-        axisPointer: {
-          type: 'shadow',
+      title: baseTitle(this.label),
+      grid: baseGrid(56),
+      tooltip: baseTooltip(this.showSymbols ? 'item' : 'axis', {
+        formatter: (params) => {
+          const list = Array.isArray(params) ? params : [params];
+          if (list.length === 0) {
+            return '';
+          }
+          const value = list[0].value as [number, number];
+          const header = formatAxisDate(value[0], span);
+          const rows = list
+            .map((p) => {
+              const v = (p.value as [number, number])[1];
+              return `${p.marker ?? ''} ${formatMoney(v, symbol)}`;
+            })
+            .join('<br/>');
+          return `${header}<br/>${rows}`;
         },
+      }),
+      xAxis: {
+        type: 'time',
+        ...axisStyle,
       },
-      xAxis: [
-        {
-          type: 'category',
-          show: false,
-          data: this.x.map(
-            (x) =>
-              `${x.getDate()} ${x.toLocaleString('en-US', {
-                month: 'short',
-              })} ${x.getFullYear()}`
-          ),
-          axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-          axisLabel: { color: NAUTICAL_MUTED },
-        },
-        {
-          type: 'category',
-          position: 'bottom',
-          data: this.x.map(
-            (x) =>
-              `${x.toLocaleString('en-US', {
-                month: 'short',
-              })} '${x.getFullYear().toString().slice(2, 4)}`
-          ),
-          axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-          axisLabel: { color: NAUTICAL_MUTED },
-          axisTick: { lineStyle: { color: NAUTICAL_GRID } },
-        },
-      ],
       yAxis: {
         type: 'value',
         axisLabel: {
           formatter: `{value}${this.money ? ' ' + this.currencySymbol : ''}`,
           color: NAUTICAL_MUTED,
         },
-        axisLine: { lineStyle: { color: NAUTICAL_GRID } },
-        splitLine: { lineStyle: { color: NAUTICAL_GRID } },
+        axisLine: axisStyle.axisLine,
+        splitLine: axisStyle.splitLine,
       },
       series: [
         {
-          data: this.y.map((value) => Math.round(value * 100) / 100),
+          data,
           type: 'line',
           connectNulls: true,
           smooth: true,


### PR DESCRIPTION
## What & why

The dashboard charts had three UX problems (the shared Dividend screenshot showed all three):

1. **Wasted space + legend overlap** — fixed `height: 360px` + `grid: { containLabel: true }` only, so a wrapped multi-row legend (e.g. 7 years) spilled into the plot.
2. **Long decimals in tooltips** — no tooltip `valueFormatter`, and `bar-chart-per-quarter-by-year` didn't round its series at all (e.g. `124.38000000002`).
3. **Irrelevant x-axis labels** — the line chart used a hardcoded dual `category` axis (`"Jun '24"`) that didn't adapt to the selected time range.

## Changes

- **New `libs/frontend/ui/src/lib/chart-theme.ts`** — centralises the nautical palette and the previously copy-pasted tooltip/grid/legend boilerplate, plus pure formatting helpers (`round2`, `formatMoney`, `formatAxisDate`, `spanDays`). Covered by `chart-theme.spec.ts`.
- **Line `ChartComponent`** → echarts native `type: 'time'` axis; data as `[timestamp, value]`; tooltip shows a clean date header + 2-decimal values. Labels now adapt (days → months → years) to the selected range.
- **All charts** → `legend.type: 'scroll'` (single row, no overlap) with reserved `grid.top`, and tight explicit grid margins to remove the empty band.
- **`bar-chart-per-quarter-by-year`** rounds its series data (the long-decimal source) + 2-decimal tooltip.
- **`bar-chart`** (Annual Return) keeps per-series units in the tooltip (`%` for return, currency for profit).

Presentational only — no `portfolio.ts`/selector/formula changes (aggregate bar charts stay full-history by design), so no README/ARCHITECTURE update needed.

## Manual test checklist

For each section (Performance, Dividends, Holdings, Transactions):
- [ ] Dividend (per-quarter-by-year) legend no longer overlaps the bars; no large empty band at the top of the card.
- [ ] Hovering points/bars shows exactly 2 decimals (e.g. `124.38 €`), incl. the Dividend chart that previously showed long decimals.
- [ ] Annual Return tooltip shows `%` for the bar and currency for the profit line.
- [ ] Switching time-range chips (1M / 6M / 1Y / 5Y / ALL) makes line-chart x-axis labels adapt (days → months → years) and read cleanly with no duplicate/cramped labels.
- [ ] Discrete-point charts (Dividend per Quarter, Buy/Sell) still hide empty/zero points.

## Validation

`nx run-many -t lint test build --all` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)