### PR TITLE
feat(captain): "Ask the Captain" GenAI chat + dashboard insights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dynamodb.zip
 node_modules
 .venv
 
+# python bytecode
+__pycache__/
+*.pyc
+
 # IDEs and editors
 /.idea
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ node_modules
 __pycache__/
 *.pyc
 
+# local SAM env vars (contains the OpenAI API key) — never commit
+env.json
+
 # IDEs and editors
 /.idea
 .project

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,17 +15,20 @@ libs/
   frontend/ui/         Presentational components (dashboard, charts, tables, landing page)
   frontend/state/      NgRx "state" slice — portfolio transactions
   frontend/yahoo/      NgRx "yahoo" slice — price tickers
+  frontend/captain/    NgRx "captain" slice — "Ask the Captain" GenAI insights
   shared/util/         Framework-agnostic domain logic (pure, heavily unit-tested)
 services/
   handler_dynamodb.py  DynamoDB Lambda — CRUD + Cognito JWT auth
   handler_yahoo.py     Yahoo Finance Lambda — fan-out price fetch
-  shared/              Shared utilities (cors.py, auth.py)
+  handler_captain.py   Captain Lambda — OpenAI chat/insights + Cognito JWT auth
+  shared/              Shared utilities (cors.py, auth.py, secrets.py)
   requirements.txt     Python dependencies for all Lambdas
   init_dynamodb.py     One-time local dev table setup
 ```
 
 Module boundaries are enforced by `@nx/enforce-module-boundaries`. Dependencies flow one way:
-`ui` / `state` / `yahoo` → `util`; `yahoo` → `state` (never the reverse — see "Prices" below).
+`ui` / `state` / `yahoo` / `captain` → `util`; `yahoo` / `captain` → `state` (never the
+reverse — see "Prices" below). `captain` never imports `yahoo`.
 
 ## Data flow
 
@@ -86,16 +89,45 @@ a user can only read/write their own data.
 
 ## Backend
 
-Two Python 3.13 Lambdas behind one API Gateway:
+Three Python 3.13 Lambdas behind one API Gateway:
 
 - **dynamodb** (`handler_dynamodb.py`) — CRUD over the `sailor` table (partition key =
   Cognito `sub`); verifies the Cognito ID token's signature via JWKS; CORS via an origin allowlist
   that reflects the request `Origin`.
 - **yahoo** (`handler_yahoo.py`) — fans out to the Yahoo Finance API for the requested symbols
   (`ThreadPoolExecutor`, per-request timeout), returning per-symbol results.
+- **captain** (`handler_captain.py`) — verifies the Cognito ID token, then calls the OpenAI Chat
+  Completions API. The OpenAI key is read from an SSM Parameter Store SecureString (cached
+  module-level, like the JWKS cache), with an `OPENAI_API_KEY` env-var fallback for local dev.
+  See "Ask the Captain (GenAI)" below.
 
-`sam build` packages each handler with `services/requirements.txt` (PyJWT + cryptography);
-`boto3` is provided by the Lambda Python runtime and not bundled.
+`sam build` packages each handler with `services/requirements.txt` (PyJWT + cryptography +
+openai); `boto3` is provided by the Lambda Python runtime and not bundled.
+
+## Ask the Captain (GenAI)
+
+A sailing-themed assistant ("the Captain") that **explains** the user's portfolio in plain
+language — a chat panel plus an auto-generated, daily-cached "Captain's read" on the dashboard.
+
+- **Deterministic first, LLM second.** The client computes a compact summary
+  (`buildCaptainSummary`) and the biggest movers (`detectMovers`) from the existing `selectState`
+  view-model, then sends only that JSON — not raw time-series — to the Lambda. The model narrates;
+  it never computes. This keeps tokens (and cost) low and the numbers reproducible.
+- **No financial advice.** The Lambda's system prompt scopes answers to the provided summary and
+  refuses any advice/forecast/recommendation with a varied, funny sailing-themed deflection. A
+  persistent disclaimer reinforces this in the UI.
+- **Cost control.** Requests go through an authenticated Lambda (key server-side), use the cheapest
+  small model with a tight `max_tokens`, and the dashboard insight is cached per day + portfolio in
+  `localStorage`, so a reload or same-day revisit triggers no new call.
+- **Demo mode.** The public `/demo` page is unauthenticated, so it never calls the Lambda — the chat
+  and insight render canned, offline responses from `captain.demo.ts` (the same advice-refusal
+  behaviour, mirrored client-side).
+
+```
+component ─build summary (selectState)→ captain effect ─POST /captain→ handler_captain.py → OpenAI
+                                              │  demo? → canned reply, no network
+                                  loadInsights cache (localStorage, per day + portfolio)
+```
 
 ## Infrastructure & CI
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local sam local start-api
 
 Serves Lambda functions on `http://localhost:3000`. Re-run `sam build` after any Lambda change.
 
+> **Ask the Captain (OpenAI):** the `captain` Lambda needs an OpenAI API key. For local dev,
+> export `OPENAI_API_KEY=sk-...` in the terminal running `sam local start-api`. In production the
+> key lives in an SSM Parameter Store SecureString (free; no idle cost) — create it once:
+> `aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...`
+
 > **Tip:** The dummy credentials prevent `sam local` from failing on an expired AWS SSO session.
 > The Lambda talks to local DynamoDB with fake creds and never calls real AWS. Alternatively
 > run `aws sso login` to use real credentials.
@@ -80,8 +85,8 @@ Serves Lambda functions on `http://localhost:3000`. Re-run `sam build` after any
 nx serve frontend
 ```
 
-Open `http://localhost:4200`. The dev server proxies `/microservice` and `/yahoo_finance` to the
-SAM APIs on `:3000`.
+Open `http://localhost:4200`. The dev server proxies `/microservice`, `/yahoo_finance` and
+`/captain` to the SAM APIs on `:3000`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local sam local start-api
 
 Serves Lambda functions on `http://localhost:3000`. Re-run `sam build` after any Lambda change.
 
-> **Ask the Captain (OpenAI):** the `captain` Lambda needs an OpenAI API key. For local dev,
-> export `OPENAI_API_KEY=sk-...` in the terminal running `sam local start-api`. In production the
-> key lives in an SSM Parameter Store SecureString (free; no idle cost) — create it once:
-> `aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...`
+> **Ask the Captain (OpenAI):** the `captain` Lambda needs an OpenAI API key. It is read from the
+> `OPENAI_API_KEY` env var first, falling back to SSM — so:
+>
+> - **Local dev** — copy `env.json.example` to `env.json` (gitignored), paste your key, and pass it
+>   to SAM: `sam local start-api --env-vars env.json`. (Or just `export OPENAI_API_KEY=sk-...` in the
+>   shell instead.)
+> - **Production** — the key lives in an SSM Parameter Store SecureString (free; no idle cost), created
+>   once: `aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...`
 
 > **Tip:** The dummy credentials prevent `sam local` from failing on an expired AWS SSO session.
 > The Lambda talks to local DynamoDB with fake creds and never calls real AWS. Alternatively

--- a/apps/frontend/proxy.conf.json
+++ b/apps/frontend/proxy.conf.json
@@ -10,5 +10,11 @@
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
+  },
+  "/captain": {
+    "target": "http://localhost:3000",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
   }
 }

--- a/apps/frontend/src/app/app.module.ts
+++ b/apps/frontend/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { EffectsModule } from '@ngrx/effects';
 import { HttpClientModule } from '@angular/common/http';
 import { UiModule } from '@aws/ui';
 import { YahooModule } from '@aws/yahoo';
+import { CaptainModule } from '@aws/captain';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { environment } from '../environments/environment';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
@@ -30,6 +31,7 @@ import { JwtInterceptor } from '../auth/jwtInterceptor/JwtInterceptor';
     EffectsModule.forRoot(),
     StateModule,
     YahooModule,
+    CaptainModule,
     StoreDevtoolsModule.instrument({connectInZone: true}),
     UiModule,
     OverlayModule,

--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -5,6 +5,8 @@ export const environment = {
     'https://03y9xjgaaj.execute-api.us-east-1.amazonaws.com/prod/yahoo_finance',
   dynamoDBLambdaUrl:
     'https://03y9xjgaaj.execute-api.us-east-1.amazonaws.com/prod/microservice',
+  captainLambdaUrl:
+    'https://03y9xjgaaj.execute-api.us-east-1.amazonaws.com/prod/captain',
   cognito: {
     userPoolId: 'us-east-1_liCB4LgDE',
     clientId: '3o34bbl92faeo9ljo11eebtim2',

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -3,6 +3,7 @@ export const environment = {
   baseUrl: 'http://localhost:4200',
   yahooLambdaUrl: 'http://localhost:4200/yahoo_finance',
   dynamoDBLambdaUrl: 'http://localhost:4200/microservice',
+  captainLambdaUrl: 'http://localhost:4200/captain',
   cognito: {
     userPoolId: 'us-east-1_liCB4LgDE',
     clientId: '3o34bbl92faeo9ljo11eebtim2',

--- a/env.json.example
+++ b/env.json.example
@@ -1,0 +1,5 @@
+{
+  "Parameters": {
+    "OPENAI_API_KEY": "sk-replace-with-your-key"
+  }
+}

--- a/libs/frontend/captain/.eslintrc.json
+++ b/libs/frontend/captain/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "aws",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "aws",
+            "style": "kebab-case"
+          }
+        ],
+        "@angular-eslint/prefer-standalone": "off"
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/frontend/captain/README.md
+++ b/libs/frontend/captain/README.md
@@ -1,0 +1,6 @@
+# captain
+
+The "Ask the Captain" GenAI slice: an NgRx feature + HTTP service that send a
+compact, pre-computed portfolio summary to the Captain Lambda (OpenAI) and hold
+the chat thread and the daily-cached dashboard insight. Depends on `state` and
+`util` only (one-way), so the `state → never → yahoo` invariant is untouched.

--- a/libs/frontend/captain/jest.config.ts
+++ b/libs/frontend/captain/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+module.exports = {
+  displayName: 'captain',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../coverage/libs/frontend/captain',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/frontend/captain/project.json
+++ b/libs/frontend/captain/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "captain",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/frontend/captain/src",
+  "prefix": "aws",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/frontend/captain/jest.config.ts",
+        "passWithNoTests": true,
+        "tsConfig": "libs/frontend/captain/tsconfig.spec.json"
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/frontend/captain/**/*.ts",
+          "libs/frontend/captain/**/*.html"
+        ]
+      }
+    }
+  }
+}

--- a/libs/frontend/captain/src/index.ts
+++ b/libs/frontend/captain/src/index.ts
@@ -1,0 +1,6 @@
+export * from './lib/captain.module';
+export * from './lib/captain.types';
+export * from './lib/captain.demo';
+export * from './lib/captain-summary';
+export * from './lib/+state/captain.actions';
+export * from './lib/+state/captain.selectors';

--- a/libs/frontend/captain/src/lib/+state/captain.actions.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.actions.ts
@@ -1,0 +1,33 @@
+import { createAction, props } from '@ngrx/store';
+import { CaptainInsight } from '../captain.types';
+
+// --- Chat ("Ask the Captain") ---------------------------------------------
+
+export const sendMessage = createAction(
+  '[Captain] Send Message',
+  props<{ content: string; demo?: boolean }>()
+);
+export const sendMessageSuccess = createAction(
+  '[Captain] Send Message Success',
+  props<{ reply: string }>()
+);
+export const sendMessageFailure = createAction(
+  '[Captain] Send Message Failure',
+  props<{ error: string }>()
+);
+export const clearChat = createAction('[Captain] Clear Chat');
+
+// --- Dashboard insight (daily-cached) -------------------------------------
+
+export const loadInsights = createAction(
+  '[Captain] Load Insights',
+  props<{ demo?: boolean }>()
+);
+export const loadInsightsSuccess = createAction(
+  '[Captain] Load Insights Success',
+  props<{ insight: CaptainInsight }>()
+);
+export const loadInsightsFailure = createAction(
+  '[Captain] Load Insights Failure',
+  props<{ error: string }>()
+);

--- a/libs/frontend/captain/src/lib/+state/captain.effects.spec.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { Observable, of, take } from 'rxjs';
+import { Action } from '@ngrx/store';
+import { selectBaseCurrency, selectState } from '@aws/state';
+import { CaptainEffects } from './captain.effects';
+import { CaptainService } from '../captain.service';
+import { selectMessages } from './captain.selectors';
+import {
+  loadInsights,
+  loadInsightsSuccess,
+  sendMessage,
+  sendMessageSuccess,
+} from './captain.actions';
+import { buildCaptainSummary } from '../captain-summary';
+import { demoChatReply, DEMO_INSIGHT } from '../captain.demo';
+import { insightFingerprint, writeCachedInsight } from '../insights-cache';
+
+const ret = (a: number, p: number) => ({ absolute: a, percentage: p });
+
+const state = {
+  transactions: { stock: [], dividend: [], commission: [] },
+  dates: [],
+  currencies: ['EUR'],
+  summary: {
+    portfolioValue: 1000,
+    totalInvested: 800,
+    totalDividend: 0,
+    totalCommission: 0,
+    startDate: new Date('2024-01-01'),
+    dailyReturn: ret(0, 0),
+    weeklyReturn: ret(0, 0),
+    monthlyReturn: ret(0, 0),
+    totalReturn: ret(200, 25),
+  },
+  stocks: {},
+} as any;
+
+describe('CaptainEffects', () => {
+  let actions$: Observable<Action>;
+  let effects: CaptainEffects;
+  let service: { chat: jest.Mock; insights: jest.Mock };
+
+  function setup() {
+    localStorage.clear();
+    service = {
+      chat: jest.fn().mockReturnValue(of('live chat reply')),
+      insights: jest.fn().mockReturnValue(of('live narrative')),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        CaptainEffects,
+        provideMockActions(() => actions$),
+        provideMockStore(),
+        { provide: CaptainService, useValue: service },
+      ],
+    });
+    const store = TestBed.inject(MockStore);
+    store.overrideSelector(selectMessages, [{ role: 'user', content: 'hi' }]);
+    store.overrideSelector(selectState, state);
+    store.overrideSelector(selectBaseCurrency, 'EUR');
+    effects = TestBed.inject(CaptainEffects);
+  }
+
+  describe('sendMessage$', () => {
+    it('serves a canned reply in demo mode without calling the service', (done) => {
+      setup();
+      actions$ = of(sendMessage({ content: 'Should I sell?', demo: true }));
+      effects.sendMessage$.pipe(take(1)).subscribe((action) => {
+        expect(action).toEqual(
+          sendMessageSuccess({ reply: demoChatReply('Should I sell?') })
+        );
+        expect(service.chat).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('calls the service with the thread + summary when not demo', (done) => {
+      setup();
+      actions$ = of(sendMessage({ content: 'How did I do?' }));
+      effects.sendMessage$.pipe(take(1)).subscribe((action) => {
+        expect(action).toEqual(sendMessageSuccess({ reply: 'live chat reply' }));
+        expect(service.chat).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  describe('loadInsights$', () => {
+    it('returns the static demo insight without calling the service', (done) => {
+      setup();
+      actions$ = of(loadInsights({ demo: true }));
+      effects.loadInsights$.pipe(take(1)).subscribe((action) => {
+        expect(action).toEqual(loadInsightsSuccess({ insight: DEMO_INSIGHT }));
+        expect(service.insights).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('calls the service on a cache miss and stores the result', (done) => {
+      setup();
+      actions$ = of(loadInsights({}));
+      effects.loadInsights$.pipe(take(1)).subscribe((action: any) => {
+        expect(service.insights).toHaveBeenCalledTimes(1);
+        expect(action.insight.narrative).toBe('live narrative');
+        done();
+      });
+    });
+
+    it('uses the cached insight on a same-day hit — no service call (no spend)', (done) => {
+      setup();
+      const fingerprint = insightFingerprint(buildCaptainSummary(state, 'EUR'));
+      const cached = { narrative: 'cached read', generatedAt: '2026-06-03T00:00:00Z', fingerprint };
+      writeCachedInsight(cached);
+
+      actions$ = of(loadInsights({}));
+      effects.loadInsights$.pipe(take(1)).subscribe((action) => {
+        expect(action).toEqual(loadInsightsSuccess({ insight: cached }));
+        expect(service.insights).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+});

--- a/libs/frontend/captain/src/lib/+state/captain.effects.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.ts
@@ -1,0 +1,95 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
+import { selectBaseCurrency, selectState } from '@aws/state';
+import { CaptainService } from '../captain.service';
+import { buildCaptainSummary } from '../captain-summary';
+import { demoChatReply, DEMO_INSIGHT } from '../captain.demo';
+import {
+  insightFingerprint,
+  readCachedInsight,
+  writeCachedInsight,
+} from '../insights-cache';
+import {
+  loadInsights,
+  loadInsightsFailure,
+  loadInsightsSuccess,
+  sendMessage,
+  sendMessageFailure,
+  sendMessageSuccess,
+} from './captain.actions';
+import { selectMessages } from './captain.selectors';
+
+@Injectable()
+export class CaptainEffects {
+  private store = inject(Store);
+  private readonly actions$ = inject(Actions);
+  private readonly service = inject(CaptainService);
+
+  // Send the (already-appended) thread + a compact portfolio summary to the
+  // Lambda. Demo mode short-circuits to a canned reply — no network, no auth,
+  // no spend.
+  public readonly sendMessage$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(sendMessage),
+      withLatestFrom(
+        this.store.select(selectMessages),
+        this.store.select(selectState),
+        this.store.select(selectBaseCurrency)
+      ),
+      switchMap(([action, messages, state, currency]) => {
+        if (action.demo) {
+          return of(sendMessageSuccess({ reply: demoChatReply(action.content) }));
+        }
+        const summary = buildCaptainSummary(state, currency);
+        return this.service.chat(messages, summary).pipe(
+          map((reply) => sendMessageSuccess({ reply })),
+          catchError((error: HttpErrorResponse) =>
+            of(sendMessageFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+
+  // Generate the dashboard "Captain's read", cached per day + portfolio so a
+  // reload (or a same-day revisit) doesn't trigger another OpenAI call.
+  public readonly loadInsights$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(loadInsights),
+      withLatestFrom(
+        this.store.select(selectState),
+        this.store.select(selectBaseCurrency)
+      ),
+      switchMap(([action, state, currency]) => {
+        if (action.demo) {
+          return of(loadInsightsSuccess({ insight: DEMO_INSIGHT }));
+        }
+        const summary = buildCaptainSummary(state, currency);
+        const fingerprint = insightFingerprint(summary);
+
+        const cached = readCachedInsight();
+        if (cached && cached.fingerprint === fingerprint) {
+          return of(loadInsightsSuccess({ insight: cached }));
+        }
+
+        return this.service.insights(summary).pipe(
+          map((narrative) => {
+            const insight = {
+              narrative,
+              generatedAt: new Date().toISOString(),
+              fingerprint,
+            };
+            writeCachedInsight(insight);
+            return loadInsightsSuccess({ insight });
+          }),
+          catchError((error: HttpErrorResponse) =>
+            of(loadInsightsFailure({ error: error.message }))
+          )
+        );
+      })
+    )
+  );
+}

--- a/libs/frontend/captain/src/lib/+state/captain.reducer.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.reducer.ts
@@ -1,0 +1,71 @@
+import { createFeature, createReducer, on } from '@ngrx/store';
+import { ChatMessage, CaptainInsight } from '../captain.types';
+import {
+  clearChat,
+  loadInsights,
+  loadInsightsFailure,
+  loadInsightsSuccess,
+  sendMessage,
+  sendMessageFailure,
+  sendMessageSuccess,
+} from './captain.actions';
+
+export const featureKey = 'captain';
+
+export interface FeatureState {
+  messages: ChatMessage[];
+  chatLoading: boolean;
+  chatError: string | null;
+  insight: CaptainInsight | null;
+  insightLoading: boolean;
+  insightError: string | null;
+}
+
+export const initialState: FeatureState = {
+  messages: [],
+  chatLoading: false,
+  chatError: null,
+  insight: null,
+  insightLoading: false,
+  insightError: null,
+};
+
+export const reducer = createReducer(
+  initialState,
+  // Append the user's message immediately so the thread updates optimistically.
+  on(sendMessage, (state, { content }) => ({
+    ...state,
+    messages: [...state.messages, { role: 'user' as const, content }],
+    chatLoading: true,
+    chatError: null,
+  })),
+  on(sendMessageSuccess, (state, { reply }) => ({
+    ...state,
+    messages: [...state.messages, { role: 'assistant' as const, content: reply }],
+    chatLoading: false,
+  })),
+  on(sendMessageFailure, (state, { error }) => ({
+    ...state,
+    chatLoading: false,
+    chatError: error,
+  })),
+  on(clearChat, (state) => ({ ...state, messages: [], chatError: null })),
+
+  on(loadInsights, (state) => ({
+    ...state,
+    insightLoading: true,
+    insightError: null,
+  })),
+  on(loadInsightsSuccess, (state, { insight }) => ({
+    ...state,
+    insight,
+    insightLoading: false,
+  })),
+  on(loadInsightsFailure, (state, { error }) => ({
+    ...state,
+    insightLoading: false,
+    insightError: error,
+  }))
+);
+
+export const feature = createFeature({ name: featureKey, reducer });

--- a/libs/frontend/captain/src/lib/+state/captain.selectors.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.selectors.ts
@@ -1,0 +1,34 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { FeatureState, featureKey } from './captain.reducer';
+
+export const selectFeature = createFeatureSelector<FeatureState>(featureKey);
+
+export const selectMessages = createSelector(
+  selectFeature,
+  (state) => state.messages
+);
+
+export const selectChatLoading = createSelector(
+  selectFeature,
+  (state) => state.chatLoading
+);
+
+export const selectChatError = createSelector(
+  selectFeature,
+  (state) => state.chatError
+);
+
+export const selectInsight = createSelector(
+  selectFeature,
+  (state) => state.insight
+);
+
+export const selectInsightLoading = createSelector(
+  selectFeature,
+  (state) => state.insightLoading
+);
+
+export const selectInsightError = createSelector(
+  selectFeature,
+  (state) => state.insightError
+);

--- a/libs/frontend/captain/src/lib/captain-summary.spec.ts
+++ b/libs/frontend/captain/src/lib/captain-summary.spec.ts
@@ -1,0 +1,98 @@
+import { PortfolioState, Return, Stock, Summary } from '@aws/util';
+import { buildCaptainSummary, detectMovers } from './captain-summary';
+import { CaptainHolding } from './captain.types';
+
+const ret = (absolute: number, percentage: number): Return => ({
+  absolute,
+  percentage,
+});
+
+function stock(ticker: string, overrides: Partial<Stock['summary']>): Stock {
+  return {
+    ticker,
+    transactions: { stock: [], dividend: [], commission: [] },
+    chartData: {} as Stock['chartData'],
+    currency: { value: 'EUR' },
+    summary: {
+      portfolioValue: 0,
+      totalInvested: 0,
+      totalDividend: 0,
+      totalCommission: 0,
+      amountOfShares: 0,
+      averageSharePrice: 0,
+      currentSharePrice: 0,
+      dailyReturn: ret(0, 0),
+      weeklyReturn: ret(0, 0),
+      monthlyReturn: ret(0, 0),
+      totalReturn: ret(0, 0),
+      ...overrides,
+    },
+  } as Stock;
+}
+
+const summary: Summary = {
+  portfolioValue: 1000,
+  totalInvested: 800,
+  totalDividend: 25,
+  totalCommission: 5,
+  startDate: new Date('2024-01-01'),
+  dailyReturn: ret(1.234, 0.123),
+  weeklyReturn: ret(10, 1),
+  monthlyReturn: ret(40, 4),
+  totalReturn: ret(200, 25),
+};
+
+const state: PortfolioState = {
+  transactions: { stock: [], dividend: [], commission: [] },
+  dates: [],
+  currencies: ['EUR'],
+  summary,
+  stocks: {
+    AAA: stock('AAA', { portfolioValue: 700, amountOfShares: 7, weeklyReturn: ret(8, 1.2), monthlyReturn: ret(20, 3), totalReturn: ret(100, 16.5) }),
+    BBB: stock('BBB', { portfolioValue: 300, amountOfShares: 30, weeklyReturn: ret(-20, -8.4), monthlyReturn: ret(-10, -3), totalReturn: ret(50, 9) }),
+  },
+};
+
+describe('buildCaptainSummary', () => {
+  it('flattens portfolio totals and rounds to 2 decimals', () => {
+    const result = buildCaptainSummary(state, 'EUR');
+    expect(result.currency).toBe('EUR');
+    expect(result.portfolio.value).toBe(1000);
+    expect(result.portfolio.dailyReturn).toEqual({ absolute: 1.23, percentage: 0.12 });
+    expect(result.holdings).toHaveLength(2);
+  });
+
+  it('computes allocation as a percentage of total value', () => {
+    const result = buildCaptainSummary(state, 'EUR');
+    const aaa = result.holdings.find((h) => h.ticker === 'AAA');
+    expect(aaa?.allocationPct).toBe(70);
+  });
+
+  it('guards against divide-by-zero when total value is 0', () => {
+    const empty = {
+      ...state,
+      summary: { ...summary, portfolioValue: 0 },
+      stocks: { AAA: stock('AAA', { portfolioValue: 0 }) },
+    };
+    const result = buildCaptainSummary(empty, 'EUR');
+    expect(result.holdings[0].allocationPct).toBe(0);
+  });
+});
+
+describe('detectMovers', () => {
+  const holdings: CaptainHolding[] = [
+    { ticker: 'AAA', value: 700, allocationPct: 70, shares: 7, weeklyReturnPct: 1.2, monthlyReturnPct: 3, totalReturnPct: 16.5 },
+    { ticker: 'BBB', value: 300, allocationPct: 30, shares: 30, weeklyReturnPct: -8.4, monthlyReturnPct: -3, totalReturnPct: 9 },
+  ];
+
+  it('ranks by the absolute size of the weekly move', () => {
+    const movers = detectMovers(holdings);
+    expect(movers[0].ticker).toBe('BBB');
+  });
+
+  it('flags moves of >= 5% as notable', () => {
+    const movers = detectMovers(holdings);
+    expect(movers.find((m) => m.ticker === 'BBB')?.notable).toBe(true);
+    expect(movers.find((m) => m.ticker === 'AAA')?.notable).toBe(false);
+  });
+});

--- a/libs/frontend/captain/src/lib/captain-summary.ts
+++ b/libs/frontend/captain/src/lib/captain-summary.ts
@@ -1,0 +1,76 @@
+import { PortfolioState, Return } from '@aws/util';
+import { CaptainHolding, CaptainSummary } from './captain.types';
+
+const round2 = (n: number): number =>
+  Number.isFinite(n) ? Math.round(n * 100) / 100 : 0;
+
+const roundReturn = (r: Return): Return => ({
+  absolute: round2(r.absolute),
+  percentage: round2(r.percentage),
+});
+
+// A holding whose 1-week move is at least this large (either direction) is
+// flagged "notable" — the deterministic seed for the insight narrative.
+const NOTABLE_WEEKLY_PCT = 5;
+const MAX_NOTABLE_MOVERS = 3;
+
+/**
+ * Rank holdings by the size of their one-week move (largest first) and flag the
+ * ones past {@link NOTABLE_WEEKLY_PCT}. Pure and deterministic so the "biggest
+ * movers / unexpected rises and drops" come from code, not the model.
+ */
+export function detectMovers(
+  holdings: CaptainHolding[]
+): { ticker: string; weeklyReturnPct: number; notable: boolean }[] {
+  return [...holdings]
+    .sort((a, b) => Math.abs(b.weeklyReturnPct) - Math.abs(a.weeklyReturnPct))
+    .slice(0, MAX_NOTABLE_MOVERS)
+    .map((h) => ({
+      ticker: h.ticker,
+      weeklyReturnPct: h.weeklyReturnPct,
+      notable: Math.abs(h.weeklyReturnPct) >= NOTABLE_WEEKLY_PCT,
+    }));
+}
+
+/**
+ * Flatten the computed portfolio view-model (as returned by `selectState`) into
+ * the compact {@link CaptainSummary} sent to the Captain Lambda.
+ */
+export function buildCaptainSummary(
+  state: PortfolioState,
+  currency: string
+): CaptainSummary {
+  const { summary, stocks } = state;
+  const totalValue = summary.portfolioValue;
+
+  const holdings: CaptainHolding[] = Object.values(stocks).map((stock) => {
+    const s = stock.summary;
+    return {
+      ticker: stock.ticker,
+      value: round2(s.portfolioValue),
+      allocationPct:
+        totalValue > 0 ? round2((s.portfolioValue / totalValue) * 100) : 0,
+      shares: round2(s.amountOfShares),
+      weeklyReturnPct: round2(s.weeklyReturn.percentage),
+      monthlyReturnPct: round2(s.monthlyReturn.percentage),
+      totalReturnPct: round2(s.totalReturn.percentage),
+    };
+  });
+
+  return {
+    currency,
+    asOf: new Date().toISOString().slice(0, 10),
+    portfolio: {
+      value: round2(summary.portfolioValue),
+      invested: round2(summary.totalInvested),
+      dividend: round2(summary.totalDividend),
+      commission: round2(summary.totalCommission),
+      dailyReturn: roundReturn(summary.dailyReturn),
+      weeklyReturn: roundReturn(summary.weeklyReturn),
+      monthlyReturn: roundReturn(summary.monthlyReturn),
+      totalReturn: roundReturn(summary.totalReturn),
+    },
+    holdings,
+    notableMovers: detectMovers(holdings),
+  };
+}

--- a/libs/frontend/captain/src/lib/captain.demo.spec.ts
+++ b/libs/frontend/captain/src/lib/captain.demo.spec.ts
@@ -1,0 +1,50 @@
+import {
+  ADVICE_DEFLECTIONS,
+  demoChatReply,
+  isAdviceRequest,
+} from './captain.demo';
+
+describe('isAdviceRequest', () => {
+  it.each([
+    'Should I sell NVDA?',
+    'should i buy more?',
+    'Will the market go up tomorrow?',
+    'Whats your forecast for next year?',
+    'Is AAPL a good investment?',
+    'What do you think I should do?',
+  ])('flags advice/forecast prompt: "%s"', (prompt) => {
+    expect(isAdviceRequest(prompt)).toBe(true);
+  });
+
+  it.each([
+    'How did I do this week?',
+    'What is my biggest holding?',
+    'Explain my dividends',
+  ])('does not flag a factual prompt: "%s"', (prompt) => {
+    expect(isAdviceRequest(prompt)).toBe(false);
+  });
+});
+
+describe('demoChatReply', () => {
+  it('deflects an advice request with a sailing-themed line', () => {
+    const reply = demoChatReply('Should I sell everything?');
+    expect(ADVICE_DEFLECTIONS).toContain(reply);
+  });
+
+  it('is deterministic for the same prompt', () => {
+    const a = demoChatReply('will it crash?');
+    const b = demoChatReply('will it crash?');
+    expect(a).toBe(b);
+  });
+
+  it('answers a known factual prompt about dividends', () => {
+    expect(demoChatReply('Explain my dividends').toLowerCase()).toContain(
+      'dividend'
+    );
+  });
+
+  it('falls back to a helpful prompt when nothing matches', () => {
+    const reply = demoChatReply('hello there captain');
+    expect(reply.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/frontend/captain/src/lib/captain.demo.ts
+++ b/libs/frontend/captain/src/lib/captain.demo.ts
@@ -1,0 +1,95 @@
+import { CaptainInsight } from './captain.types';
+
+/**
+ * Static, offline responses for the public /demo page. The demo is
+ * unauthenticated and the Captain Lambda requires auth, so demo mode never
+ * calls OpenAI — these canned, sailing-flavoured replies stand in. The
+ * advice-refusal behaviour mirrors the Lambda's system-prompt guardrail.
+ */
+
+// Funny, varied sailing-themed deflections for any advice/forecast request.
+export const ADVICE_DEFLECTIONS: string[] = [
+  "That I can't chart for you — let's see where the waves take us. ⚓",
+  'Forecasting the markets? I left my crystal ball ashore. I can tell you where you have sailed, not where the wind blows next.',
+  'I read the wake, not the horizon — no course-setting from this captain. 🧭',
+  'Buy or sell? You are the helmsman here — I only point out what is on the charts behind us.',
+  'The seas ahead are nobody’s to predict. I share what your logbook shows, not what tomorrow’s tide brings.',
+];
+
+const ADVICE_PATTERNS: RegExp[] = [
+  /\bshould i\b/,
+  /\b(buy|sell|hold)\b/,
+  /\b(will|gonna|going to)\b.*\b(go|rise|drop|fall|crash|moon)\b/,
+  /\b(forecast|predict|prediction|outlook|future)\b/,
+  /\b(worth (it|buying)|good (investment|buy|stock)|bad (investment|buy))\b/,
+  /\b(recommend|advice|advise|price target|what do you think)\b/,
+];
+
+/** True when the prompt is asking for advice, an opinion or a forecast. */
+export function isAdviceRequest(text: string): boolean {
+  const t = text.toLowerCase();
+  return ADVICE_PATTERNS.some((re) => re.test(t));
+}
+
+// Keyword → canned factual answer about the demo portfolio.
+const DEMO_QA: { match: RegExp; reply: string }[] = [
+  {
+    match: /\b(week|weekly|this week|recent)\b/,
+    reply:
+      'Steady sailing this week, captain — the demo portfolio is up around +1.4%, riding the same upward swell it has held all year. 📈',
+  },
+  {
+    match: /\b(biggest|largest|top) (holding|position)\b|allocation/,
+    reply:
+      'Your largest position carries roughly a third of the demo portfolio’s value — a well-ballasted ship, with the rest spread across smaller holdings.',
+  },
+  {
+    match: /\b(moved|mover|move|biggest change|rise|drop|gain|loss)\b/,
+    reply:
+      'The biggest mover this week climbed about +6% — a brisk gust in its sails — while the rest of the fleet drifted gently along.',
+  },
+  {
+    match: /\bdividend/,
+    reply:
+      'Dividends drip in quarterly in this demo, and the trailing-twelve-month total has been climbing each quarter — a tidy following current of income. 💧',
+  },
+  {
+    match: /\b(total|overall|how am i doing|performance|return)\b/,
+    reply:
+      'All told, the demo portfolio sits comfortably in profit — up roughly +18% on what was invested, dividends included.',
+  },
+];
+
+const DEMO_FALLBACK =
+  'I can read out what is on the demo charts — your value, returns, biggest movers and dividends. Pick one of the prompts below and I’ll tell you what I see. 🧭';
+
+/** Deterministic so tests and renders are stable. */
+function pickDeflection(text: string): string {
+  return ADVICE_DEFLECTIONS[text.length % ADVICE_DEFLECTIONS.length];
+}
+
+/** The Captain's canned reply for the demo page (no network call). */
+export function demoChatReply(text: string): string {
+  if (isAdviceRequest(text)) {
+    return pickDeflection(text);
+  }
+  const t = text.toLowerCase();
+  const hit = DEMO_QA.find((qa) => qa.match.test(t));
+  return hit ? hit.reply : DEMO_FALLBACK;
+}
+
+/** Ready-to-use prompt chips shown in the chat panel. */
+export const CAPTAIN_PROMPTS: string[] = [
+  'How did I do this week?',
+  'What is my biggest holding?',
+  'Which holding moved the most?',
+  'Explain my dividends',
+];
+
+/** Static "Captain's read" for the demo dashboard banner. */
+export const DEMO_INSIGHT: CaptainInsight = {
+  narrative:
+    'A calm, profitable voyage so far: the portfolio is up about +18% overall with dividends climbing each quarter. This week’s strongest gust lifted the top mover near +6%, while the largest holding holds steady at roughly a third of the fleet. ⚓',
+  generatedAt: new Date().toISOString(),
+  fingerprint: 'demo',
+};

--- a/libs/frontend/captain/src/lib/captain.module.ts
+++ b/libs/frontend/captain/src/lib/captain.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { CaptainEffects } from './+state/captain.effects';
+import { feature } from './+state/captain.reducer';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    StoreModule.forFeature(feature),
+    EffectsModule.forFeature([CaptainEffects]),
+  ],
+})
+export class CaptainModule {}

--- a/libs/frontend/captain/src/lib/captain.schemas.ts
+++ b/libs/frontend/captain/src/lib/captain.schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// Validate the Captain Lambda response before it reaches the UI — a malformed
+// payload would otherwise render as `undefined` in the chat.
+const captainReplySchema = z.object({ reply: z.string() });
+
+export function parseCaptainReply(raw: unknown): string {
+  return captainReplySchema.parse(raw).reply;
+}

--- a/libs/frontend/captain/src/lib/captain.service.spec.ts
+++ b/libs/frontend/captain/src/lib/captain.service.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { CaptainService } from './captain.service';
+import { CaptainSummary } from './captain.types';
+
+const summary = { currency: 'EUR', holdings: [], notableMovers: [] } as unknown as CaptainSummary;
+
+describe('CaptainService', () => {
+  let service: CaptainService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        CaptainService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: 'ENVIRONMENT', useValue: { captainLambdaUrl: '/captain' } },
+      ],
+    });
+    service = TestBed.inject(CaptainService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('posts a chat request and resolves to the reply', (done) => {
+    service.chat([{ role: 'user', content: 'How did I do?' }], summary).subscribe((reply) => {
+      expect(reply).toBe('Aye, all is well.');
+      done();
+    });
+    const req = httpMock.expectOne('/captain');
+    expect(req.request.body.mode).toBe('chat');
+    req.flush({ reply: 'Aye, all is well.' });
+  });
+
+  it('posts an insights request in insights mode', (done) => {
+    service.insights(summary).subscribe((reply) => {
+      expect(reply).toBe('Calm seas.');
+      done();
+    });
+    const req = httpMock.expectOne('/captain');
+    expect(req.request.body.mode).toBe('insights');
+    req.flush({ reply: 'Calm seas.' });
+  });
+
+  it('rejects a malformed payload (zod)', (done) => {
+    service.insights(summary).subscribe({
+      next: () => done.fail('should not succeed'),
+      error: (err) => {
+        expect(err).toBeDefined();
+        done();
+      },
+    });
+    httpMock.expectOne('/captain').flush({ notReply: true });
+  });
+});

--- a/libs/frontend/captain/src/lib/captain.service.ts
+++ b/libs/frontend/captain/src/lib/captain.service.ts
@@ -1,0 +1,43 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { map, Observable, timeout } from 'rxjs';
+import { retryWithBackoff } from '@aws/util';
+import { ChatMessage, CaptainSummary } from './captain.types';
+import { parseCaptainReply } from './captain.schemas';
+
+// The Captain Lambda calls OpenAI, which can be slower than the DynamoDB CRUD
+// path; give it the same headroom as the Yahoo fan-out.
+const CAPTAIN_TIMEOUT_MS = 35_000;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CaptainService {
+  private environment = inject<any>('ENVIRONMENT' as any);
+  private http = inject(HttpClient);
+
+  /** Send the chat thread + portfolio summary, resolve to the Captain's reply. */
+  public chat(
+    messages: ChatMessage[],
+    summary: CaptainSummary
+  ): Observable<string> {
+    const body = { mode: 'chat', messages, summary };
+    return this.post(body);
+  }
+
+  /** Ask for the dashboard "Captain's read" narrative. */
+  public insights(summary: CaptainSummary): Observable<string> {
+    const body = { mode: 'insights', summary };
+    return this.post(body);
+  }
+
+  private post(body: unknown): Observable<string> {
+    return this.http
+      .post<unknown>(this.environment.captainLambdaUrl, body)
+      .pipe(
+        timeout(CAPTAIN_TIMEOUT_MS),
+        retryWithBackoff(),
+        map((response) => parseCaptainReply(response))
+      );
+  }
+}

--- a/libs/frontend/captain/src/lib/captain.types.ts
+++ b/libs/frontend/captain/src/lib/captain.types.ts
@@ -1,0 +1,51 @@
+import { Return } from '@aws/util';
+
+/** A single turn in the chat thread sent to / shown by the Captain. */
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** One holding, flattened to just the figures the Captain narrates. */
+export interface CaptainHolding {
+  ticker: string;
+  value: number;
+  /** Share of total portfolio value, as a percentage. */
+  allocationPct: number;
+  shares: number;
+  weeklyReturnPct: number;
+  monthlyReturnPct: number;
+  totalReturnPct: number;
+}
+
+/**
+ * The compact, pre-computed payload sent to the Captain Lambda. Everything is
+ * derived client-side and rounded so the prompt stays small (low token cost)
+ * and the numbers are reproducible — the model only narrates, it never computes.
+ */
+export interface CaptainSummary {
+  currency: string;
+  asOf: string;
+  portfolio: {
+    value: number;
+    invested: number;
+    dividend: number;
+    commission: number;
+    dailyReturn: Return;
+    weeklyReturn: Return;
+    monthlyReturn: Return;
+    totalReturn: Return;
+  };
+  holdings: CaptainHolding[];
+  /** Deterministically ranked biggest movers, to seed the insight. */
+  notableMovers: { ticker: string; weeklyReturnPct: number; notable: boolean }[];
+}
+
+/** The dashboard's daily "Captain's read", cached in localStorage. */
+export interface CaptainInsight {
+  narrative: string;
+  /** ISO timestamp of when it was generated. */
+  generatedAt: string;
+  /** Identifies the date + portfolio state it was generated for (cache key). */
+  fingerprint: string;
+}

--- a/libs/frontend/captain/src/lib/insights-cache.spec.ts
+++ b/libs/frontend/captain/src/lib/insights-cache.spec.ts
@@ -1,0 +1,47 @@
+import { CaptainSummary } from './captain.types';
+import {
+  insightFingerprint,
+  readCachedInsight,
+  writeCachedInsight,
+} from './insights-cache';
+
+const summary = (value: number, holdings: { ticker: string; value: number }[]): CaptainSummary =>
+  ({
+    currency: 'EUR',
+    asOf: '2026-06-03',
+    portfolio: { value } as CaptainSummary['portfolio'],
+    holdings: holdings.map((h) => ({ ...h, allocationPct: 0, shares: 0, weeklyReturnPct: 0, monthlyReturnPct: 0, totalReturnPct: 0 })),
+    notableMovers: [],
+  }) as CaptainSummary;
+
+describe('insightFingerprint', () => {
+  it('is stable for the same portfolio on the same day', () => {
+    const s = summary(1000, [{ ticker: 'AAA', value: 700 }]);
+    expect(insightFingerprint(s)).toBe(insightFingerprint(s));
+  });
+
+  it('changes when a holding value changes', () => {
+    const a = insightFingerprint(summary(1000, [{ ticker: 'AAA', value: 700 }]));
+    const b = insightFingerprint(summary(1000, [{ ticker: 'AAA', value: 750 }]));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('insight cache', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips an insight through localStorage', () => {
+    const insight = { narrative: 'calm seas', generatedAt: '2026-06-03T00:00:00Z', fingerprint: 'fp' };
+    writeCachedInsight(insight);
+    expect(readCachedInsight()).toEqual(insight);
+  });
+
+  it('returns null when nothing is cached', () => {
+    expect(readCachedInsight()).toBeNull();
+  });
+
+  it('returns null on corrupt cache data', () => {
+    localStorage.setItem('captain.insight', '{not json');
+    expect(readCachedInsight()).toBeNull();
+  });
+});

--- a/libs/frontend/captain/src/lib/insights-cache.ts
+++ b/libs/frontend/captain/src/lib/insights-cache.ts
@@ -1,0 +1,33 @@
+import { CaptainInsight, CaptainSummary } from './captain.types';
+
+const CACHE_KEY = 'captain.insight';
+
+/**
+ * A stable key for "this portfolio, today". Same portfolio on the same calendar
+ * day → same fingerprint → cache hit → no OpenAI call (survives page reloads).
+ * A changed value/holding or a new day → new fingerprint → regenerate.
+ */
+export function insightFingerprint(summary: CaptainSummary): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const holdings = summary.holdings
+    .map((h) => `${h.ticker}:${h.value}`)
+    .join('|');
+  return `${today}|${summary.portfolio.value}|${holdings}`;
+}
+
+export function readCachedInsight(): CaptainInsight | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    return raw ? (JSON.parse(raw) as CaptainInsight) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedInsight(insight: CaptainInsight): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(insight));
+  } catch {
+    // localStorage unavailable (private mode / quota) — skip caching silently.
+  }
+}

--- a/libs/frontend/captain/src/test-setup.ts
+++ b/libs/frontend/captain/src/test-setup.ts
@@ -1,0 +1,10 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();

--- a/libs/frontend/captain/tsconfig.json
+++ b/libs/frontend/captain/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/frontend/captain/tsconfig.lib.json
+++ b/libs/frontend/captain/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/frontend/captain/tsconfig.spec.json
+++ b/libs/frontend/captain/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "preserve",
+    "target": "es2016",
+    "types": ["jest", "node"],
+    "moduleResolution": "bundler",
+    "isolatedModules": true
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/frontend/ui/src/index.ts
+++ b/libs/frontend/ui/src/index.ts
@@ -8,3 +8,5 @@ export * from './lib/settings/settings.component';
 export * from './lib/landing-page/landing-page.component';
 export * from './lib/demo/demo.component';
 export * from './lib/reveal-on-scroll/reveal-on-scroll.directive';
+export * from './lib/captain-panel/captain-panel.component';
+export * from './lib/insights-banner/insights-banner.component';

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
@@ -1,0 +1,67 @@
+<div class="captain">
+  <!-- Header -->
+  <header class="captain-header">
+    <div class="captain-title">
+      <lucide-icon name="Ship" [size]="22"></lucide-icon>
+      <div>
+        <h2>Ask the Captain</h2>
+        <p class="captain-subtitle">A plain-language read of your charts.</p>
+      </div>
+    </div>
+    <button class="icon-btn" (click)="close()" aria-label="Close">
+      <lucide-icon name="X" [size]="20"></lucide-icon>
+    </button>
+  </header>
+
+  <!-- Conversation -->
+  <div class="captain-messages">
+    @if ((messages$ | async)?.length) {
+      @for (msg of messages$ | async; track $index) {
+        <div class="bubble" [class.user]="msg.role === 'user'" [class.captain-bubble]="msg.role === 'assistant'">
+          {{ msg.content }}
+        </div>
+      }
+    } @else {
+      <div class="captain-welcome">
+        <lucide-icon name="Compass" [size]="28"></lucide-icon>
+        <p>Ahoy! Ask me what your numbers are doing — or tap a prompt below.</p>
+      </div>
+    }
+
+    @if (loading$ | async) {
+      <div class="bubble captain-bubble typing">
+        <span></span><span></span><span></span>
+      </div>
+    }
+
+    @if (error$ | async; as error) {
+      <div class="captain-error">The Captain couldn't reply just now. Try again shortly.</div>
+    }
+  </div>
+
+  <!-- Ready-to-use prompts -->
+  <div class="captain-prompts">
+    @for (prompt of prompts; track prompt) {
+      <button class="prompt-chip" (click)="send(prompt)" type="button">{{ prompt }}</button>
+    }
+  </div>
+
+  <!-- Input -->
+  <div class="captain-input">
+    <input
+      type="text"
+      [(ngModel)]="draft"
+      (keyup.enter)="send(draft)"
+      placeholder="Ask about your portfolio…"
+      aria-label="Message the Captain"
+    />
+    <button class="send-btn" (click)="send(draft)" [disabled]="!draft.trim()" aria-label="Send">
+      <lucide-icon name="Send" [size]="18"></lucide-icon>
+    </button>
+  </div>
+
+  <!-- Disclaimer -->
+  <p class="captain-disclaimer">
+    The Captain shares facts about your portfolio, not financial advice.
+  </p>
+</div>

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
@@ -1,0 +1,213 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+:host {
+  display: block;
+  background: $color-bg-elevated;
+  width: 100%;
+}
+
+.captain {
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+  min-width: 320px;
+}
+
+.captain-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 20px 14px;
+  border-bottom: 1px solid $color-border;
+
+  lucide-icon {
+    color: $color-gold;
+  }
+}
+
+.captain-title {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+
+  h2 {
+    @include serif-heading;
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 0;
+  }
+}
+
+.captain-subtitle {
+  margin: 2px 0 0;
+  font-size: 0.78rem;
+  color: $color-muted;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  color: $color-muted;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: $radius-sm;
+  transition: $transition-base;
+
+  &:hover {
+    color: $color-cream;
+  }
+}
+
+.captain-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 200px;
+}
+
+.captain-welcome {
+  margin: auto;
+  text-align: center;
+  color: $color-muted;
+  max-width: 280px;
+
+  lucide-icon {
+    color: $color-gold;
+    margin-bottom: 8px;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9rem;
+  }
+}
+
+.bubble {
+  max-width: 85%;
+  padding: 10px 14px;
+  border-radius: $radius-md;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.user {
+  align-self: flex-end;
+  background: $accent-gradient;
+  color: $color-bg-base;
+  font-weight: 500;
+}
+
+.captain-bubble {
+  align-self: flex-start;
+  background: $color-bg-surface;
+  border: 1px solid $color-border;
+  color: $color-cream;
+}
+
+.typing {
+  display: flex;
+  gap: 4px;
+
+  span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: $color-muted;
+    animation: bounce 1.2s infinite ease-in-out;
+
+    &:nth-child(2) { animation-delay: 0.15s; }
+    &:nth-child(3) { animation-delay: 0.3s; }
+  }
+}
+
+@keyframes bounce {
+  0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-3px); }
+}
+
+.captain-error {
+  align-self: center;
+  color: $color-error;
+  font-size: 0.82rem;
+}
+
+.captain-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 20px 12px;
+}
+
+.prompt-chip {
+  background: $color-bg-surface;
+  border: 1px solid $color-border-strong;
+  color: $color-sand;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.78rem;
+  font-family: $font-sans;
+  cursor: pointer;
+  transition: $transition-base;
+
+  &:hover {
+    border-color: $color-gold;
+    color: $color-cream;
+  }
+}
+
+.captain-input {
+  display: flex;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid $color-border;
+
+  input {
+    flex: 1;
+    background: $color-bg-surface;
+    border: 1px solid $color-border-strong;
+    border-radius: $radius-sm;
+    padding: 10px 14px;
+    color: $color-cream;
+    font-family: $font-sans;
+    font-size: 0.9rem;
+    outline: none;
+    transition: $transition-base;
+
+    &::placeholder { color: rgba($color-muted, 0.5); }
+    &:focus {
+      border-color: $color-gold;
+      box-shadow: $shadow-focus-gold;
+    }
+  }
+}
+
+.send-btn {
+  background: $accent-gradient;
+  border: none;
+  border-radius: $radius-sm;
+  color: $color-bg-base;
+  padding: 0 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  transition: $transition-base;
+
+  &[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.captain-disclaimer {
+  margin: 0;
+  padding: 0 20px 16px;
+  font-size: 0.7rem;
+  color: $color-muted;
+  text-align: center;
+}

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.spec.ts
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { Store } from '@ngrx/store';
+import { sendMessage, clearChat } from '@aws/captain';
+import { CaptainPanelComponent } from './captain-panel.component';
+import { DialogRef, DIALOG_DATA, DIALOG_REF } from '../dialog/dialog-ref';
+
+describe('CaptainPanelComponent', () => {
+  let component: CaptainPanelComponent;
+  let store: MockStore;
+  let dispatch: jest.SpyInstance;
+  let dialogRef: DialogRef<CaptainPanelComponent>;
+
+  function setup(data: { demo?: boolean } = {}) {
+    dialogRef = new DialogRef<CaptainPanelComponent>();
+    TestBed.configureTestingModule({
+      imports: [CaptainPanelComponent],
+      providers: [
+        provideMockStore(),
+        { provide: DIALOG_REF, useValue: dialogRef },
+        { provide: DIALOG_DATA, useValue: data },
+      ],
+    });
+    const fixture = TestBed.createComponent(CaptainPanelComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    dispatch = jest.spyOn(store, 'dispatch');
+  }
+
+  it('dispatches sendMessage with the trimmed content and clears the draft', () => {
+    setup();
+    component.draft = '  How did I do?  ';
+    component.send(component.draft);
+    expect(dispatch).toHaveBeenCalledWith(
+      sendMessage({ content: 'How did I do?', demo: undefined })
+    );
+    expect(component.draft).toBe('');
+  });
+
+  it('forwards the demo flag from dialog data', () => {
+    setup({ demo: true });
+    component.send('What is my biggest holding?');
+    expect(dispatch).toHaveBeenCalledWith(
+      sendMessage({ content: 'What is my biggest holding?', demo: true })
+    );
+  });
+
+  it('ignores an empty or whitespace-only message', () => {
+    setup();
+    component.send('   ');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('clear() dispatches clearChat', () => {
+    setup();
+    component.clear();
+    expect(dispatch).toHaveBeenCalledWith(clearChat());
+  });
+
+  it('close() closes the dialog', () => {
+    setup();
+    const spy = jest.spyOn(dialogRef, 'close');
+    component.close();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.ts
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.ts
@@ -1,0 +1,61 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { LucideAngularModule } from 'lucide-angular';
+import { Store } from '@ngrx/store';
+import {
+  CAPTAIN_PROMPTS,
+  clearChat,
+  selectChatError,
+  selectChatLoading,
+  selectMessages,
+  sendMessage,
+} from '@aws/captain';
+import { DialogRef, DIALOG_DATA, DIALOG_REF } from '../dialog/dialog-ref';
+
+export type CaptainPanelData = {
+  /** Demo mode serves canned replies and never calls the Lambda. */
+  demo?: boolean;
+};
+
+/**
+ * "Ask the Captain" chat panel. Wired to the global `captain` NgRx slice; when
+ * opened in demo mode the same actions resolve to canned, offline replies (see
+ * the captain effects), so this one component serves both the app and /demo.
+ */
+@Component({
+  selector: 'aws-captain-panel',
+  standalone: true,
+  imports: [CommonModule, FormsModule, LucideAngularModule],
+  templateUrl: './captain-panel.component.html',
+  styleUrls: ['./captain-panel.component.scss'],
+})
+export class CaptainPanelComponent {
+  private store = inject(Store);
+  dialogRef = inject<DialogRef<CaptainPanelComponent>>(DIALOG_REF);
+  data = inject<CaptainPanelData>(DIALOG_DATA);
+
+  readonly prompts = CAPTAIN_PROMPTS;
+  messages$ = this.store.select(selectMessages);
+  loading$ = this.store.select(selectChatLoading);
+  error$ = this.store.select(selectChatError);
+
+  draft = '';
+
+  send(content: string): void {
+    const text = content.trim();
+    if (!text) {
+      return;
+    }
+    this.store.dispatch(sendMessage({ content: text, demo: this.data?.demo }));
+    this.draft = '';
+  }
+
+  clear(): void {
+    this.store.dispatch(clearChat());
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -54,6 +54,12 @@
     @if (vm.loading) {
       <div class="computing-bar"></div>
     }
+    <!-- Captain's read (auto, daily-cached) — only when there are holdings -->
+    @if ((vm.state?.stocks | keyvalue)?.length) {
+      <section class="page-section">
+        <aws-insights-banner></aws-insights-banner>
+      </section>
+    }
     <section class="page-section">
       <aws-summary [summary]="vm.state?.summary" [currency]="vm.currency ?? 'EUR'"></aws-summary>
     </section>

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -14,12 +14,13 @@ import { Store } from '@ngrx/store';
 import { SummaryComponent } from '../summary/summary.component';
 import { AsyncPipe, CommonModule, DatePipe } from '@angular/common';
 import { ActiveTickersComponent } from '../active-tickers/active-tickers.component';
+import { InsightsBannerComponent } from '../insights-banner/insights-banner.component';
 
 @Component({
   selector: 'aws-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent],
+  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent, InsightsBannerComponent],
 })
 export class DashboardComponent {
   private store = inject(Store);

--- a/libs/frontend/ui/src/lib/demo/demo.component.html
+++ b/libs/frontend/ui/src/lib/demo/demo.component.html
@@ -31,6 +31,15 @@
       </p>
     </div>
 
+    <!-- Captain's read (static demo narrative) + chat launcher -->
+    <div class="demo-captain">
+      <aws-insights-banner [demo]="true"></aws-insights-banner>
+      <button class="btn btn-secondary demo-captain-btn" (click)="openCaptain()" type="button">
+        <lucide-icon name="Ship" [size]="18"></lucide-icon>
+        Ask the Captain
+      </button>
+    </div>
+
     <!-- Headline metrics -->
     <aws-summary [summary]="summary" [currency]="currency"></aws-summary>
 

--- a/libs/frontend/ui/src/lib/demo/demo.component.scss
+++ b/libs/frontend/ui/src/lib/demo/demo.component.scss
@@ -148,3 +148,17 @@
   .demo-badge { display: none; }
   .demo-intro h1 { font-size: 2rem; }
 }
+
+.demo-captain {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.demo-captain-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/libs/frontend/ui/src/lib/demo/demo.component.ts
+++ b/libs/frontend/ui/src/lib/demo/demo.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { LucideAngularModule } from 'lucide-angular';
@@ -9,6 +9,9 @@ import { BarAndLineChartComponent } from '../bar-and-line-chart/bar-and-line-cha
 import { BarChartPerQuarterByYearComponent } from '../bar-chart-per-quarter-by-year/bar-chart-per-quarter-by-year.component';
 import { SummaryComponent } from '../summary/summary.component';
 import { ScrollingTextComponent } from '../scrolling-text/scrolling-text.component';
+import { InsightsBannerComponent } from '../insights-banner/insights-banner.component';
+import { CaptainPanelComponent } from '../captain-panel/captain-panel.component';
+import { DialogService } from '../dialog/dialog.service';
 import {
   buildDemoAnnualReturns,
   buildDemoQuarterlyDividends,
@@ -36,11 +39,14 @@ import {
     BarChartPerQuarterByYearComponent,
     SummaryComponent,
     ScrollingTextComponent,
+    InsightsBannerComponent,
   ],
   templateUrl: './demo.component.html',
   styleUrl: './demo.component.scss',
 })
 export class DemoComponent {
+  private readonly dialog = inject(DialogService);
+
   readonly currency = 'EUR';
   readonly currencySymbol = '€';
 
@@ -60,4 +66,12 @@ export class DemoComponent {
     buildDemoQuarterlyDividends();
   readonly ttmDividends: { yearQuarters: YearQuarter[]; dividends: number[] } =
     buildDemoTtmDividends();
+
+  // Opens "Ask the Captain" in demo mode — canned, offline replies, no API call.
+  openCaptain(): void {
+    this.dialog.open(CaptainPanelComponent, {
+      width: '440px',
+      data: { demo: true },
+    });
+  }
 }

--- a/libs/frontend/ui/src/lib/icons.ts
+++ b/libs/frontend/ui/src/lib/icons.ts
@@ -22,6 +22,8 @@ import {
   ArrowRight,
   Sparkles,
   LineChart,
+  Send,
+  X,
 } from 'lucide-angular';
 
 export const APP_ICONS = {
@@ -48,4 +50,6 @@ export const APP_ICONS = {
   ArrowRight,
   Sparkles,
   LineChart,
+  Send,
+  X,
 };

--- a/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.html
+++ b/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.html
@@ -1,0 +1,23 @@
+@if ((insight$ | async); as insight) {
+  <div class="insight">
+    <div class="insight-icon">
+      <lucide-icon name="Compass" [size]="20"></lucide-icon>
+    </div>
+    <div class="insight-body">
+      <span class="insight-label">The Captain's read</span>
+      <p class="insight-text">{{ insight.narrative }}</p>
+      <span class="insight-note">Facts about your portfolio, not financial advice.</span>
+    </div>
+  </div>
+} @else if (loading$ | async) {
+  <div class="insight insight-loading">
+    <div class="insight-icon">
+      <lucide-icon name="Compass" [size]="20"></lucide-icon>
+    </div>
+    <div class="insight-body">
+      <span class="insight-label">The Captain's read</span>
+      <div class="shimmer"></div>
+      <div class="shimmer short"></div>
+    </div>
+  </div>
+}

--- a/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.scss
+++ b/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.scss
@@ -1,0 +1,64 @@
+@use 'tokens' as *;
+@use 'mixins' as *;
+
+.insight {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  background: linear-gradient(135deg, rgba($color-gold, 0.07), rgba($color-gold, 0.02));
+  border: 1px solid $color-border;
+  border-radius: $radius-md;
+  padding: 16px 18px;
+}
+
+.insight-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba($color-gold, 0.12);
+  color: $color-gold;
+}
+
+.insight-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.insight-label {
+  @include serif-heading;
+  font-size: 0.95rem;
+  color: $color-gold;
+}
+
+.insight-text {
+  margin: 0;
+  color: $color-cream;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.insight-note {
+  font-size: 0.7rem;
+  color: $color-muted;
+}
+
+.shimmer {
+  height: 12px;
+  width: 100%;
+  border-radius: $radius-sm;
+  background: linear-gradient(90deg, rgba($color-muted, 0.1), rgba($color-muted, 0.25), rgba($color-muted, 0.1));
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+
+  &.short { width: 60%; }
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.spec.ts
+++ b/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { selectState } from '@aws/state';
+import { loadInsights } from '@aws/captain';
+import { InsightsBannerComponent } from './insights-banner.component';
+
+describe('InsightsBannerComponent', () => {
+  let component: InsightsBannerComponent;
+  let store: MockStore;
+  let dispatch: jest.SpyInstance;
+
+  function setup(portfolioValue: number) {
+    TestBed.configureTestingModule({
+      imports: [InsightsBannerComponent],
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: selectState, value: { summary: { portfolioValue } } },
+          ],
+        }),
+      ],
+    });
+    const fixture = TestBed.createComponent(InsightsBannerComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    dispatch = jest.spyOn(store, 'dispatch');
+  }
+
+  it('dispatches the demo insight immediately in demo mode', () => {
+    setup(0);
+    component.demo = true;
+    component.ngOnInit();
+    expect(dispatch).toHaveBeenCalledWith(loadInsights({ demo: true }));
+  });
+
+  it('waits for a funded portfolio before asking (no spend on empty)', () => {
+    setup(0);
+    component.ngOnInit();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('asks for the insight once the portfolio has value', () => {
+    setup(1234);
+    component.ngOnInit();
+    expect(dispatch).toHaveBeenCalledWith(loadInsights({}));
+  });
+});

--- a/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.ts
+++ b/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.ts
@@ -1,0 +1,53 @@
+import { Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { LucideAngularModule } from 'lucide-angular';
+import { Store } from '@ngrx/store';
+import { filter, take } from 'rxjs';
+import { selectState } from '@aws/state';
+import {
+  loadInsights,
+  selectInsight,
+  selectInsightLoading,
+} from '@aws/captain';
+
+/**
+ * The dashboard's "Captain's read": a short, auto-generated narrative about the
+ * portfolio. The result is cached per day + portfolio (in the captain slice /
+ * localStorage), so this triggers at most one OpenAI call per day. In demo mode
+ * it renders a static narrative with no network call.
+ */
+@Component({
+  selector: 'aws-insights-banner',
+  standalone: true,
+  imports: [CommonModule, LucideAngularModule],
+  templateUrl: './insights-banner.component.html',
+  styleUrls: ['./insights-banner.component.scss'],
+})
+export class InsightsBannerComponent implements OnInit {
+  /** When true, render the static demo narrative and never call the Lambda. */
+  @Input() demo = false;
+
+  private store = inject(Store);
+  private destroyRef = inject(DestroyRef);
+
+  insight$ = this.store.select(selectInsight);
+  loading$ = this.store.select(selectInsightLoading);
+
+  ngOnInit(): void {
+    if (this.demo) {
+      this.store.dispatch(loadInsights({ demo: true }));
+      return;
+    }
+    // Wait until the portfolio has a real value (prices loaded) before asking,
+    // so the narrative reflects funded holdings and we spend only once.
+    this.store
+      .select(selectState)
+      .pipe(
+        filter((state) => state.summary.portfolioValue > 0),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.store.dispatch(loadInsights({})));
+  }
+}

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
@@ -6,6 +6,10 @@
       <lucide-icon name="Menu" [size]="20"></lucide-icon>
     </button>
     <aws-scrolling-text></aws-scrolling-text>
+    <button class="captain-btn" (click)="openCaptain()" aria-label="Ask the Captain">
+      <lucide-icon name="Ship" [size]="18"></lucide-icon>
+      <span class="captain-btn-label">Ask the Captain</span>
+    </button>
   </header>
 
   <!-- ── Loading bar ──────────────────────────────────────────────────────── -->

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.scss
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.scss
@@ -52,6 +52,34 @@ aws-scrolling-text {
   min-width: 0;
 }
 
+.captain-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 10px 0 6px;
+  padding: 7px 14px;
+  background: rgba($color-gold, 0.1);
+  border: 1px solid $color-border-strong;
+  border-radius: 999px;
+  cursor: pointer;
+  color: $color-gold;
+  font-family: $font-sans;
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: $transition-base;
+
+  &:hover {
+    background: rgba($color-gold, 0.18);
+    color: $color-gold-light;
+  }
+
+  .is-mobile & .captain-btn-label {
+    display: none;
+  }
+}
+
 // ─── Loading bar ──────────────────────────────────────────────────────────────
 .loading-bar {
   height: 4px;

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.ts
@@ -6,6 +6,8 @@ import { getData, selectLoading } from '@aws/state';
 import { ScrollingTextComponent } from '../scrolling-text/scrolling-text.component';
 import { CommonModule } from '@angular/common';
 import { LucideAngularModule } from 'lucide-angular';
+import { DialogService } from '../dialog/dialog.service';
+import { CaptainPanelComponent } from '../captain-panel/captain-panel.component';
 
 @Component({
   selector: 'aws-page-wrapper',
@@ -21,6 +23,7 @@ import { LucideAngularModule } from 'lucide-angular';
 export class PageWrapperComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private store = inject(Store);
+  private readonly dialog = inject(DialogService);
 
   loading$ = this.store.select(selectLoading);
   mobileQuery: MediaQueryList;
@@ -51,6 +54,10 @@ export class PageWrapperComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.store.dispatch(getData());
+  }
+
+  openCaptain(): void {
+    this.dialog.open(CaptainPanelComponent, { width: '440px' });
   }
 
   ngOnDestroy(): void {

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -3,6 +3,11 @@ version = 0.1
 # Deploy with:  sam deploy --config-env prod
 # (CodeUri points at the esbuild output, so run `node libs/backend/lambdas/build.mjs`
 #  first — the buildspec does this in CI.)
+#
+# The Captain Lambda reads the OpenAI API key from the SSM SecureString named by
+# OpenAIParamName (default /sailor/openai-api-key). Create it once, out of band:
+#   aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...
+# For local dev, export OPENAI_API_KEY in the shell running `sam local start-api`.
 
 [default.deploy.parameters]
 stack_name = "sailor"

--- a/services/handler_captain.py
+++ b/services/handler_captain.py
@@ -1,0 +1,164 @@
+import json
+import os
+
+from shared.auth import verify_token
+from shared.cors import build_headers
+from shared.secrets import get_openai_api_key
+
+# Cheapest small chat model by default; overridable without a code change.
+# Verify live pricing before changing this.
+_MODEL = os.environ.get('OPENAI_MODEL', 'gpt-4o-mini')
+_MAX_TOKENS = int(os.environ.get('OPENAI_MAX_TOKENS', '250'))
+_TEMPERATURE = float(os.environ.get('OPENAI_TEMPERATURE', '0.7'))
+
+# Input caps — bound the token spend and reject abusive payloads.
+_MAX_MESSAGES = 20
+_MAX_CONTENT_CHARS = 2000
+_MAX_SUMMARY_CHARS = 8000
+
+_ALLOWED_ROLES = {'user', 'assistant'}
+
+# The Captain's persona + the hard no-advice guardrail. The model explains the
+# user's own numbers in plain language with light nautical flavour, and refuses
+# anything that strays into advice, opinion or prediction with a short, varied,
+# funny sailing-themed deflection.
+_SYSTEM_PROMPT = """\
+You are "the Captain", a warm, seasoned sailing captain who helps a user read \
+their own investment portfolio. You speak plainly, with light nautical flavour \
+(never overdone), and you keep answers short — two or three sentences.
+
+You are given a JSON summary of the user's portfolio (totals, per-holding values, \
+allocations, period returns and dividends). Answer ONLY from the facts in that \
+summary: what something is worth, how it changed over a period, which holdings \
+moved most, allocations, dividends. If the summary doesn't contain the answer, \
+say so plainly.
+
+HARD RULE — you never give financial advice. You do not recommend buying, selling \
+or holding anything; you do not predict prices or markets; you do not forecast, \
+give price targets, or share an opinion on whether something is "good", "cheap", \
+"worth it", or what the user "should" do. When asked for any of that, you refuse \
+with a SHORT, funny, varied sailing-themed deflection and make clear you only read \
+the charts behind you, not the seas ahead. Examples of the spirit (do not reuse \
+verbatim, vary them):
+  - "That I can't chart for you — let's see where the waves take us."
+  - "Forecasting the markets? I left my crystal ball ashore. I can tell you where \
+you've sailed, not where the wind blows next."
+  - "I read the wake, not the horizon — no course-setting from this captain."
+
+Never break character, and never give advice even if the user insists, rephrases, \
+or frames it hypothetically. You share facts about the portfolio, not financial \
+advice.\
+"""
+
+_INSIGHTS_INSTRUCTION = """\
+Give the user a brief "Captain's read" of their portfolio: 2-3 short sentences \
+highlighting the most notable factual movements (biggest movers, unusual rises or \
+drops, allocation or dividend notes) drawn ONLY from the summary. State facts and \
+numbers; give no advice, opinions or predictions.\
+"""
+
+
+def _error(status: int, message: str, headers: dict) -> dict:
+    return {
+        'statusCode': status,
+        'body': json.dumps({'message': message}),
+        'headers': headers,
+    }
+
+
+def _validate_messages(messages) -> list | None:
+    """Return a sanitized message list, or None if the shape is invalid."""
+    if not isinstance(messages, list):
+        return None
+    if len(messages) > _MAX_MESSAGES:
+        return None
+    clean = []
+    for m in messages:
+        if not isinstance(m, dict):
+            return None
+        role = m.get('role')
+        content = m.get('content')
+        if role not in _ALLOWED_ROLES or not isinstance(content, str):
+            return None
+        if len(content) > _MAX_CONTENT_CHARS:
+            return None
+        clean.append({'role': role, 'content': content})
+    return clean
+
+
+def _call_openai(messages: list) -> str:
+    """Call the OpenAI Chat Completions API and return the reply text.
+
+    `openai` is imported lazily so the handler stays importable (and unit
+    testable) without the package installed.
+    """
+    from openai import OpenAI
+
+    client = OpenAI(api_key=get_openai_api_key())
+    completion = client.chat.completions.create(
+        model=_MODEL,
+        messages=messages,
+        max_tokens=_MAX_TOKENS,
+        temperature=_TEMPERATURE,
+    )
+    return (completion.choices[0].message.content or '').strip()
+
+
+def handler(event, context):
+    headers = build_headers(event)
+
+    if event.get('httpMethod') == 'OPTIONS':
+        return {'statusCode': 200, 'body': '', 'headers': headers}
+
+    # Auth — the Captain reads the user's own portfolio, so require a valid token.
+    token = (event.get('headers') or {}).get('Authorization') or \
+            (event.get('headers') or {}).get('authorization')
+    if not token:
+        return _error(401, 'Unauthorized: Missing token', headers)
+    try:
+        verify_token(token)
+    except Exception as exc:
+        return _error(401, f'Unauthorized: {exc}', headers)
+
+    try:
+        body = json.loads(event.get('body') or '{}')
+    except Exception:
+        return _error(400, 'Invalid JSON body', headers)
+
+    mode = body.get('mode', 'chat')
+    if mode not in ('chat', 'insights'):
+        return _error(400, "Field 'mode' must be 'chat' or 'insights'", headers)
+
+    summary = body.get('summary')
+    if not isinstance(summary, dict):
+        return _error(400, "Field 'summary' must be an object", headers)
+    summary_json = json.dumps(summary, default=str)
+    if len(summary_json) > _MAX_SUMMARY_CHARS:
+        return _error(400, 'Portfolio summary is too large', headers)
+
+    user_messages = _validate_messages(body.get('messages', []))
+    if user_messages is None:
+        return _error(400, "Field 'messages' is malformed", headers)
+    if mode == 'chat' and not user_messages:
+        return _error(400, "Chat mode requires at least one message", headers)
+
+    chat_messages = [
+        {'role': 'system', 'content': _SYSTEM_PROMPT},
+        {'role': 'system', 'content': f'Portfolio summary (JSON):\n{summary_json}'},
+    ]
+    if mode == 'insights':
+        chat_messages.append({'role': 'user', 'content': _INSIGHTS_INSTRUCTION})
+    else:
+        chat_messages.extend(user_messages)
+
+    try:
+        reply = _call_openai(chat_messages)
+    except Exception as exc:
+        print(f'OpenAI call failed: {exc}')
+        return _error(502, 'The Captain is below deck — try again shortly.', headers)
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'reply': reply}),
+        'headers': headers,
+    }

--- a/services/handler_captain.py
+++ b/services/handler_captain.py
@@ -9,7 +9,10 @@ from shared.secrets import get_openai_api_key
 # Verify live pricing before changing this.
 _MODEL = os.environ.get('OPENAI_MODEL', 'gpt-4o-mini')
 _MAX_TOKENS = int(os.environ.get('OPENAI_MAX_TOKENS', '250'))
-_TEMPERATURE = float(os.environ.get('OPENAI_TEMPERATURE', '0.7'))
+# Left unset by default: newer models only accept the default temperature and
+# reject an explicit value. Set OPENAI_TEMPERATURE to opt in on models that
+# support it.
+_TEMPERATURE = os.environ.get('OPENAI_TEMPERATURE')
 
 # Input caps — bound the token spend and reject abusive payloads.
 _MAX_MESSAGES = 20
@@ -95,12 +98,15 @@ def _call_openai(messages: list) -> str:
     from openai import OpenAI
 
     client = OpenAI(api_key=get_openai_api_key())
-    completion = client.chat.completions.create(
-        model=_MODEL,
-        messages=messages,
-        max_tokens=_MAX_TOKENS,
-        temperature=_TEMPERATURE,
-    )
+    kwargs = {
+        'model': _MODEL,
+        'messages': messages,
+        # Newer models require max_completion_tokens; max_tokens is rejected.
+        'max_completion_tokens': _MAX_TOKENS,
+    }
+    if _TEMPERATURE is not None:
+        kwargs['temperature'] = float(_TEMPERATURE)
+    completion = client.chat.completions.create(**kwargs)
     return (completion.choices[0].message.content or '').strip()
 
 

--- a/services/requirements-dev.txt
+++ b/services/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 boto3>=1.35.0
+pytest>=8.0.0

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -1,2 +1,3 @@
 PyJWT[cryptography]>=2.8.0
 cryptography>=41.0.0
+openai>=1.0.0

--- a/services/shared/secrets.py
+++ b/services/shared/secrets.py
@@ -1,0 +1,40 @@
+import os
+
+# Module-level cache: populated on first lookup, reused across warm-start
+# invocations (mirrors the JWKS cache in shared/auth.py).
+_openai_api_key: str | None = None
+
+
+def get_openai_api_key() -> str:
+    """Return the OpenAI API key.
+
+    Resolution order:
+      1. ``OPENAI_API_KEY`` env var — used for local dev / `sam local`, where
+         SSM isn't reachable.
+      2. The SSM Parameter Store SecureString named by ``OPENAI_PARAM_NAME``
+         (prod). Standard parameters + the AWS-managed ``aws/ssm`` key are free,
+         which keeps the idle cost at zero.
+
+    Raises RuntimeError if neither is configured.
+    """
+    global _openai_api_key
+    if _openai_api_key:
+        return _openai_api_key
+
+    env_key = os.environ.get('OPENAI_API_KEY')
+    if env_key:
+        _openai_api_key = env_key
+        return _openai_api_key
+
+    param_name = os.environ.get('OPENAI_PARAM_NAME')
+    if param_name:
+        import boto3  # provided by the Lambda runtime
+
+        ssm = boto3.client('ssm')
+        resp = ssm.get_parameter(Name=param_name, WithDecryption=True)
+        _openai_api_key = resp['Parameter']['Value']
+        return _openai_api_key
+
+    raise RuntimeError(
+        'No OpenAI API key configured: set OPENAI_API_KEY or OPENAI_PARAM_NAME'
+    )

--- a/services/test_handler_captain.py
+++ b/services/test_handler_captain.py
@@ -1,0 +1,151 @@
+"""Unit tests for the Captain Lambda's request handling.
+
+Run from the services/ directory:  pytest test_handler_captain.py
+
+Auth and the OpenAI call are monkeypatched, so these run offline without a
+Cognito token or an OpenAI key.
+"""
+import json
+
+import handler_captain
+
+
+def _event(method='POST', body=None, token='valid-token'):
+    headers = {'origin': 'http://localhost:4200'}
+    if token is not None:
+        headers['Authorization'] = token
+    return {
+        'httpMethod': method,
+        'headers': headers,
+        'body': None if body is None else json.dumps(body),
+    }
+
+
+def _patch_ok(monkeypatch, capture=None):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'user-1'})
+
+    def fake_call(messages):
+        if capture is not None:
+            capture.extend(messages)
+        return 'Aye, your portfolio is up.'
+
+    monkeypatch.setattr(handler_captain, '_call_openai', fake_call)
+
+
+def test_options_preflight_skips_auth():
+    resp = handler_captain.handler(_event(method='OPTIONS', token=None), None)
+    assert resp['statusCode'] == 200
+
+
+def test_missing_token_returns_401():
+    resp = handler_captain.handler(_event(body={'summary': {}}, token=None), None)
+    assert resp['statusCode'] == 401
+
+
+def test_invalid_token_returns_401(monkeypatch):
+    def boom(token):
+        raise ValueError('bad token')
+
+    monkeypatch.setattr(handler_captain, 'verify_token', boom)
+    resp = handler_captain.handler(_event(body={'summary': {}}), None)
+    assert resp['statusCode'] == 401
+
+
+def test_invalid_json_body_returns_400(monkeypatch):
+    _patch_ok(monkeypatch)
+    event = _event()
+    event['body'] = '{not json'
+    resp = handler_captain.handler(event, None)
+    assert resp['statusCode'] == 400
+
+
+def test_missing_summary_returns_400(monkeypatch):
+    _patch_ok(monkeypatch)
+    resp = handler_captain.handler(_event(body={'mode': 'chat', 'messages': []}), None)
+    assert resp['statusCode'] == 400
+
+
+def test_bad_mode_returns_400(monkeypatch):
+    _patch_ok(monkeypatch)
+    resp = handler_captain.handler(_event(body={'mode': 'wat', 'summary': {}}), None)
+    assert resp['statusCode'] == 400
+
+
+def test_chat_requires_a_message(monkeypatch):
+    _patch_ok(monkeypatch)
+    resp = handler_captain.handler(_event(body={'mode': 'chat', 'summary': {}, 'messages': []}), None)
+    assert resp['statusCode'] == 400
+
+
+def test_too_many_messages_returns_400(monkeypatch):
+    _patch_ok(monkeypatch)
+    messages = [{'role': 'user', 'content': 'hi'}] * (handler_captain._MAX_MESSAGES + 1)
+    resp = handler_captain.handler(
+        _event(body={'mode': 'chat', 'summary': {}, 'messages': messages}), None
+    )
+    assert resp['statusCode'] == 400
+
+
+def test_oversized_content_returns_400(monkeypatch):
+    _patch_ok(monkeypatch)
+    messages = [{'role': 'user', 'content': 'x' * (handler_captain._MAX_CONTENT_CHARS + 1)}]
+    resp = handler_captain.handler(
+        _event(body={'mode': 'chat', 'summary': {}, 'messages': messages}), None
+    )
+    assert resp['statusCode'] == 400
+
+
+def test_oversized_summary_returns_400(monkeypatch):
+    _patch_ok(monkeypatch)
+    big = {'blob': 'x' * (handler_captain._MAX_SUMMARY_CHARS + 1)}
+    resp = handler_captain.handler(
+        _event(body={'mode': 'chat', 'summary': big, 'messages': [{'role': 'user', 'content': 'hi'}]}),
+        None,
+    )
+    assert resp['statusCode'] == 400
+
+
+def test_chat_happy_path_returns_reply(monkeypatch):
+    captured = []
+    _patch_ok(monkeypatch, capture=captured)
+    resp = handler_captain.handler(
+        _event(body={
+            'mode': 'chat',
+            'summary': {'portfolioValue': 1000},
+            'messages': [{'role': 'user', 'content': 'How did I do?'}],
+        }),
+        None,
+    )
+    assert resp['statusCode'] == 200
+    assert json.loads(resp['body'])['reply'] == 'Aye, your portfolio is up.'
+    # System prompt + summary context precede the user's message.
+    assert captured[0]['role'] == 'system'
+    assert 'never give financial advice' in captured[0]['content']
+    assert any('portfolioValue' in m['content'] for m in captured if m['role'] == 'system')
+    assert captured[-1] == {'role': 'user', 'content': 'How did I do?'}
+
+
+def test_insights_mode_synthesizes_instruction(monkeypatch):
+    captured = []
+    _patch_ok(monkeypatch, capture=captured)
+    resp = handler_captain.handler(
+        _event(body={'mode': 'insights', 'summary': {'portfolioValue': 1000}}),
+        None,
+    )
+    assert resp['statusCode'] == 200
+    # No user messages needed; the handler appends the Captain's-read instruction.
+    assert captured[-1]['role'] == 'user'
+    assert "Captain's read" in captured[-1]['content']
+
+
+def test_openai_failure_returns_502(monkeypatch):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u'})
+
+    def boom(messages):
+        raise RuntimeError('api down')
+
+    monkeypatch.setattr(handler_captain, '_call_openai', boom)
+    resp = handler_captain.handler(
+        _event(body={'mode': 'insights', 'summary': {'v': 1}}), None
+    )
+    assert resp['statusCode'] == 502

--- a/template.yaml
+++ b/template.yaml
@@ -27,6 +27,17 @@ Parameters:
       Existing DynamoDB table (holds user data). Intentionally NOT created by this
       stack so a fresh deploy can't replace it with an empty table — the function is
       only granted access to it.
+  OpenAIParamName:
+    Type: String
+    Default: /sailor/openai-api-key
+    Description: >
+      Name of the SSM Parameter Store SecureString holding the OpenAI API key.
+      Created out-of-band (see README) and intentionally NOT managed by this stack
+      so the secret never lives in the template or CI logs.
+  OpenAIModel:
+    Type: String
+    Default: gpt-4o-mini
+    Description: OpenAI chat model for the Captain. Verify live pricing before changing.
 
 Globals:
   Function:
@@ -82,6 +93,34 @@ Resources:
             Path: /microservice
             Method: any
 
+  CaptainFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler_captain.handler
+      Environment:
+        Variables:
+          ALLOWED_ORIGINS: !Ref AllowedOrigins
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          OPENAI_PARAM_NAME: !Ref OpenAIParamName
+          OPENAI_MODEL: !Ref OpenAIModel
+      Policies:
+        # Read-only access to just the OpenAI key parameter (decryption via the
+        # AWS-managed aws/ssm key is handled transparently by SSM, for free).
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: ssm:GetParameter
+              Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OpenAIParamName}'
+      Events:
+        Captain:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /captain
+            # ANY so the Lambda also answers the CORS preflight (OPTIONS).
+            Method: any
+
 Outputs:
   ApiBaseUrl:
     Description: Base URL of the deployed API stage.
@@ -92,3 +131,6 @@ Outputs:
   MicroserviceEndpoint:
     Description: Copy into environment.prod.ts -> dynamoDBLambdaUrl
     Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/microservice'
+  CaptainEndpoint:
+    Description: Copy into environment.prod.ts -> captainLambdaUrl
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/captain'

--- a/template.yaml
+++ b/template.yaml
@@ -36,7 +36,7 @@ Parameters:
       so the secret never lives in the template or CI logs.
   OpenAIModel:
     Type: String
-    Default: gpt-4o-mini
+    Default: gpt-5.4-mini
     Description: OpenAI chat model for the Captain. Verify live pricing before changing.
 
 Globals:
@@ -104,6 +104,11 @@ Resources:
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           OPENAI_PARAM_NAME: !Ref OpenAIParamName
           OPENAI_MODEL: !Ref OpenAIModel
+          # Empty by default (prod reads the key from SSM). Declared so a local
+          # `sam local --env-vars env.json` override can inject it — SAM only
+          # overrides variables that already exist in the template. Empty string
+          # is falsy, so prod still falls through to SSM.
+          OPENAI_API_KEY: ''
       Policies:
         # Read-only access to just the OpenAI key parameter (decryption via the
         # AWS-managed aws/ssm key is handled transparently by SSM, for free).

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@aws/captain": ["libs/frontend/captain/src/index.ts"],
       "@aws/lambdas": ["libs/backend/lambdas/src/index.ts"],
       "@aws/state": ["libs/frontend/state/src/index.ts"],
       "@aws/ui": ["libs/frontend/ui/src/index.ts"],


### PR DESCRIPTION
## What & why

sailor had no GenAI. This adds **"the Captain"**, a sailing-themed assistant that *explains* a user's portfolio in plain language:

- **Chat panel** "Ask the Captain" (toolbar launcher) with ready-to-use prompt chips.
- **Dashboard insights banner** — an auto-generated, **daily-cached** "Captain's read".

It explicitly **never gives financial advice** — advice/forecast requests get a varied, funny sailing deflection, plus a persistent UI disclaimer.

## How it's built

- **Deterministic first, LLM second.** The client computes a compact summary (`buildCaptainSummary`) + biggest movers (`detectMovers`) from the existing `selectState` view-model and sends only that JSON — the model narrates, it never computes. Low tokens, reproducible numbers.
- **New authenticated Lambda** `handler_captain.py` (Cognito-verified) calls OpenAI. Key from an **SSM Parameter Store SecureString** (free; protects the ~\$1/mo idle target) with an `OPENAI_API_KEY` fallback for local dev.
- **New `captain` NgRx slice** (`libs/frontend/captain`) — depends on `state`/`util` only, never `yahoo`.
- **Cost controls**: cheapest small model + tight `max_tokens`, input-size caps in the Lambda, and the dashboard insight cached per day + portfolio in `localStorage` (reload/same-day revisit ⇒ no new call).
- **Demo mode**: public `/demo` is unauthenticated, so it never calls the Lambda — chat + banner render canned offline replies from `captain.demo.ts`.

## ⚠️ Before deploy (config, not code)

1. **Verify the live OpenAI model/pricing**; adjust the `OpenAIModel` param in `template.yaml` if `gpt-4o-mini` isn't the cheapest current small tier.
2. Prod key (one-time): `aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...`
3. Local: `export OPENAI_API_KEY=sk-...` before `sam local start-api`.

## Validation

- `nx run-many -t lint test build --all` ✅ (6 projects)
- `pytest services/test_handler_captain.py` ✅ (13)
- `sam validate` ✅

## Manual test checklist

- [ ] Logged in: toolbar **Ask the Captain** opens the panel; a prompt chip returns a factual, sailing-flavoured answer about real holdings.
- [ ] Ask "should I buy more NVDA?" / "will it go up?" → funny sailing deflection, **no advice**.
- [ ] Dashboard shows the "Captain's read" banner; **reload does not** trigger a second OpenAI call (check network/Lambda logs).
- [ ] `/demo` (no login): Captain + banner render from fixtures; confirm **zero** calls to `/captain`.
- [ ] Empty/new portfolio: no insight call fires until the portfolio has value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)