### PR TITLE
feat(captain): usage quotas, Stripe subscription, and admin bypass

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@ services differ:
 
 | Concern | Development (`sam local`) | Production (deployed) |
 |---|---|---|
-| Cognito pool | `COGNITO_USER_POOL_ID` (today: the prod pool — see note) | prod pool |
+| Cognito pool | dedicated `sailor-dev` pool (isolates test users + `admin` group) | prod pool |
 | JWKS verification | same (live fetch from Cognito) | same |
 | DynamoDB (`plan`, counters) | DynamoDB Local (Docker) | `sailor` table |
 | Stripe secret/webhook | from `env.json` | from SSM SecureStrings |
@@ -145,10 +145,10 @@ services differ:
 | Webhook delivery | `stripe listen` relay → `localhost:3000` | Stripe Dashboard endpoint → API Gateway |
 | `GLOBAL_MONTHLY_LIMIT` | `0` (disabled) | derived from budget (e.g. 450) |
 
-> **Note — shared Cognito pool.** Dev and prod currently use the *same* user pool, so test users
-> and the `admin` group live alongside real users. DynamoDB and Stripe are already isolated
-> (local table; test mode). The recommended hardening is a **separate dev user pool** so test
-> accounts and admin membership never touch prod; see the README's testing section.
+> **Note — isolated dev pool.** Dev uses its own `sailor-dev` Cognito pool, so test users and the
+> `admin` group never touch prod. `environment.ts` (frontend) and the local Lambdas' `env.json`
+> both point at it; `environment.prod.ts` keeps the prod pool. DynamoDB and Stripe are isolated too
+> (local table; test mode). See the README's "Test users" section for the pool/seed setup.
 
 ## Backend
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,10 +83,72 @@ transactions using the tickers already in the store.
 
 ## Auth
 
-OIDC via Cognito (`angular-auth-oidc-client`). After login the **ID token** is attached to every
-HTTP request by `JwtInterceptor`. The DynamoDB Lambda **verifies the token's signature** against
-the Cognito JWKS (not just decodes it) and uses the `sub` claim as the DynamoDB partition key, so
-a user can only read/write their own data.
+Cognito User Pool auth (`amazon-cognito-identity-js`). After login the **ID token** is attached to
+every HTTP request by `JwtInterceptor`. Each Lambda **verifies the token's signature** against the
+Cognito JWKS (not just decodes it) and uses the `sub` claim as the DynamoDB partition key, so a
+user can only read/write their own data.
+
+### Authentication + "has the user paid?" flow
+
+The same token proves *who* the user is (`sub`), whether they're an **admin** (`cognito:groups`),
+and — combined with their DynamoDB record — whether they're on a **paid** plan. Identity lives in
+Cognito; entitlement (`plan`) lives in DynamoDB and is written **only** by the Stripe webhook.
+
+```
+            ┌─────────┐   sign in    ┌──────────────────┐
+            │ Browser │ ───────────▶ │ Cognito User Pool │
+            │ (Angular)│ ◀─────────── │  (issues JWTs)    │
+            └────┬─────┘   ID token   └──────────────────┘
+                 │  ID token in sessionStorage; JwtInterceptor adds
+                 │  "Authorization: <id-token>" to every request
+                 ▼
+          ┌──────────────┐
+          │ API Gateway  │
+          └──────┬───────┘
+                 ▼
+        ┌─────────────────────────────────────────────────────────┐
+        │ Lambda (captain / dynamodb / billing)                    │
+        │ 1. verify_token(): fetch JWKS (cached) → check signature, │
+        │    audience (client id), issuer, expiry, token_use=id     │
+        │    → extract  sub  and  cognito:groups                    │
+        │                                                           │
+        │ 2. entitlement (captain quota path):                      │
+        │      'admin' in cognito:groups ? ──▶ bypass (unlimited)   │
+        │      else GetItem userId=sub → read `plan`                │
+        │            plan == 'paid' ? PAID_LIMIT : FREE_LIMIT       │
+        │      atomic ADD on usage#<sub>#<month> guarded by         │
+        │            ConditionExpression count < limit              │
+        │            pass → call OpenAI · fail → 429                │
+        └─────────────────────────────────────────────────────────┘
+
+  How `plan` becomes 'paid' (the only writer is the webhook):
+
+    Browser ─Upgrade─▶ POST /billing/checkout (authed; client_reference_id=sub)
+            ◀─ Stripe Checkout URL ─ Lambda
+    Browser ─pay (test card)─▶ Stripe-hosted Checkout
+    Stripe  ─POST /billing/webhook (signed)─▶ Lambda
+            verify signature → SET plan='paid' on userId=sub
+```
+
+### Dev vs prod wiring
+
+Identity verification and the entitlement logic are **identical** in both; only the backing
+services differ:
+
+| Concern | Development (`sam local`) | Production (deployed) |
+|---|---|---|
+| Cognito pool | `COGNITO_USER_POOL_ID` (today: the prod pool — see note) | prod pool |
+| JWKS verification | same (live fetch from Cognito) | same |
+| DynamoDB (`plan`, counters) | DynamoDB Local (Docker) | `sailor` table |
+| Stripe secret/webhook | from `env.json` | from SSM SecureStrings |
+| Stripe mode | **test** | test (until live keys are set) |
+| Webhook delivery | `stripe listen` relay → `localhost:3000` | Stripe Dashboard endpoint → API Gateway |
+| `GLOBAL_MONTHLY_LIMIT` | `0` (disabled) | derived from budget (e.g. 450) |
+
+> **Note — shared Cognito pool.** Dev and prod currently use the *same* user pool, so test users
+> and the `admin` group live alongside real users. DynamoDB and Stripe are already isolated
+> (local table; test mode). The recommended hardening is a **separate dev user pool** so test
+> accounts and admin membership never touch prod; see the README's testing section.
 
 ## Backend
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,8 +20,9 @@ libs/
 services/
   handler_dynamodb.py  DynamoDB Lambda — CRUD + Cognito JWT auth
   handler_yahoo.py     Yahoo Finance Lambda — fan-out price fetch
-  handler_captain.py   Captain Lambda — OpenAI chat/insights + Cognito JWT auth
-  shared/              Shared utilities (cors.py, auth.py, secrets.py)
+  handler_captain.py   Captain Lambda — OpenAI chat/insights + auth + usage quotas
+  handler_billing.py   Billing Lambda — Stripe Checkout + webhook (subscription)
+  shared/              Shared utilities (cors.py, auth.py, secrets.py, db.py)
   requirements.txt     Python dependencies for all Lambdas
   init_dynamodb.py     One-time local dev table setup
 ```
@@ -96,10 +97,20 @@ Three Python 3.13 Lambdas behind one API Gateway:
   that reflects the request `Origin`.
 - **yahoo** (`handler_yahoo.py`) — fans out to the Yahoo Finance API for the requested symbols
   (`ThreadPoolExecutor`, per-request timeout), returning per-symbol results.
-- **captain** (`handler_captain.py`) — verifies the Cognito ID token, then calls the OpenAI Chat
-  Completions API. The OpenAI key is read from an SSM Parameter Store SecureString (cached
-  module-level, like the JWKS cache), with an `OPENAI_API_KEY` env-var fallback for local dev.
-  See "Ask the Captain (GenAI)" below.
+- **captain** (`handler_captain.py`) — verifies the Cognito ID token, enforces usage quotas,
+  then calls the OpenAI Chat Completions API. The OpenAI key is read from an SSM Parameter
+  Store SecureString (cached module-level, like the JWKS cache), with an `OPENAI_API_KEY`
+  env-var fallback for local dev. See "Ask the Captain (GenAI)" below.
+- **billing** (`handler_billing.py`) — Stripe Checkout (`/billing/checkout`), webhook
+  (`/billing/webhook`) and portal (`/billing/portal`) behind one `{proxy+}` route. The webhook
+  verifies the Stripe signature and is the **only** writer of a user's `plan`; the client can
+  never grant itself paid access.
+
+`shared/db.py` centralises the DynamoDB table handle (dev-vs-prod endpoint selection) and the
+atomic monthly-counter primitives used for quotas — race-free via a DynamoDB
+`ConditionExpression`, with a TTL attribute so old counters self-delete (free). Usage counters
+live in the same `sailor` table under reserved `usage#...` partition keys, so no new table or
+schema change is needed.
 
 `sam build` packages each handler with `services/requirements.txt` (PyJWT + cryptography +
 openai); `boto3` is provided by the Lambda Python runtime and not bundled.
@@ -118,7 +129,11 @@ language — a chat panel plus an auto-generated, daily-cached "Captain's read" 
   persistent disclaimer reinforces this in the UI.
 - **Cost control.** Requests go through an authenticated Lambda (key server-side), use the cheapest
   small model with a tight `max_tokens`, and the dashboard insight is cached per day + portfolio in
-  `localStorage`, so a reload or same-day revisit triggers no new call.
+  `localStorage`, so a reload or same-day revisit triggers no new call. On top of that, two quota
+  layers bound spend: a **per-user monthly limit** (free vs paid, raised via a Stripe subscription)
+  and a **global monthly ceiling** that hard-stops all calls once reached — the real "never spend
+  more than I earn" guarantee. Cognito `admin`-group members bypass both. See "Captain limits &
+  subscription" in the README.
 - **Demo mode.** The public `/demo` page is unauthenticated, so it never calls the Lambda — the chat
   and insight render canned, offline responses from `captain.demo.ts` (the same advice-refusal
   behaviour, mirrored client-side).

--- a/README.md
+++ b/README.md
@@ -277,18 +277,11 @@ TTL):
 - **Per-user monthly quota** — fairness. Free users get `FREE_MONTHLY_LIMIT` calls/month;
   paid users get `PAID_MONTHLY_LIMIT`. Hitting it returns `429` and the chat panel shows an
   **Upgrade** call-to-action.
-- **Global monthly ceiling** — the hard spend guarantee. Once the whole user base has made
-  `GLOBAL_MONTHLY_LIMIT` calls in a month, **all** captain calls stop until the next month.
-  Set it from live OpenAI pricing: `floor(monthly_budget / cost_per_call)` (0 disables it).
-
-  *Worked example (GPT-5.4 mini, $0.75/1M input · $4.50/1M output, verified 2026-06):* a
-  worst-case call is the input caps (summary ≈2k + system ≈0.5k + 20 messages ≈10k ≈ **12.5k
-  input tokens**) plus the hard 250-token output cap →
-  `12,500 × 0.75/1M + 250 × 4.50/1M ≈ $0.0105/call`. For a $5/mo budget that's
-  `floor(5 / 0.0105) ≈ 476`, so **`GLOBAL_MONTHLY_LIMIT=450`** keeps worst-case spend ≈ $4.73.
-  Real calls are far smaller than the caps, so headroom is generous; raise the ceiling as paid
-  revenue grows. Re-verify pricing before changing models.
-- **Admin bypass** — members of the Cognito `admin` group skip all quotas (free, unlimited).
+- **Global monthly ceiling** — the hard spend cap: once the whole user base makes
+  `GLOBAL_MONTHLY_LIMIT` calls in a month, all captain calls stop until the next month
+  (`0` disables it). Derive it from live pricing — `floor(monthly_budget / cost_per_call)`. At
+  GPT-5.4-mini rates a worst-case call is ≈ $0.0105, so `450` keeps a $5/mo budget safe (~$4.73).
+- **Admin bypass** — members of the Cognito `admin` group are unlimited.
 
 Upgrades go through **Stripe Checkout** (run in *test mode* until you're ready for real
 charges). The `billing` Lambda's webhook is the **only** writer of a user's `plan` — the
@@ -339,77 +332,36 @@ stripe listen --forward-to http://localhost:3000/billing/webhook
 Restart `./scripts/start-backend.sh` after editing `env.json` (it's read at startup). Leave
 `GLOBAL_MONTHLY_LIMIT` at `0` locally to disable the global ceiling.
 
-### Environments & test users
+### Test users
 
-Recommended split (cheapest setup that's still robust):
-
-| Layer | Dev / test | Prod |
-|---|---|---|
-| Data (DynamoDB) | DynamoDB Local — already isolated | `sailor` table |
-| Stripe | **test** keys in `env.json` | **test** keys in SSM (switch to live only when charging) |
-| Cognito | **separate dev user pool** (recommended) | prod user pool |
-
-Stripe **test mode** is shared safely across local and a future staging — you don't need a
-separate "test Stripe". A full separate *deployed* staging stack is intentionally **out of scope**
-for this project's budget; local (`sam local` + DynamoDB Local + Stripe test) is the test
-environment. The one gap worth closing is Cognito: today dev and prod share a pool, so test
-accounts and the `admin` group sit next to real users.
-
-**Isolating dev with its own Cognito pool (recommended).** Cognito is free up to 50k MAUs, so a
-dedicated dev pool keeps test users and the `admin` group off prod. One-time:
+Dev uses its **own Cognito pool** (free; keeps test accounts and the `admin` group off prod),
+configured in `environment.ts` (frontend) and `env.json` (`COGNITO_USER_POOL_ID` /
+`COGNITO_CLIENT_ID`, for the local Lambdas). One-time pool creation — the web app logs in via
+**SRP**, so `ALLOW_USER_SRP_AUTH` is required:
 
 ```bash
-# Create the pool + an app client (note the two IDs they print)
-aws cognito-idp create-user-pool --pool-name sailor-dev \
-  --query 'UserPool.Id' --output text
-aws cognito-idp create-user-pool-client --user-pool-id <DEV_POOL> \
-  --client-name sailor-dev-web --no-generate-secret \
+aws cognito-idp create-user-pool --pool-name sailor-dev --query 'UserPool.Id' --output text
+aws cognito-idp create-user-pool-client --user-pool-id <DEV_POOL> --client-name sailor-dev-web \
+  --no-generate-secret \
   --explicit-auth-flows ALLOW_USER_SRP_AUTH ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
   --query 'UserPoolClient.ClientId' --output text
-# The web app logs in via SRP, so ALLOW_USER_SRP_AUTH is required; if you already
-# created the client without it, run `update-user-pool-client` with these flags.
 ```
 
-Then point dev at it (leave `environment.prod.ts` untouched):
-- `environment.ts` → set `cognito.userPoolId` / `cognito.clientId` to the dev IDs (frontend login).
-- `env.json` → add `"COGNITO_USER_POOL_ID"` and `"COGNITO_CLIENT_ID"` so the local Lambdas verify
-  tokens against the same dev pool. Restart `./scripts/start-backend.sh`.
-
-**Test-user matrix** — create one account per role to exercise every path:
-
-| User | Cognito group | `plan` (DynamoDB) | Expected behaviour |
-|---|---|---|---|
-| `admin@test` | `admin` | — | unlimited; "Admin" badge; no upgrade button |
-| `paid@test` | — | `paid` | `PAID_MONTHLY_LIMIT`; "Captain Plus" badge; no upgrade button |
-| `regular@test` | — | _(none)_ → free | `FREE_MONTHLY_LIMIT`; upgrade button + quota CTA at the cap |
-
-The quickest path is the seed script, which creates all three (permanent passwords), adds the
-admin to the group, and marks the paid user `plan=paid` in DynamoDB Local:
+Seed all three roles (creates the users with permanent passwords, adds the admin to the group,
+and flags the paid user in DynamoDB Local):
 
 ```bash
-POOL_ID=us-east-1_yourDevPool ./scripts/seed-test-users.sh
+POOL_ID=<DEV_POOL> ./scripts/seed-test-users.sh
 ```
 
-Or set each up by hand (against the dev pool / DynamoDB Local):
+| Username | Password | What it tests |
+|---|---|---|
+| `admin@test` | `Passw0rd!` | Admin — unlimited; "Admin" badge; no upgrade button |
+| `paid@test` | `Passw0rd!` | Paid — `PAID_MONTHLY_LIMIT`; "Captain Plus" badge; no upgrade button |
+| `regular@test` | `Passw0rd!` | Free — `FREE_MONTHLY_LIMIT`; upgrade CTA when the cap is hit |
 
-```bash
-# Cognito user with a permanent password (no forced reset)
-aws cognito-idp admin-create-user --user-pool-id <DEV_POOL> --username paid@test --message-action SUPPRESS
-aws cognito-idp admin-set-user-password --user-pool-id <DEV_POOL> --username paid@test --password 'Passw0rd!' --permanent
-
-# admin → add to the admin group
-aws cognito-idp admin-add-user-to-group --user-pool-id <DEV_POOL> --group-name admin --username admin@test
-
-# paid → set plan (locally; <SUB> is the user's Cognito sub)
-AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local \
-aws dynamodb update-item --endpoint-url http://localhost:8000 --region us-east-1 \
-  --table-name sailor --key '{"userId":{"S":"<SUB>"}}' \
-  --update-expression "SET #p = :p" --expression-attribute-names '{"#p":"plan"}' \
-  --expression-attribute-values '{":p":{"S":"paid"}}'
-```
-
-New roles later (e.g. a higher tier or a `beta` group) slot in the same way: a Cognito group for
-capability flags, or a `plan` value for billing tiers.
+> Override the password with `PASSWORD=… POOL_ID=… ./scripts/seed-test-users.sh`. Re-run after
+> resetting the local table — the paid flag lives in DynamoDB Local.
 
 ## 🏗 Architecture
 

--- a/README.md
+++ b/README.md
@@ -364,8 +364,10 @@ aws cognito-idp create-user-pool --pool-name sailor-dev \
   --query 'UserPool.Id' --output text
 aws cognito-idp create-user-pool-client --user-pool-id <DEV_POOL> \
   --client-name sailor-dev-web --no-generate-secret \
-  --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+  --explicit-auth-flows ALLOW_USER_SRP_AUTH ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
   --query 'UserPoolClient.ClientId' --output text
+# The web app logs in via SRP, so ALLOW_USER_SRP_AUTH is required; if you already
+# created the client without it, run `update-user-pool-client` with these flags.
 ```
 
 Then point dev at it (leave `environment.prod.ts` untouched):

--- a/README.md
+++ b/README.md
@@ -263,6 +263,68 @@ day.
 
 ---
 
+## 💳 Captain limits & subscription
+
+Every "Ask the Captain" call costs OpenAI tokens, so the `captain` Lambda enforces two
+layers of quota before it spends (atomic, race-free DynamoDB counters that self-expire via
+TTL):
+
+- **Per-user monthly quota** — fairness. Free users get `FREE_MONTHLY_LIMIT` calls/month;
+  paid users get `PAID_MONTHLY_LIMIT`. Hitting it returns `429` and the chat panel shows an
+  **Upgrade** call-to-action.
+- **Global monthly ceiling** — the hard spend guarantee. Once the whole user base has made
+  `GLOBAL_MONTHLY_LIMIT` calls in a month, **all** captain calls stop until the next month.
+  Set it from live OpenAI pricing: `floor(monthly_budget / cost_per_call)` (0 disables it).
+
+  *Worked example (GPT-5.4 mini, $0.75/1M input · $4.50/1M output, verified 2026-06):* a
+  worst-case call is the input caps (summary ≈2k + system ≈0.5k + 20 messages ≈10k ≈ **12.5k
+  input tokens**) plus the hard 250-token output cap →
+  `12,500 × 0.75/1M + 250 × 4.50/1M ≈ $0.0105/call`. For a $5/mo budget that's
+  `floor(5 / 0.0105) ≈ 476`, so **`GLOBAL_MONTHLY_LIMIT=450`** keeps worst-case spend ≈ $4.73.
+  Real calls are far smaller than the caps, so headroom is generous; raise the ceiling as paid
+  revenue grows. Re-verify pricing before changing models.
+- **Admin bypass** — members of the Cognito `admin` group skip all quotas (free, unlimited).
+
+Upgrades go through **Stripe Checkout** (run in *test mode* until you're ready for real
+charges). The `billing` Lambda's webhook is the **only** writer of a user's `plan` — the
+client is never trusted to grant itself paid access.
+
+### One-time prod setup (out-of-band — not managed by the stack)
+
+```bash
+# 1. Counters self-clean via TTL on the 'expiresAt' attribute (free).
+aws dynamodb update-time-to-live --table-name sailor \
+  --time-to-live-specification "Enabled=true, AttributeName=expiresAt"
+
+# 2. Admin (free, unlimited) access — create the group, add yourself.
+aws cognito-idp create-group --user-pool-id us-east-1_liCB4LgDE --group-name admin
+aws cognito-idp admin-add-user-to-group --user-pool-id us-east-1_liCB4LgDE \
+  --group-name admin --username <your-email>
+
+# 3. Stripe secrets in SSM SecureStrings (free; no idle cost).
+aws ssm put-parameter --name /sailor/stripe-secret-key     --type SecureString --value sk_test_...
+aws ssm put-parameter --name /sailor/stripe-webhook-secret --type SecureString --value whsec_...
+
+# 4. Defense in depth — a hard $5 budget alarm behind the real-time global ceiling.
+#    Create an AWS Budget (Cost → Budgets) at $5/mo with an email alert.
+```
+
+Deploy with the price ID and ceiling, e.g.
+`sam deploy --parameter-overrides StripePriceId=price_... GlobalMonthlyLimit=450`, then copy
+the `BillingEndpoint` output into `environment.prod.ts → billingLambdaUrl` and configure the
+`StripeWebhookEndpoint` output as the webhook destination in the Stripe Dashboard.
+
+### Local dev
+
+Add Stripe **test** keys to `env.json` (gitignored) alongside the OpenAI key, and forward
+webhooks with the Stripe CLI:
+
+```bash
+stripe listen --forward-to http://localhost:3000/billing/webhook
+```
+
+Leave `GLOBAL_MONTHLY_LIMIT` at `0` locally to disable the global ceiling.
+
 ## 🏗 Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the complete project layout, data flow, and

--- a/README.md
+++ b/README.md
@@ -321,14 +321,23 @@ the `BillingEndpoint` output into `environment.prod.ts → billingLambdaUrl` and
 
 ### Local dev
 
-Add Stripe **test** keys to `env.json` (gitignored) alongside the OpenAI key, and forward
-webhooks with the Stripe CLI:
+The `samconfig.toml` price/secrets only apply to the **deployed** stack — `sam local` reads
+billing config from `env.json` instead (see `env.json.example`). Add your **test-mode** values:
+`STRIPE_SECRET_KEY` (`sk_test_…`), `STRIPE_PRICE_ID` (a **test-mode** price — IDs are
+mode-specific), and `BILLING_SUCCESS_URL`/`BILLING_CANCEL_URL` pointed at `http://localhost:4200`
+so checkout returns to your local app. Without `STRIPE_PRICE_ID` the checkout endpoint returns
+`{"message":"Billing is not configured"}`.
+
+To let a completed checkout flip the user's plan locally, forward webhooks with the Stripe CLI
+and paste **its** signing secret into `env.json` as `STRIPE_WEBHOOK_SECRET` (it differs from the
+Dashboard endpoint's secret):
 
 ```bash
 stripe listen --forward-to http://localhost:3000/billing/webhook
 ```
 
-Leave `GLOBAL_MONTHLY_LIMIT` at `0` locally to disable the global ceiling.
+Restart `./scripts/start-backend.sh` after editing `env.json` (it's read at startup). Leave
+`GLOBAL_MONTHLY_LIMIT` at `0` locally to disable the global ceiling.
 
 ## 🏗 Architecture
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,53 @@ stripe listen --forward-to http://localhost:3000/billing/webhook
 Restart `./scripts/start-backend.sh` after editing `env.json` (it's read at startup). Leave
 `GLOBAL_MONTHLY_LIMIT` at `0` locally to disable the global ceiling.
 
+### Environments & test users
+
+Recommended split (cheapest setup that's still robust):
+
+| Layer | Dev / test | Prod |
+|---|---|---|
+| Data (DynamoDB) | DynamoDB Local — already isolated | `sailor` table |
+| Stripe | **test** keys in `env.json` | **test** keys in SSM (switch to live only when charging) |
+| Cognito | **separate dev user pool** (recommended) | prod user pool |
+
+Stripe **test mode** is shared safely across local and a future staging — you don't need a
+separate "test Stripe". A full separate *deployed* staging stack is intentionally **out of scope**
+for this project's budget; local (`sam local` + DynamoDB Local + Stripe test) is the test
+environment. The one gap worth closing is Cognito: today dev and prod share a pool, so test
+accounts and the `admin` group sit next to real users. Creating a **dedicated dev user pool**
+(Cognito is free up to 50k MAUs) and pointing `environment.ts` + the local `COGNITO_*` env vars at
+it keeps testing fully isolated.
+
+**Test-user matrix** — create one account per role to exercise every path:
+
+| User | Cognito group | `plan` (DynamoDB) | Expected behaviour |
+|---|---|---|---|
+| `admin@test` | `admin` | — | unlimited; "Admin" badge; no upgrade button |
+| `paid@test` | — | `paid` | `PAID_MONTHLY_LIMIT`; "Captain Plus" badge; no upgrade button |
+| `regular@test` | — | _(none)_ → free | `FREE_MONTHLY_LIMIT`; upgrade button + quota CTA at the cap |
+
+Setting each up (against the dev pool / DynamoDB Local):
+
+```bash
+# Cognito user with a permanent password (no forced reset)
+aws cognito-idp admin-create-user --user-pool-id <DEV_POOL> --username paid@test --message-action SUPPRESS
+aws cognito-idp admin-set-user-password --user-pool-id <DEV_POOL> --username paid@test --password 'Passw0rd!' --permanent
+
+# admin → add to the admin group
+aws cognito-idp admin-add-user-to-group --user-pool-id <DEV_POOL> --group-name admin --username admin@test
+
+# paid → set plan (locally; <SUB> is the user's Cognito sub)
+AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local \
+aws dynamodb update-item --endpoint-url http://localhost:8000 --region us-east-1 \
+  --table-name sailor --key '{"userId":{"S":"<SUB>"}}' \
+  --update-expression "SET #p = :p" --expression-attribute-names '{"#p":"plan"}' \
+  --expression-attribute-values '{":p":{"S":"paid"}}'
+```
+
+New roles later (e.g. a higher tier or a `beta` group) slot in the same way: a Cognito group for
+capability flags, or a `plan` value for billing tiers.
+
 ## 🏗 Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the complete project layout, data flow, and

--- a/README.md
+++ b/README.md
@@ -63,25 +63,30 @@ python services/init_dynamodb.py
 
 ### 3 — Backend APIs (AWS SAM)
 
+First copy the secrets template (one-time): `cp env.json.example env.json` and paste your keys
+(at least `OPENAI_API_KEY`). `env.json` is gitignored.
+
 ```bash
-sam build
-AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local sam local start-api
+./scripts/start-backend.sh
 ```
 
-Serves Lambda functions on `http://localhost:3000`. Re-run `sam build` after any Lambda change.
+This runs `sam build` then `sam local start-api` with dummy AWS credentials and `--env-vars
+env.json`, serving the Lambdas on `http://localhost:3000`. Re-run it after any Lambda change
+(it rebuilds each time).
 
-> **Ask the Captain (OpenAI):** the `captain` Lambda needs an OpenAI API key. It is read from the
-> `OPENAI_API_KEY` env var first, falling back to SSM — so:
+> **Why the script (and the dummy creds + env.json):** the dummy credentials let the Lambdas talk
+> to DynamoDB Local without an AWS session, and `--env-vars env.json` injects `OPENAI_API_KEY` so
+> the `captain` Lambda reads the key directly. Without it the key resolver falls through to SSM,
+> which the dummy credentials reject (`UnrecognizedClientException`) → a 502 from `/captain`.
 >
-> - **Local dev** — copy `env.json.example` to `env.json` (gitignored), paste your key, and pass it
->   to SAM: `sam local start-api --env-vars env.json`. (Or just `export OPENAI_API_KEY=sk-...` in the
->   shell instead.)
-> - **Production** — the key lives in an SSM Parameter Store SecureString (free; no idle cost), created
->   once: `aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...`
+> - **Secret resolution:** `OPENAI_API_KEY` (env var) first, then the SSM SecureString. The same
+>   applies to the Stripe keys (`STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`) — add them to
+>   `env.json` to exercise billing locally.
+> - **Production** — keys live in SSM SecureStrings (free; no idle cost), created once, e.g.
+>   `aws ssm put-parameter --name /sailor/openai-api-key --type SecureString --value sk-...`
 
-> **Tip:** The dummy credentials prevent `sam local` from failing on an expired AWS SSO session.
-> The Lambda talks to local DynamoDB with fake creds and never calls real AWS. Alternatively
-> run `aws sso login` to use real credentials.
+> **Tip:** prefer real credentials instead? Run `aws sso login` and `sam local start-api
+> --env-vars env.json` directly — then the SSM fallback works too.
 
 ### 4 — Frontend
 

--- a/README.md
+++ b/README.md
@@ -353,9 +353,25 @@ Stripe **test mode** is shared safely across local and a future staging — you 
 separate "test Stripe". A full separate *deployed* staging stack is intentionally **out of scope**
 for this project's budget; local (`sam local` + DynamoDB Local + Stripe test) is the test
 environment. The one gap worth closing is Cognito: today dev and prod share a pool, so test
-accounts and the `admin` group sit next to real users. Creating a **dedicated dev user pool**
-(Cognito is free up to 50k MAUs) and pointing `environment.ts` + the local `COGNITO_*` env vars at
-it keeps testing fully isolated.
+accounts and the `admin` group sit next to real users.
+
+**Isolating dev with its own Cognito pool (recommended).** Cognito is free up to 50k MAUs, so a
+dedicated dev pool keeps test users and the `admin` group off prod. One-time:
+
+```bash
+# Create the pool + an app client (note the two IDs they print)
+aws cognito-idp create-user-pool --pool-name sailor-dev \
+  --query 'UserPool.Id' --output text
+aws cognito-idp create-user-pool-client --user-pool-id <DEV_POOL> \
+  --client-name sailor-dev-web --no-generate-secret \
+  --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+  --query 'UserPoolClient.ClientId' --output text
+```
+
+Then point dev at it (leave `environment.prod.ts` untouched):
+- `environment.ts` → set `cognito.userPoolId` / `cognito.clientId` to the dev IDs (frontend login).
+- `env.json` → add `"COGNITO_USER_POOL_ID"` and `"COGNITO_CLIENT_ID"` so the local Lambdas verify
+  tokens against the same dev pool. Restart `./scripts/start-backend.sh`.
 
 **Test-user matrix** — create one account per role to exercise every path:
 
@@ -365,7 +381,14 @@ it keeps testing fully isolated.
 | `paid@test` | — | `paid` | `PAID_MONTHLY_LIMIT`; "Captain Plus" badge; no upgrade button |
 | `regular@test` | — | _(none)_ → free | `FREE_MONTHLY_LIMIT`; upgrade button + quota CTA at the cap |
 
-Setting each up (against the dev pool / DynamoDB Local):
+The quickest path is the seed script, which creates all three (permanent passwords), adds the
+admin to the group, and marks the paid user `plan=paid` in DynamoDB Local:
+
+```bash
+POOL_ID=us-east-1_yourDevPool ./scripts/seed-test-users.sh
+```
+
+Or set each up by hand (against the dev pool / DynamoDB Local):
 
 ```bash
 # Cognito user with a permanent password (no forced reset)

--- a/README.md
+++ b/README.md
@@ -303,8 +303,14 @@ aws cognito-idp admin-add-user-to-group --user-pool-id us-east-1_liCB4LgDE \
 aws ssm put-parameter --name /sailor/stripe-secret-key     --type SecureString --value sk_test_...
 aws ssm put-parameter --name /sailor/stripe-webhook-secret --type SecureString --value whsec_...
 
-# 4. Defense in depth — a hard $5 budget alarm behind the real-time global ceiling.
-#    Create an AWS Budget (Cost → Budgets) at $5/mo with an email alert.
+# 4. Backstop the OpenAI spend itself. AWS Budgets only sees AWS costs, NOT the
+#    OpenAI bill (a separate vendor invoice), so the real out-of-band cap behind
+#    the in-app global ceiling is OpenAI's own hard usage limit:
+#    OpenAI Dashboard → Settings → Limits → set a monthly hard cap (e.g. $5) + alert.
+
+# 5. (Optional) Catch AWS-side surprises — Lambda/API Gateway/DynamoDB — with an
+#    AWS Budget (Cost → Budgets) at a low $/mo with an email alert. This does not
+#    cover OpenAI; see step 4 for that.
 ```
 
 Deploy with the price ID and ceiling, e.g.

--- a/apps/frontend/proxy.conf.json
+++ b/apps/frontend/proxy.conf.json
@@ -16,5 +16,11 @@
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
+  },
+  "/billing": {
+    "target": "http://localhost:3000",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
   }
 }

--- a/apps/frontend/src/environments/environment.prod.ts
+++ b/apps/frontend/src/environments/environment.prod.ts
@@ -7,6 +7,8 @@ export const environment = {
     'https://03y9xjgaaj.execute-api.us-east-1.amazonaws.com/prod/microservice',
   captainLambdaUrl:
     'https://03y9xjgaaj.execute-api.us-east-1.amazonaws.com/prod/captain',
+  billingLambdaUrl:
+    'https://03y9xjgaaj.execute-api.us-east-1.amazonaws.com/prod/billing',
   cognito: {
     userPoolId: 'us-east-1_liCB4LgDE',
     clientId: '3o34bbl92faeo9ljo11eebtim2',

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   captainLambdaUrl: 'http://localhost:4200/captain',
   billingLambdaUrl: 'http://localhost:4200/billing',
   cognito: {
-    userPoolId: 'us-east-1_liCB4LgDE',
-    clientId: '3o34bbl92faeo9ljo11eebtim2',
+    userPoolId: 'us-east-1_j0J6oG4Qj',
+    clientId: '305kqokc6u2e74n8qlfjed64av',
   },
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -4,6 +4,7 @@ export const environment = {
   yahooLambdaUrl: 'http://localhost:4200/yahoo_finance',
   dynamoDBLambdaUrl: 'http://localhost:4200/microservice',
   captainLambdaUrl: 'http://localhost:4200/captain',
+  billingLambdaUrl: 'http://localhost:4200/billing',
   cognito: {
     userPoolId: 'us-east-1_liCB4LgDE',
     clientId: '3o34bbl92faeo9ljo11eebtim2',

--- a/env.json.example
+++ b/env.json.example
@@ -2,6 +2,9 @@
   "Parameters": {
     "OPENAI_API_KEY": "sk-replace-with-your-key",
     "STRIPE_SECRET_KEY": "sk_test_replace-with-your-key",
-    "STRIPE_WEBHOOK_SECRET": "whsec_replace-with-your-secret"
+    "STRIPE_WEBHOOK_SECRET": "whsec_from-stripe-listen",
+    "STRIPE_PRICE_ID": "price_replace-with-your-TEST-mode-price",
+    "BILLING_SUCCESS_URL": "http://localhost:4200/?upgraded=1",
+    "BILLING_CANCEL_URL": "http://localhost:4200/"
   }
 }

--- a/env.json.example
+++ b/env.json.example
@@ -1,5 +1,7 @@
 {
   "Parameters": {
-    "OPENAI_API_KEY": "sk-replace-with-your-key"
+    "OPENAI_API_KEY": "sk-replace-with-your-key",
+    "STRIPE_SECRET_KEY": "sk_test_replace-with-your-key",
+    "STRIPE_WEBHOOK_SECRET": "whsec_replace-with-your-secret"
   }
 }

--- a/libs/frontend/captain/src/index.ts
+++ b/libs/frontend/captain/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/captain.module';
+export * from './lib/billing.service';
 export * from './lib/captain.types';
 export * from './lib/captain.demo';
 export * from './lib/captain-summary';

--- a/libs/frontend/captain/src/lib/+state/captain.actions.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from '@ngrx/store';
-import { CaptainInsight } from '../captain.types';
+import { CaptainInsight, CaptainStatus } from '../captain.types';
 
 // --- Chat ("Ask the Captain") ---------------------------------------------
 
@@ -9,7 +9,7 @@ export const sendMessage = createAction(
 );
 export const sendMessageSuccess = createAction(
   '[Captain] Send Message Success',
-  props<{ reply: string }>()
+  props<{ reply: string; usage?: CaptainStatus | null }>()
 );
 export const sendMessageFailure = createAction(
   '[Captain] Send Message Failure',
@@ -25,9 +25,17 @@ export const loadInsights = createAction(
 );
 export const loadInsightsSuccess = createAction(
   '[Captain] Load Insights Success',
-  props<{ insight: CaptainInsight }>()
+  props<{ insight: CaptainInsight; usage?: CaptainStatus | null }>()
 );
 export const loadInsightsFailure = createAction(
   '[Captain] Load Insights Failure',
   props<{ error: string; quota?: boolean }>()
+);
+
+// --- Plan + usage status --------------------------------------------------
+
+export const loadStatus = createAction('[Captain] Load Status');
+export const loadStatusSuccess = createAction(
+  '[Captain] Load Status Success',
+  props<{ status: CaptainStatus }>()
 );

--- a/libs/frontend/captain/src/lib/+state/captain.actions.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.actions.ts
@@ -13,7 +13,7 @@ export const sendMessageSuccess = createAction(
 );
 export const sendMessageFailure = createAction(
   '[Captain] Send Message Failure',
-  props<{ error: string }>()
+  props<{ error: string; quota?: boolean }>()
 );
 export const clearChat = createAction('[Captain] Clear Chat');
 
@@ -29,5 +29,5 @@ export const loadInsightsSuccess = createAction(
 );
 export const loadInsightsFailure = createAction(
   '[Captain] Load Insights Failure',
-  props<{ error: string }>()
+  props<{ error: string; quota?: boolean }>()
 );

--- a/libs/frontend/captain/src/lib/+state/captain.actions.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.actions.ts
@@ -29,7 +29,7 @@ export const loadInsightsSuccess = createAction(
 );
 export const loadInsightsFailure = createAction(
   '[Captain] Load Insights Failure',
-  props<{ error: string; quota?: boolean }>()
+  props<{ error: string }>()
 );
 
 // --- Plan + usage status --------------------------------------------------

--- a/libs/frontend/captain/src/lib/+state/captain.effects.spec.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.spec.ts
@@ -12,6 +12,8 @@ import {
   loadInsights,
   loadInsightsFailure,
   loadInsightsSuccess,
+  loadStatus,
+  loadStatusSuccess,
   sendMessage,
   sendMessageFailure,
   sendMessageSuccess,
@@ -43,13 +45,16 @@ const state = {
 describe('CaptainEffects', () => {
   let actions$: Observable<Action>;
   let effects: CaptainEffects;
-  let service: { chat: jest.Mock; insights: jest.Mock };
+  let service: { chat: jest.Mock; insights: jest.Mock; status: jest.Mock };
+
+  const usage = { plan: 'free', limit: 30, used: 1, remaining: 29 };
 
   function setup() {
     localStorage.clear();
     service = {
-      chat: jest.fn().mockReturnValue(of('live chat reply')),
-      insights: jest.fn().mockReturnValue(of('live narrative')),
+      chat: jest.fn().mockReturnValue(of({ reply: 'live chat reply', usage })),
+      insights: jest.fn().mockReturnValue(of({ reply: 'live narrative', usage })),
+      status: jest.fn().mockReturnValue(of(usage)),
     };
     TestBed.configureTestingModule({
       providers: [
@@ -83,7 +88,9 @@ describe('CaptainEffects', () => {
       setup();
       actions$ = of(sendMessage({ content: 'How did I do?' }));
       effects.sendMessage$.pipe(take(1)).subscribe((action) => {
-        expect(action).toEqual(sendMessageSuccess({ reply: 'live chat reply' }));
+        expect(action).toEqual(
+          sendMessageSuccess({ reply: 'live chat reply', usage })
+        );
         expect(service.chat).toHaveBeenCalledTimes(1);
         done();
       });
@@ -147,6 +154,18 @@ describe('CaptainEffects', () => {
       effects.loadInsights$.pipe(take(1)).subscribe((action) => {
         expect(action).toEqual(loadInsightsSuccess({ insight: cached }));
         expect(service.insights).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('loadStatus$', () => {
+    it('fetches the status snapshot and emits loadStatusSuccess', (done) => {
+      setup();
+      actions$ = of(loadStatus());
+      effects.loadStatus$.pipe(take(1)).subscribe((action) => {
+        expect(action).toEqual(loadStatusSuccess({ status: usage }));
+        expect(service.status).toHaveBeenCalledTimes(1);
         done();
       });
     });

--- a/libs/frontend/captain/src/lib/+state/captain.effects.spec.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.spec.ts
@@ -1,16 +1,19 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
-import { Observable, of, take } from 'rxjs';
+import { Observable, of, take, throwError } from 'rxjs';
 import { Action } from '@ngrx/store';
+import { HttpErrorResponse } from '@angular/common/http';
 import { selectBaseCurrency, selectState } from '@aws/state';
 import { CaptainEffects } from './captain.effects';
 import { CaptainService } from '../captain.service';
 import { selectMessages } from './captain.selectors';
 import {
   loadInsights,
+  loadInsightsFailure,
   loadInsightsSuccess,
   sendMessage,
+  sendMessageFailure,
   sendMessageSuccess,
 } from './captain.actions';
 import { buildCaptainSummary } from '../captain-summary';
@@ -82,6 +85,32 @@ describe('CaptainEffects', () => {
       effects.sendMessage$.pipe(take(1)).subscribe((action) => {
         expect(action).toEqual(sendMessageSuccess({ reply: 'live chat reply' }));
         expect(service.chat).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+
+    it('maps a 429 to a quota-exceeded failure', (done) => {
+      setup();
+      service.chat.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 429, statusText: 'Too Many Requests' }))
+      );
+      actions$ = of(sendMessage({ content: 'How did I do?' }));
+      effects.sendMessage$.pipe(take(1)).subscribe((action: any) => {
+        expect(action.type).toBe(sendMessageFailure.type);
+        expect(action.quota).toBe(true);
+        done();
+      });
+    });
+
+    it('does not flag a non-429 error as a quota issue', (done) => {
+      setup();
+      service.chat.mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500, statusText: 'Server Error' }))
+      );
+      actions$ = of(sendMessage({ content: 'How did I do?' }));
+      effects.sendMessage$.pipe(take(1)).subscribe((action: any) => {
+        expect(action.type).toBe(sendMessageFailure.type);
+        expect(action.quota).toBe(false);
         done();
       });
     });

--- a/libs/frontend/captain/src/lib/+state/captain.effects.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.ts
@@ -47,7 +47,12 @@ export class CaptainEffects {
         return this.service.chat(messages, summary).pipe(
           map((reply) => sendMessageSuccess({ reply })),
           catchError((error: HttpErrorResponse) =>
-            of(sendMessageFailure({ error: error.message }))
+            of(
+              sendMessageFailure({
+                error: error.message,
+                quota: error.status === 429,
+              })
+            )
           )
         );
       })
@@ -86,7 +91,12 @@ export class CaptainEffects {
             return loadInsightsSuccess({ insight });
           }),
           catchError((error: HttpErrorResponse) =>
-            of(loadInsightsFailure({ error: error.message }))
+            of(
+              loadInsightsFailure({
+                error: error.message,
+                quota: error.status === 429,
+              })
+            )
           )
         );
       })

--- a/libs/frontend/captain/src/lib/+state/captain.effects.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.ts
@@ -93,12 +93,7 @@ export class CaptainEffects {
             return loadInsightsSuccess({ insight, usage });
           }),
           catchError((error: HttpErrorResponse) =>
-            of(
-              loadInsightsFailure({
-                error: error.message,
-                quota: error.status === 429,
-              })
-            )
+            of(loadInsightsFailure({ error: error.message }))
           )
         );
       })

--- a/libs/frontend/captain/src/lib/+state/captain.effects.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.effects.ts
@@ -2,7 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
+import { EMPTY, catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
 import { selectBaseCurrency, selectState } from '@aws/state';
 import { CaptainService } from '../captain.service';
 import { buildCaptainSummary } from '../captain-summary';
@@ -16,6 +16,8 @@ import {
   loadInsights,
   loadInsightsFailure,
   loadInsightsSuccess,
+  loadStatus,
+  loadStatusSuccess,
   sendMessage,
   sendMessageFailure,
   sendMessageSuccess,
@@ -45,7 +47,7 @@ export class CaptainEffects {
         }
         const summary = buildCaptainSummary(state, currency);
         return this.service.chat(messages, summary).pipe(
-          map((reply) => sendMessageSuccess({ reply })),
+          map(({ reply, usage }) => sendMessageSuccess({ reply, usage })),
           catchError((error: HttpErrorResponse) =>
             of(
               sendMessageFailure({
@@ -81,14 +83,14 @@ export class CaptainEffects {
         }
 
         return this.service.insights(summary).pipe(
-          map((narrative) => {
+          map(({ reply: narrative, usage }) => {
             const insight = {
               narrative,
               generatedAt: new Date().toISOString(),
               fingerprint,
             };
             writeCachedInsight(insight);
-            return loadInsightsSuccess({ insight });
+            return loadInsightsSuccess({ insight, usage });
           }),
           catchError((error: HttpErrorResponse) =>
             of(
@@ -100,6 +102,21 @@ export class CaptainEffects {
           )
         );
       })
+    )
+  );
+
+  // Fetch the plan + monthly usage snapshot (no spend). Used for the dashboard
+  // badge and the chat's quota display; silently ignored on error so a status
+  // hiccup never disrupts the page.
+  public readonly loadStatus$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(loadStatus),
+      switchMap(() =>
+        this.service.status().pipe(
+          map((status) => loadStatusSuccess({ status })),
+          catchError(() => EMPTY)
+        )
+      )
     )
   );
 }

--- a/libs/frontend/captain/src/lib/+state/captain.reducer.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.reducer.ts
@@ -1,10 +1,11 @@
 import { createFeature, createReducer, on } from '@ngrx/store';
-import { ChatMessage, CaptainInsight } from '../captain.types';
+import { ChatMessage, CaptainInsight, CaptainStatus } from '../captain.types';
 import {
   clearChat,
   loadInsights,
   loadInsightsFailure,
   loadInsightsSuccess,
+  loadStatusSuccess,
   sendMessage,
   sendMessageFailure,
   sendMessageSuccess,
@@ -21,6 +22,8 @@ export interface FeatureState {
   insight: CaptainInsight | null;
   insightLoading: boolean;
   insightError: string | null;
+  /** The user's plan + monthly usage; null until first fetched. */
+  status: CaptainStatus | null;
 }
 
 export const initialState: FeatureState = {
@@ -31,6 +34,7 @@ export const initialState: FeatureState = {
   insight: null,
   insightLoading: false,
   insightError: null,
+  status: null,
 };
 
 export const reducer = createReducer(
@@ -43,10 +47,11 @@ export const reducer = createReducer(
     chatError: null,
     chatQuotaExceeded: false,
   })),
-  on(sendMessageSuccess, (state, { reply }) => ({
+  on(sendMessageSuccess, (state, { reply, usage }) => ({
     ...state,
     messages: [...state.messages, { role: 'assistant' as const, content: reply }],
     chatLoading: false,
+    status: usage ?? state.status,
   })),
   on(sendMessageFailure, (state, { error, quota }) => ({
     ...state,
@@ -66,16 +71,19 @@ export const reducer = createReducer(
     insightLoading: true,
     insightError: null,
   })),
-  on(loadInsightsSuccess, (state, { insight }) => ({
+  on(loadInsightsSuccess, (state, { insight, usage }) => ({
     ...state,
     insight,
     insightLoading: false,
+    status: usage ?? state.status,
   })),
   on(loadInsightsFailure, (state, { error }) => ({
     ...state,
     insightLoading: false,
     insightError: error,
-  }))
+  })),
+
+  on(loadStatusSuccess, (state, { status }) => ({ ...state, status }))
 );
 
 export const feature = createFeature({ name: featureKey, reducer });

--- a/libs/frontend/captain/src/lib/+state/captain.reducer.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.reducer.ts
@@ -16,6 +16,8 @@ export interface FeatureState {
   messages: ChatMessage[];
   chatLoading: boolean;
   chatError: string | null;
+  /** True when the last chat call was rejected for hitting the monthly quota. */
+  chatQuotaExceeded: boolean;
   insight: CaptainInsight | null;
   insightLoading: boolean;
   insightError: string | null;
@@ -25,6 +27,7 @@ export const initialState: FeatureState = {
   messages: [],
   chatLoading: false,
   chatError: null,
+  chatQuotaExceeded: false,
   insight: null,
   insightLoading: false,
   insightError: null,
@@ -38,18 +41,25 @@ export const reducer = createReducer(
     messages: [...state.messages, { role: 'user' as const, content }],
     chatLoading: true,
     chatError: null,
+    chatQuotaExceeded: false,
   })),
   on(sendMessageSuccess, (state, { reply }) => ({
     ...state,
     messages: [...state.messages, { role: 'assistant' as const, content: reply }],
     chatLoading: false,
   })),
-  on(sendMessageFailure, (state, { error }) => ({
+  on(sendMessageFailure, (state, { error, quota }) => ({
     ...state,
     chatLoading: false,
     chatError: error,
+    chatQuotaExceeded: !!quota,
   })),
-  on(clearChat, (state) => ({ ...state, messages: [], chatError: null })),
+  on(clearChat, (state) => ({
+    ...state,
+    messages: [],
+    chatError: null,
+    chatQuotaExceeded: false,
+  })),
 
   on(loadInsights, (state) => ({
     ...state,

--- a/libs/frontend/captain/src/lib/+state/captain.selectors.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.selectors.ts
@@ -37,3 +37,19 @@ export const selectInsightError = createSelector(
   selectFeature,
   (state) => state.insightError
 );
+
+export const selectStatus = createSelector(
+  selectFeature,
+  (state) => state.status
+);
+
+export const selectPlan = createSelector(
+  selectStatus,
+  (status) => status?.plan ?? null
+);
+
+/** Paid members and admins both have an elevated/unlimited plan. */
+export const selectIsPaidMember = createSelector(
+  selectPlan,
+  (plan) => plan === 'paid' || plan === 'admin'
+);

--- a/libs/frontend/captain/src/lib/+state/captain.selectors.ts
+++ b/libs/frontend/captain/src/lib/+state/captain.selectors.ts
@@ -18,6 +18,11 @@ export const selectChatError = createSelector(
   (state) => state.chatError
 );
 
+export const selectChatQuotaExceeded = createSelector(
+  selectFeature,
+  (state) => state.chatQuotaExceeded
+);
+
 export const selectInsight = createSelector(
   selectFeature,
   (state) => state.insight

--- a/libs/frontend/captain/src/lib/billing.service.spec.ts
+++ b/libs/frontend/captain/src/lib/billing.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { BillingService } from './billing.service';
+
+describe('BillingService', () => {
+  let service: BillingService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        BillingService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: 'ENVIRONMENT', useValue: { billingLambdaUrl: '/billing' } },
+      ],
+    });
+    service = TestBed.inject(BillingService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('posts to /billing/checkout and resolves to the Stripe URL', (done) => {
+    service.createCheckout().subscribe((url) => {
+      expect(url).toBe('https://checkout.stripe.com/abc');
+      done();
+    });
+    const req = httpMock.expectOne('/billing/checkout');
+    expect(req.request.method).toBe('POST');
+    req.flush({ url: 'https://checkout.stripe.com/abc' });
+  });
+
+  it('rejects a malformed checkout response (zod)', (done) => {
+    service.createCheckout().subscribe({
+      next: () => done.fail('should not succeed'),
+      error: (err) => {
+        expect(err).toBeDefined();
+        done();
+      },
+    });
+    httpMock.expectOne('/billing/checkout').flush({ notUrl: true });
+  });
+
+  it('startUpgrade triggers the checkout request', () => {
+    service.startUpgrade();
+    const req = httpMock.expectOne('/billing/checkout');
+    expect(req.request.method).toBe('POST');
+    // The redirect side-effect (window.location.href = url) is environment-
+    // driven and not asserted here; the checkout request firing is the unit.
+    req.flush({ url: 'https://checkout.stripe.com/go' });
+  });
+});

--- a/libs/frontend/captain/src/lib/billing.service.ts
+++ b/libs/frontend/captain/src/lib/billing.service.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { z } from 'zod';
+
+// The billing Lambda returns a Stripe Checkout Session URL to redirect to.
+const checkoutSchema = z.object({ url: z.string().url() });
+
+/**
+ * Talks to the billing Lambda to start a Stripe Checkout (subscription) flow.
+ * The JwtInterceptor attaches the Cognito ID token, so the Lambda knows which
+ * user to upgrade. The Stripe webhook — not the client — is the source of truth
+ * for the resulting plan.
+ */
+@Injectable({ providedIn: 'root' })
+export class BillingService {
+  private environment = inject<any>('ENVIRONMENT' as any);
+  private http = inject(HttpClient);
+
+  /** Resolve to the Stripe Checkout URL the caller should redirect to. */
+  public createCheckout(): Observable<string> {
+    return this.http
+      .post<unknown>(`${this.environment.billingLambdaUrl}/checkout`, {})
+      .pipe(map((res) => checkoutSchema.parse(res).url));
+  }
+
+  /** Start checkout and redirect the browser to Stripe. */
+  public startUpgrade(): void {
+    this.createCheckout().subscribe({
+      next: (url) => {
+        window.location.href = url;
+      },
+      // Surfaced by the caller's own error handling if needed; swallow here so
+      // a failed redirect doesn't throw in the click handler.
+      error: () => undefined,
+    });
+  }
+}

--- a/libs/frontend/captain/src/lib/captain.schemas.ts
+++ b/libs/frontend/captain/src/lib/captain.schemas.ts
@@ -1,9 +1,33 @@
 import { z } from 'zod';
+import { CaptainStatus } from './captain.types';
+
+// Usage snapshot the Lambda returns alongside a reply and from `mode: 'status'`.
+const usageSchema = z.object({
+  plan: z.enum(['free', 'paid', 'admin']),
+  limit: z.number().nullable(),
+  used: z.number(),
+  remaining: z.number().nullable(),
+});
 
 // Validate the Captain Lambda response before it reaches the UI — a malformed
 // payload would otherwise render as `undefined` in the chat.
-const captainReplySchema = z.object({ reply: z.string() });
+const captainReplySchema = z.object({
+  reply: z.string(),
+  usage: usageSchema.nullable().optional(),
+});
 
-export function parseCaptainReply(raw: unknown): string {
-  return captainReplySchema.parse(raw).reply;
+/** A Captain chat/insights reply plus the caller's post-call usage snapshot. */
+export interface CaptainReply {
+  reply: string;
+  usage: CaptainStatus | null;
+}
+
+export function parseCaptainReply(raw: unknown): CaptainReply {
+  const parsed = captainReplySchema.parse(raw);
+  return { reply: parsed.reply, usage: parsed.usage ?? null };
+}
+
+/** Validate the `mode: 'status'` response. */
+export function parseCaptainStatus(raw: unknown): CaptainStatus {
+  return usageSchema.parse(raw);
 }

--- a/libs/frontend/captain/src/lib/captain.service.spec.ts
+++ b/libs/frontend/captain/src/lib/captain.service.spec.ts
@@ -28,24 +28,49 @@ describe('CaptainService', () => {
 
   afterEach(() => httpMock.verify());
 
-  it('posts a chat request and resolves to the reply', (done) => {
-    service.chat([{ role: 'user', content: 'How did I do?' }], summary).subscribe((reply) => {
-      expect(reply).toBe('Aye, all is well.');
+  it('posts a chat request and resolves to the reply + usage', (done) => {
+    service.chat([{ role: 'user', content: 'How did I do?' }], summary).subscribe((res) => {
+      expect(res.reply).toBe('Aye, all is well.');
+      expect(res.usage?.plan).toBe('free');
+      expect(res.usage?.remaining).toBe(29);
       done();
     });
     const req = httpMock.expectOne('/captain');
     expect(req.request.body.mode).toBe('chat');
-    req.flush({ reply: 'Aye, all is well.' });
+    req.flush({
+      reply: 'Aye, all is well.',
+      usage: { plan: 'free', limit: 30, used: 1, remaining: 29 },
+    });
+  });
+
+  it('tolerates a reply with no usage (usage = null)', (done) => {
+    service.chat([{ role: 'user', content: 'hi' }], summary).subscribe((res) => {
+      expect(res.reply).toBe('Aye.');
+      expect(res.usage).toBeNull();
+      done();
+    });
+    httpMock.expectOne('/captain').flush({ reply: 'Aye.' });
   });
 
   it('posts an insights request in insights mode', (done) => {
-    service.insights(summary).subscribe((reply) => {
-      expect(reply).toBe('Calm seas.');
+    service.insights(summary).subscribe((res) => {
+      expect(res.reply).toBe('Calm seas.');
       done();
     });
     const req = httpMock.expectOne('/captain');
     expect(req.request.body.mode).toBe('insights');
     req.flush({ reply: 'Calm seas.' });
+  });
+
+  it('posts a status request and resolves to the snapshot', (done) => {
+    service.status().subscribe((status) => {
+      expect(status.plan).toBe('paid');
+      expect(status.limit).toBe(1000);
+      done();
+    });
+    const req = httpMock.expectOne('/captain');
+    expect(req.request.body.mode).toBe('status');
+    req.flush({ plan: 'paid', limit: 1000, used: 5, remaining: 995 });
   });
 
   it('rejects a malformed payload (zod)', (done) => {

--- a/libs/frontend/captain/src/lib/captain.service.ts
+++ b/libs/frontend/captain/src/lib/captain.service.ts
@@ -2,8 +2,8 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { map, Observable, timeout } from 'rxjs';
 import { retryWithBackoff } from '@aws/util';
-import { ChatMessage, CaptainSummary } from './captain.types';
-import { parseCaptainReply } from './captain.schemas';
+import { ChatMessage, CaptainStatus, CaptainSummary } from './captain.types';
+import { CaptainReply, parseCaptainReply, parseCaptainStatus } from './captain.schemas';
 
 // The Captain Lambda calls OpenAI, which can be slower than the DynamoDB CRUD
 // path; give it the same headroom as the Yahoo fan-out.
@@ -20,18 +20,29 @@ export class CaptainService {
   public chat(
     messages: ChatMessage[],
     summary: CaptainSummary
-  ): Observable<string> {
+  ): Observable<CaptainReply> {
     const body = { mode: 'chat', messages, summary };
     return this.post(body);
   }
 
   /** Ask for the dashboard "Captain's read" narrative. */
-  public insights(summary: CaptainSummary): Observable<string> {
+  public insights(summary: CaptainSummary): Observable<CaptainReply> {
     const body = { mode: 'insights', summary };
     return this.post(body);
   }
 
-  private post(body: unknown): Observable<string> {
+  /** Read-only plan + monthly usage snapshot (no spend, no quota increment). */
+  public status(): Observable<CaptainStatus> {
+    return this.http
+      .post<unknown>(this.environment.captainLambdaUrl, { mode: 'status' })
+      .pipe(
+        timeout(CAPTAIN_TIMEOUT_MS),
+        retryWithBackoff(),
+        map((response) => parseCaptainStatus(response))
+      );
+  }
+
+  private post(body: unknown): Observable<CaptainReply> {
     return this.http
       .post<unknown>(this.environment.captainLambdaUrl, body)
       .pipe(

--- a/libs/frontend/captain/src/lib/captain.types.ts
+++ b/libs/frontend/captain/src/lib/captain.types.ts
@@ -6,6 +6,20 @@ export interface ChatMessage {
   content: string;
 }
 
+/** Which subscription tier the user is on. `admin` is free + unlimited. */
+export type CaptainPlan = 'free' | 'paid' | 'admin';
+
+/** The user's plan + monthly usage, surfaced to the UI (badge, quota display). */
+export interface CaptainStatus {
+  plan: CaptainPlan;
+  /** Monthly call limit; `null` means unlimited (admin). */
+  limit: number | null;
+  /** Calls made this month. */
+  used: number;
+  /** Calls left this month; `null` when unlimited. */
+  remaining: number | null;
+}
+
 /** One holding, flattened to just the figures the Captain narrates. */
 export interface CaptainHolding {
   ticker: string;

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="captain-header-actions">
-      @if (!data?.demo) {
+      @if (!data?.demo && (isPaidMember$ | async) === false) {
         <button class="upgrade-link" (click)="upgrade()" type="button">
           <lucide-icon name="Sparkles" [size]="14"></lucide-icon>
           Captain Plus
@@ -77,6 +77,17 @@
       <lucide-icon name="Send" [size]="18"></lucide-icon>
     </button>
   </div>
+
+  <!-- Monthly usage -->
+  @if (!data?.demo && (status$ | async); as status) {
+    <p class="captain-usage">
+      @if (status.limit === null) {
+        Unlimited questions this month
+      } @else {
+        {{ status.used }} / {{ status.limit }} questions used this month
+      }
+    </p>
+  }
 
   <!-- Disclaimer -->
   <p class="captain-disclaimer">

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
@@ -8,9 +8,17 @@
         <p class="captain-subtitle">A plain-language read of your charts.</p>
       </div>
     </div>
-    <button class="icon-btn" (click)="close()" aria-label="Close">
-      <lucide-icon name="X" [size]="20"></lucide-icon>
-    </button>
+    <div class="captain-header-actions">
+      @if (!data?.demo) {
+        <button class="upgrade-link" (click)="upgrade()" type="button">
+          <lucide-icon name="Sparkles" [size]="14"></lucide-icon>
+          Captain Plus
+        </button>
+      }
+      <button class="icon-btn" (click)="close()" aria-label="Close">
+        <lucide-icon name="X" [size]="20"></lucide-icon>
+      </button>
+    </div>
   </header>
 
   <!-- Conversation -->

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
@@ -34,7 +34,17 @@
       </div>
     }
 
-    @if (error$ | async; as error) {
+    @if (quotaExceeded$ | async) {
+      <div class="captain-quota">
+        <lucide-icon name="Anchor" [size]="22"></lucide-icon>
+        <p>You've used all your Captain questions this month.</p>
+        @if (!data?.demo) {
+          <button class="upgrade-btn" (click)="upgrade()" type="button">
+            Upgrade for more
+          </button>
+        }
+      </div>
+    } @else if (error$ | async) {
       <div class="captain-error">The Captain couldn't reply just now. Try again shortly.</div>
     }
   </div>

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
@@ -46,6 +46,34 @@
   color: $color-muted;
 }
 
+.captain-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.upgrade-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: 1px solid $color-gold;
+  color: $color-gold;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-family: $font-sans;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: $transition-base;
+
+  &:hover {
+    background: $color-gold;
+    color: $color-bg-base;
+  }
+}
+
 .icon-btn {
   background: transparent;
   border: none;

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
@@ -137,6 +137,44 @@
   font-size: 0.82rem;
 }
 
+.captain-quota {
+  align-self: center;
+  text-align: center;
+  max-width: 280px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 14px;
+
+  lucide-icon {
+    color: $color-gold;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: $color-sand;
+  }
+}
+
+.upgrade-btn {
+  background: $accent-gradient;
+  border: none;
+  border-radius: $radius-sm;
+  color: $color-bg-base;
+  font-family: $font-sans;
+  font-weight: 600;
+  font-size: 0.82rem;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: $transition-base;
+
+  &:hover {
+    opacity: 0.92;
+  }
+}
+
 .captain-prompts {
   display: flex;
   flex-wrap: wrap;

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
@@ -270,9 +270,17 @@
   }
 }
 
+.captain-usage {
+  margin: 0;
+  padding: 8px 20px 0;
+  font-size: 0.72rem;
+  color: $color-sand;
+  text-align: center;
+}
+
 .captain-disclaimer {
   margin: 0;
-  padding: 0 20px 16px;
+  padding: 8px 20px 16px;
   font-size: 0.7rem;
   color: $color-muted;
   text-align: center;

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.spec.ts
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
-import { Store } from '@ngrx/store';
-import { sendMessage, clearChat } from '@aws/captain';
+import { BillingService, sendMessage, clearChat } from '@aws/captain';
 import { CaptainPanelComponent } from './captain-panel.component';
 import { DialogRef, DIALOG_DATA, DIALOG_REF } from '../dialog/dialog-ref';
 
@@ -10,15 +9,18 @@ describe('CaptainPanelComponent', () => {
   let store: MockStore;
   let dispatch: jest.SpyInstance;
   let dialogRef: DialogRef<CaptainPanelComponent>;
+  let billing: { startUpgrade: jest.Mock };
 
   function setup(data: { demo?: boolean } = {}) {
     dialogRef = new DialogRef<CaptainPanelComponent>();
+    billing = { startUpgrade: jest.fn() };
     TestBed.configureTestingModule({
       imports: [CaptainPanelComponent],
       providers: [
         provideMockStore(),
         { provide: DIALOG_REF, useValue: dialogRef },
         { provide: DIALOG_DATA, useValue: data },
+        { provide: BillingService, useValue: billing },
       ],
     });
     const fixture = TestBed.createComponent(CaptainPanelComponent);
@@ -62,5 +64,17 @@ describe('CaptainPanelComponent', () => {
     const spy = jest.spyOn(dialogRef, 'close');
     component.close();
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('upgrade() starts the Stripe checkout flow', () => {
+    setup();
+    component.upgrade();
+    expect(billing.startUpgrade).toHaveBeenCalled();
+  });
+
+  it('upgrade() is a no-op in demo mode', () => {
+    setup({ demo: true });
+    component.upgrade();
+    expect(billing.startUpgrade).not.toHaveBeenCalled();
   });
 });

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.ts
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule } from 'lucide-angular';
@@ -7,10 +7,13 @@ import {
   BillingService,
   CAPTAIN_PROMPTS,
   clearChat,
+  loadStatus,
   selectChatError,
   selectChatLoading,
   selectChatQuotaExceeded,
+  selectIsPaidMember,
   selectMessages,
+  selectStatus,
   sendMessage,
 } from '@aws/captain';
 import { DialogRef, DIALOG_DATA, DIALOG_REF } from '../dialog/dialog-ref';
@@ -32,7 +35,7 @@ export type CaptainPanelData = {
   templateUrl: './captain-panel.component.html',
   styleUrls: ['./captain-panel.component.scss'],
 })
-export class CaptainPanelComponent {
+export class CaptainPanelComponent implements OnInit {
   private store = inject(Store);
   private billing = inject(BillingService);
   dialogRef = inject<DialogRef<CaptainPanelComponent>>(DIALOG_REF);
@@ -43,8 +46,17 @@ export class CaptainPanelComponent {
   loading$ = this.store.select(selectChatLoading);
   error$ = this.store.select(selectChatError);
   quotaExceeded$ = this.store.select(selectChatQuotaExceeded);
+  status$ = this.store.select(selectStatus);
+  isPaidMember$ = this.store.select(selectIsPaidMember);
 
   draft = '';
+
+  ngOnInit(): void {
+    // Refresh plan + usage when the panel opens (skipped in demo — no backend).
+    if (!this.data?.demo) {
+      this.store.dispatch(loadStatus());
+    }
+  }
 
   send(content: string): void {
     const text = content.trim();

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.ts
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.ts
@@ -4,10 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { LucideAngularModule } from 'lucide-angular';
 import { Store } from '@ngrx/store';
 import {
+  BillingService,
   CAPTAIN_PROMPTS,
   clearChat,
   selectChatError,
   selectChatLoading,
+  selectChatQuotaExceeded,
   selectMessages,
   sendMessage,
 } from '@aws/captain';
@@ -32,6 +34,7 @@ export type CaptainPanelData = {
 })
 export class CaptainPanelComponent {
   private store = inject(Store);
+  private billing = inject(BillingService);
   dialogRef = inject<DialogRef<CaptainPanelComponent>>(DIALOG_REF);
   data = inject<CaptainPanelData>(DIALOG_DATA);
 
@@ -39,6 +42,7 @@ export class CaptainPanelComponent {
   messages$ = this.store.select(selectMessages);
   loading$ = this.store.select(selectChatLoading);
   error$ = this.store.select(selectChatError);
+  quotaExceeded$ = this.store.select(selectChatQuotaExceeded);
 
   draft = '';
 
@@ -53,6 +57,14 @@ export class CaptainPanelComponent {
 
   clear(): void {
     this.store.dispatch(clearChat());
+  }
+
+  /** Start the Stripe Checkout upgrade flow (no-op in demo mode). */
+  upgrade(): void {
+    if (this.data?.demo) {
+      return;
+    }
+    this.billing.startUpgrade();
   }
 
   close(): void {

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -10,11 +10,19 @@
     class="page"
     >
     <header class="page-header">
-      <h1 class="page-title">Portfolio</h1>
-      @if (vm.state?.summary?.startDate) {
-        <p class="page-subtitle">
-          Since {{ vm.state?.summary?.startDate | date : 'MMM yyyy' }}
-        </p>
+      <div class="page-heading">
+        <h1 class="page-title">Portfolio</h1>
+        @if (vm.state?.summary?.startDate) {
+          <p class="page-subtitle">
+            Since {{ vm.state?.summary?.startDate | date : 'MMM yyyy' }}
+          </p>
+        }
+      </div>
+      @if (isPaidMember$ | async) {
+        <span class="plan-badge" [class.admin]="(plan$ | async) === 'admin'">
+          <lucide-icon name="Sparkles" [size]="14"></lucide-icon>
+          {{ (plan$ | async) === 'admin' ? 'Admin' : 'Captain Plus' }}
+        </span>
       }
     </header>
     <!-- Portfolio filter chips (shown only when multiple portfolios exist) -->

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
@@ -9,6 +9,30 @@
 
 .page-header {
   margin-bottom: 8px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.plan-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  background: $accent-gradient;
+  color: $color-bg-base;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+
+  &.admin {
+    background: transparent;
+    border: 1px solid $color-gold;
+    color: $color-gold;
+  }
 }
 
 .page-title {

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.spec.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
-import { Store } from '@ngrx/store';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { setSelectedPortfolios, setTimeRange } from '@aws/state';
+import { loadStatus } from '@aws/captain';
 import { DashboardComponent } from './dashboard.component';
 
 describe('DashboardComponent', () => {
@@ -12,7 +13,14 @@ describe('DashboardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DashboardComponent],
-      providers: [provideMockStore()],
+      providers: [
+        provideMockStore(),
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: convertToParamMap({}) } },
+        },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+      ],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(DashboardComponent);
@@ -23,6 +31,11 @@ describe('DashboardComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('fetches plan + usage on init', () => {
+    component.ngOnInit();
+    expect(dispatch).toHaveBeenCalledWith(loadStatus());
   });
 
   describe('selectRange', () => {

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -1,4 +1,7 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { take, timer } from 'rxjs';
 import {
   selectBaseCurrency,
   selectLoading,
@@ -30,6 +33,9 @@ import { InsightsBannerComponent } from '../insights-banner/insights-banner.comp
 })
 export class DashboardComponent implements OnInit {
   private store = inject(Store);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   state$ = this.store.select(selectState);
   portfolios$ = this.store.select(selectPortfoliosDbo);
@@ -43,6 +49,17 @@ export class DashboardComponent implements OnInit {
   ngOnInit(): void {
     // Fetch plan + usage so the badge and the chat's quota display are accurate.
     this.store.dispatch(loadStatus());
+
+    // Returning from Stripe Checkout (success_url carries ?upgraded=1): the
+    // webhook that flips `plan` to paid can land a beat after the redirect, so
+    // re-poll a few times to surface the new badge/limit without a manual
+    // refresh, then drop the query param.
+    if (this.route.snapshot.queryParamMap.has('upgraded')) {
+      timer(2000, 2500)
+        .pipe(take(3), takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.store.dispatch(loadStatus()));
+      this.router.navigate([], { queryParams: {}, replaceUrl: true });
+    }
   }
 
   readonly ranges: TimeRange[] = ['1M', '3M', '6M', 'YTD', '1Y', '5Y', 'ALL'];

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import {
   selectBaseCurrency,
   selectLoading,
@@ -9,8 +9,14 @@ import {
   setSelectedPortfolios,
   setTimeRange,
 } from '@aws/state';
+import {
+  loadStatus,
+  selectIsPaidMember,
+  selectPlan,
+} from '@aws/captain';
 import { getCurrencySymbol, TIME_RANGE_LABELS, TimeRange } from '@aws/util';
 import { Store } from '@ngrx/store';
+import { LucideAngularModule } from 'lucide-angular';
 import { SummaryComponent } from '../summary/summary.component';
 import { AsyncPipe, CommonModule, DatePipe } from '@angular/common';
 import { ActiveTickersComponent } from '../active-tickers/active-tickers.component';
@@ -20,9 +26,9 @@ import { InsightsBannerComponent } from '../insights-banner/insights-banner.comp
   selector: 'aws-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent, InsightsBannerComponent],
+  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent, InsightsBannerComponent, LucideAngularModule],
 })
-export class DashboardComponent {
+export class DashboardComponent implements OnInit {
   private store = inject(Store);
 
   state$ = this.store.select(selectState);
@@ -31,6 +37,13 @@ export class DashboardComponent {
   baseCurrency$ = this.store.select(selectBaseCurrency);
   loading$ = this.store.select(selectLoading);
   timeRange$ = this.store.select(selectTimeRange);
+  plan$ = this.store.select(selectPlan);
+  isPaidMember$ = this.store.select(selectIsPaidMember);
+
+  ngOnInit(): void {
+    // Fetch plan + usage so the badge and the chat's quota display are accurate.
+    this.store.dispatch(loadStatus());
+  }
 
   readonly ranges: TimeRange[] = ['1M', '3M', '6M', 'YTD', '1Y', '5Y', 'ALL'];
   readonly rangeLabels = TIME_RANGE_LABELS;

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -25,4 +25,4 @@ capabilities = "CAPABILITY_IAM"
 resolve_s3 = true
 confirm_changeset = false
 fail_on_empty_changeset = false
-parameter_overrides = "Stage=\"prod\" AllowedOrigins=\"https://sailor.toondeboer.com\" CognitoUserPoolId=\"us-east-1_liCB4LgDE\" CognitoClientId=\"3o34bbl92faeo9ljo11eebtim2\" TableName=\"sailor\""
+parameter_overrides = "Stage=\"prod\" AllowedOrigins=\"https://sailor.toondeboer.com\" CognitoUserPoolId=\"us-east-1_liCB4LgDE\" CognitoClientId=\"3o34bbl92faeo9ljo11eebtim2\" TableName=\"sailor\" StripePriceId=\"price_1Teh4i6QCB4ocnGQUbiEpFbc\" GlobalMonthlyLimit=\"450\""

--- a/scripts/seed-test-users.sh
+++ b/scripts/seed-test-users.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Seed repeatable test users (admin / paid / regular) for local testing.
+#
+# Creates three Cognito users with permanent passwords in the given pool, adds
+# the admin to the `admin` group, and marks the paid user `plan=paid` in
+# DynamoDB Local — so every access path (unlimited / paid limit / free limit +
+# upgrade CTA) has a ready account.
+#
+# Cognito calls use your ambient AWS credentials (point this at a DEV pool, not
+# prod — see the README). The plan write goes to DynamoDB Local.
+#
+# Usage:
+#   POOL_ID=us-east-1_xxxx ./scripts/seed-test-users.sh
+#   POOL_ID=us-east-1_xxxx PASSWORD='Custom1!' ./scripts/seed-test-users.sh
+set -euo pipefail
+
+: "${POOL_ID:?Set POOL_ID to your (dev) Cognito user pool id}"
+PASSWORD="${PASSWORD:-Passw0rd!}"
+REGION="${AWS_REGION:-us-east-1}"
+DDB_ENDPOINT="${DDB_ENDPOINT:-http://localhost:8000}"
+
+ADMIN_USER="admin@test"
+PAID_USER="paid@test"
+REGULAR_USER="regular@test"
+
+create_user() {
+  local username="$1"
+  # Idempotent: ignore "already exists".
+  aws cognito-idp admin-create-user --region "$REGION" \
+    --user-pool-id "$POOL_ID" --username "$username" \
+    --message-action SUPPRESS >/dev/null 2>&1 || true
+  aws cognito-idp admin-set-user-password --region "$REGION" \
+    --user-pool-id "$POOL_ID" --username "$username" \
+    --password "$PASSWORD" --permanent
+  echo "  ✓ $username"
+}
+
+user_sub() {
+  aws cognito-idp admin-get-user --region "$REGION" \
+    --user-pool-id "$POOL_ID" --username "$1" \
+    --query 'UserAttributes[?Name==`sub`].Value' --output text
+}
+
+echo "Seeding test users in pool $POOL_ID (region $REGION)…"
+create_user "$ADMIN_USER"
+create_user "$PAID_USER"
+create_user "$REGULAR_USER"
+
+# Admin group (create if missing) + membership.
+aws cognito-idp create-group --region "$REGION" \
+  --user-pool-id "$POOL_ID" --group-name admin >/dev/null 2>&1 || true
+aws cognito-idp admin-add-user-to-group --region "$REGION" \
+  --user-pool-id "$POOL_ID" --group-name admin --username "$ADMIN_USER"
+echo "  ✓ $ADMIN_USER added to 'admin' group"
+
+# Mark the paid user paid in DynamoDB Local (dummy creds; local endpoint).
+PAID_SUB="$(user_sub "$PAID_USER")"
+AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local \
+aws dynamodb update-item --endpoint-url "$DDB_ENDPOINT" --region "$REGION" \
+  --table-name sailor --key "{\"userId\":{\"S\":\"$PAID_SUB\"}}" \
+  --update-expression "SET #p = :p" \
+  --expression-attribute-names '{"#p":"plan"}' \
+  --expression-attribute-values '{":p":{"S":"paid"}}'
+echo "  ✓ $PAID_USER set to plan=paid (sub $PAID_SUB)"
+
+cat <<SUMMARY
+
+Done. Sign in with password: $PASSWORD
+  admin   → $ADMIN_USER    (unlimited; "Admin" badge; no upgrade button)
+  paid    → $PAID_USER     (paid limit; "Captain Plus" badge; no upgrade button)
+  regular → $REGULAR_USER  (free limit; upgrade CTA at the cap)
+
+Note: the paid flag lives in DynamoDB Local, so re-run this after resetting the table.
+SUMMARY

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Build and run the sailor Lambdas locally with AWS SAM.
+#
+# Uses dummy AWS credentials (so DynamoDB Local works and no real AWS call is
+# made) and injects secrets from env.json — crucially OPENAI_API_KEY, so the
+# Captain Lambda reads the key directly instead of falling through to SSM (which
+# would fail under the dummy credentials).
+#
+# Prereqs (separate terminals): `docker-compose up` for DynamoDB Local, and a
+# one-time `python services/init_dynamodb.py` to create the table.
+#
+# Usage:  ./scripts/start-backend.sh
+set -euo pipefail
+
+# Run from the repo root regardless of where the script is invoked from.
+cd "$(dirname "$0")/.."
+
+if [[ ! -f env.json ]]; then
+  echo "error: env.json not found." >&2
+  echo "  cp env.json.example env.json   # then paste your OpenAI (and Stripe) keys" >&2
+  exit 1
+fi
+
+sam build
+
+AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local \
+  sam local start-api --env-vars env.json

--- a/services/handler_billing.py
+++ b/services/handler_billing.py
@@ -1,0 +1,176 @@
+"""Billing Lambda — Stripe Checkout + webhook for the Captain subscription.
+
+Two endpoints behind /billing/{proxy+}:
+
+  * POST /billing/checkout  — Cognito-authed. Starts a Stripe Checkout Session
+    (mode=subscription) and returns its URL for the browser to redirect to.
+  * POST /billing/webhook   — NOT Cognito-authed (Stripe calls it). Verifies the
+    Stripe signature, then writes the resulting plan onto the user's record.
+  * GET  /billing/portal    — Cognito-authed. Returns a Stripe Billing Portal URL
+    so the user can manage/cancel their subscription.
+
+The webhook is the ONLY writer of `plan` — the client is never trusted to set it.
+`stripe` is imported lazily so the handler stays importable/unit-testable without
+the package installed.
+"""
+import json
+import os
+
+from shared.auth import verify_token
+from shared.cors import build_headers
+from shared.db import get_table
+from shared.secrets import get_stripe_secret_key, get_stripe_webhook_secret
+
+_PRICE_ID = os.environ.get('STRIPE_PRICE_ID', '')
+_SUCCESS_URL = os.environ.get('BILLING_SUCCESS_URL', 'http://localhost:4200/?upgraded=1')
+_CANCEL_URL = os.environ.get('BILLING_CANCEL_URL', 'http://localhost:4200/')
+
+# Stripe subscription statuses that grant the paid plan.
+_ACTIVE_STATUSES = {'active', 'trialing'}
+
+
+def _json(status: int, payload: dict, headers: dict) -> dict:
+    return {'statusCode': status, 'body': json.dumps(payload), 'headers': headers}
+
+
+def _stripe():
+    import stripe
+
+    stripe.api_key = get_stripe_secret_key()
+    return stripe
+
+
+def _authed_sub(event):
+    """Return (sub, email) from a verified Cognito ID token, or raise."""
+    token = (event.get('headers') or {}).get('Authorization') or \
+            (event.get('headers') or {}).get('authorization')
+    if not token:
+        raise PermissionError('Missing token')
+    decoded = verify_token(token)
+    return decoded['sub'], decoded.get('email')
+
+
+def _set_plan(sub: str, plan: str, **fields) -> None:
+    """Write the plan (and optional Stripe metadata) onto the user's record."""
+    table = get_table()
+    names = {'#plan': 'plan'}
+    values = {':plan': plan}
+    sets = ['#plan = :plan']
+    for i, (key, val) in enumerate(fields.items()):
+        if val is None:
+            continue
+        names[f'#f{i}'] = key
+        values[f':v{i}'] = val
+        sets.append(f'#f{i} = :v{i}')
+    table.update_item(
+        Key={'userId': sub},
+        UpdateExpression='SET ' + ', '.join(sets),
+        ExpressionAttributeNames=names,
+        ExpressionAttributeValues=values,
+    )
+
+
+def _checkout(event, headers):
+    try:
+        sub, email = _authed_sub(event)
+    except Exception as exc:
+        return _json(401, {'message': f'Unauthorized: {exc}'}, headers)
+
+    if not _PRICE_ID:
+        return _json(500, {'message': 'Billing is not configured'}, headers)
+
+    stripe = _stripe()
+    # Reuse the stored customer if we have one (set by a prior webhook).
+    customer_id = get_table().get_item(Key={'userId': sub}).get('Item', {}).get('stripeCustomerId')
+    session = stripe.checkout.Session.create(
+        mode='subscription',
+        line_items=[{'price': _PRICE_ID, 'quantity': 1}],
+        success_url=_SUCCESS_URL,
+        cancel_url=_CANCEL_URL,
+        client_reference_id=sub,
+        # Stamp the sub onto the subscription so later subscription.* webhooks
+        # can resolve the user without a reverse lookup / GSI.
+        subscription_data={'metadata': {'sub': sub}},
+        **({'customer': customer_id} if customer_id else {'customer_email': email}),
+    )
+    return _json(200, {'url': session.url}, headers)
+
+
+def _portal(event, headers):
+    try:
+        sub, _ = _authed_sub(event)
+    except Exception as exc:
+        return _json(401, {'message': f'Unauthorized: {exc}'}, headers)
+
+    customer_id = get_table().get_item(Key={'userId': sub}).get('Item', {}).get('stripeCustomerId')
+    if not customer_id:
+        return _json(400, {'message': 'No subscription to manage'}, headers)
+
+    stripe = _stripe()
+    session = stripe.billing_portal.Session.create(
+        customer=customer_id, return_url=_CANCEL_URL
+    )
+    return _json(200, {'url': session.url}, headers)
+
+
+def _webhook(event, headers):
+    stripe = _stripe()
+    sig = (event.get('headers') or {}).get('Stripe-Signature') or \
+          (event.get('headers') or {}).get('stripe-signature')
+    payload = event.get('body') or ''
+    try:
+        stripe_event = stripe.Webhook.construct_event(
+            payload, sig, get_stripe_webhook_secret()
+        )
+    except Exception as exc:
+        # Bad/forged signature — never trust the payload.
+        print(f'Stripe webhook signature verification failed: {exc}')
+        return _json(400, {'message': 'Invalid signature'}, headers)
+
+    etype = stripe_event['type']
+    obj = stripe_event['data']['object']
+
+    if etype == 'checkout.session.completed':
+        sub = obj.get('client_reference_id')
+        if sub:
+            _set_plan(
+                sub, 'paid',
+                stripeCustomerId=obj.get('customer'),
+                subscriptionStatus='active',
+            )
+    elif etype in ('customer.subscription.updated', 'customer.subscription.created'):
+        sub = (obj.get('metadata') or {}).get('sub')
+        if sub:
+            active = obj.get('status') in _ACTIVE_STATUSES
+            _set_plan(
+                sub, 'paid' if active else 'free',
+                stripeCustomerId=obj.get('customer'),
+                subscriptionStatus=obj.get('status'),
+                currentPeriodEnd=obj.get('current_period_end'),
+            )
+    elif etype == 'customer.subscription.deleted':
+        sub = (obj.get('metadata') or {}).get('sub')
+        if sub:
+            _set_plan(sub, 'free', subscriptionStatus='canceled')
+
+    # Always 200 for handled-or-ignored events so Stripe stops retrying.
+    return _json(200, {'received': True}, headers)
+
+
+def handler(event, context):
+    headers = build_headers(event)
+
+    if event.get('httpMethod') == 'OPTIONS':
+        return {'statusCode': 200, 'body': '', 'headers': headers}
+
+    route = (event.get('pathParameters') or {}).get('proxy') or ''
+    route = route.strip('/')
+
+    if route == 'checkout':
+        return _checkout(event, headers)
+    if route == 'portal':
+        return _portal(event, headers)
+    if route == 'webhook':
+        return _webhook(event, headers)
+
+    return _json(404, {'message': f'Unknown billing route: {route}'}, headers)

--- a/services/handler_captain.py
+++ b/services/handler_captain.py
@@ -3,6 +3,7 @@ import os
 
 from shared.auth import verify_token
 from shared.cors import build_headers
+from shared.db import current_month, decrement, get_table, try_increment
 from shared.secrets import get_openai_api_key
 
 # Cheapest small chat model by default; overridable without a code change.
@@ -20,6 +21,32 @@ _MAX_CONTENT_CHARS = 2000
 _MAX_SUMMARY_CHARS = 8000
 
 _ALLOWED_ROLES = {'user', 'assistant'}
+
+# --- Usage quotas ---------------------------------------------------------
+# Two layers protect spend (see README "Cost control"):
+#   * Per-user monthly quota — fairness; differs by plan (free vs paid).
+#   * Global monthly ceiling — the hard money guarantee: once the whole crew
+#     has made this many calls in a month, ALL captain calls stop until the
+#     next month. Derive it from live OpenAI pricing (budget / cost-per-call);
+#     0 disables it (local dev / tests).
+_FREE_MONTHLY_LIMIT = int(os.environ.get('FREE_MONTHLY_LIMIT', '30'))
+_PAID_MONTHLY_LIMIT = int(os.environ.get('PAID_MONTHLY_LIMIT', '1000'))
+_GLOBAL_MONTHLY_LIMIT = int(os.environ.get('GLOBAL_MONTHLY_LIMIT', '0'))
+
+# Cognito group whose members bypass all quotas (free, unlimited).
+_ADMIN_GROUP = 'admin'
+
+
+class QuotaExceeded(Exception):
+    """Raised when a per-user or global monthly quota is exhausted.
+
+    ``scope`` is 'user' (the caller hit their own limit — offer an upgrade) or
+    'global' (the service-wide ceiling is reached — nobody is served).
+    """
+
+    def __init__(self, scope: str):
+        self.scope = scope
+        super().__init__(scope)
 
 # The Captain's persona + the hard no-advice guardrail. The model explains the
 # user's own numbers in plain language with light nautical flavour, and refuses
@@ -110,6 +137,61 @@ def _call_openai(messages: list) -> str:
     return (completion.choices[0].message.content or '').strip()
 
 
+def _user_plan(table, sub: str) -> str:
+    """Return the user's plan ('paid' or 'free'), defaulting to 'free'.
+
+    The plan is written solely by the Stripe webhook (handler_billing). Fails
+    open to 'free' on any read error so a transient DynamoDB blip applies the
+    stricter limit rather than crashing the request.
+    """
+    try:
+        resp = table.get_item(Key={'userId': sub})
+        return resp.get('Item', {}).get('plan', 'free')
+    except Exception as exc:  # noqa: BLE001
+        print(f'plan lookup failed, defaulting to free: {exc}')
+        return 'free'
+
+
+def _enforce_quota(sub: str):
+    """Reserve one call against the user + global monthly quotas.
+
+    Returns the user's remaining quota after this call (``None`` when the check
+    could not be applied), or raises ``QuotaExceeded``.
+
+    Failure policy: the per-user check fails OPEN (a DynamoDB blip must not block
+    a user mid-conversation), while the global ceiling fails CLOSED (if we can't
+    prove we're under budget, refuse rather than risk overspend).
+    """
+    table = get_table()
+    month = current_month()
+
+    plan = _user_plan(table, sub)
+    user_limit = _PAID_MONTHLY_LIMIT if plan == 'paid' else _FREE_MONTHLY_LIMIT
+
+    user_key = f'usage#{sub}#{month}'
+    try:
+        new_count = try_increment(table, user_key, user_limit)
+    except Exception as exc:  # noqa: BLE001 - fail open to protect UX
+        print(f'per-user quota check failed open: {exc}')
+        return None
+    if new_count is None:
+        raise QuotaExceeded('user')
+
+    if _GLOBAL_MONTHLY_LIMIT > 0:
+        global_key = f'usage#global#{month}'
+        try:
+            under_cap = try_increment(table, global_key, _GLOBAL_MONTHLY_LIMIT)
+        except Exception as exc:  # noqa: BLE001 - fail closed to protect spend
+            print(f'global quota check failed closed: {exc}')
+            decrement(table, user_key)  # refund the call we just reserved
+            raise QuotaExceeded('global')
+        if under_cap is None:
+            decrement(table, user_key)
+            raise QuotaExceeded('global')
+
+    return max(user_limit - new_count, 0)
+
+
 def handler(event, context):
     headers = build_headers(event)
 
@@ -122,9 +204,11 @@ def handler(event, context):
     if not token:
         return _error(401, 'Unauthorized: Missing token', headers)
     try:
-        verify_token(token)
+        decoded = verify_token(token)
     except Exception as exc:
         return _error(401, f'Unauthorized: {exc}', headers)
+    sub = decoded.get('sub')
+    is_admin = _ADMIN_GROUP in (decoded.get('cognito:groups') or [])
 
     try:
         body = json.loads(event.get('body') or '{}')
@@ -148,6 +232,25 @@ def handler(event, context):
     if mode == 'chat' and not user_messages:
         return _error(400, "Chat mode requires at least one message", headers)
 
+    # Quota — admins bypass; everyone else reserves one call against their
+    # per-user and the global monthly ceiling before we spend on OpenAI.
+    remaining = None
+    if not is_admin:
+        try:
+            remaining = _enforce_quota(sub)
+        except QuotaExceeded as exc:
+            if exc.scope == 'global':
+                msg = ("The Captain is resting — the crew has reached this "
+                       "month's limit. Fair winds again next month.")
+            else:
+                msg = ("You've used all your Captain questions this month. "
+                       "Upgrade for more, or check back next month.")
+            return {
+                'statusCode': 429,
+                'body': json.dumps({'message': msg, 'scope': exc.scope}),
+                'headers': headers,
+            }
+
     chat_messages = [
         {'role': 'system', 'content': _SYSTEM_PROMPT},
         {'role': 'system', 'content': f'Portfolio summary (JSON):\n{summary_json}'},
@@ -165,6 +268,6 @@ def handler(event, context):
 
     return {
         'statusCode': 200,
-        'body': json.dumps({'reply': reply}),
+        'body': json.dumps({'reply': reply, 'remaining': remaining}),
         'headers': headers,
     }

--- a/services/handler_captain.py
+++ b/services/handler_captain.py
@@ -48,6 +48,15 @@ class QuotaExceeded(Exception):
         self.scope = scope
         super().__init__(scope)
 
+
+class QuotaUnavailable(Exception):
+    """Raised when the quota counter store itself can't be reached.
+
+    Distinct from ``QuotaExceeded`` (a limit was hit). Here we couldn't even
+    record the call, so we can't prove we're under budget — the handler fails
+    CLOSED (refuse, never call OpenAI) rather than risk unbounded spend.
+    """
+
 # The Captain's persona + the hard no-advice guardrail. The model explains the
 # user's own numbers in plain language with light nautical flavour, and refuses
 # anything that strays into advice, opinion or prediction with a short, varied,
@@ -183,11 +192,14 @@ def _enforce_quota(sub: str):
     """Reserve one call against the user + global monthly quotas.
 
     Returns a usage snapshot dict (plan, limit, used, remaining) after this call,
-    ``None`` when the check could not be applied, or raises ``QuotaExceeded``.
+    or raises ``QuotaExceeded`` (a limit was hit → 429) / ``QuotaUnavailable``
+    (the counter store errored → 503).
 
-    Failure policy: the per-user check fails OPEN (a DynamoDB blip must not block
-    a user mid-conversation), while the global ceiling fails CLOSED (if we can't
-    prove we're under budget, refuse rather than risk overspend).
+    Failure policy: both counter writes fail CLOSED. The atomic increment is the
+    spend gate — OpenAI is only ever reached after one succeeds — so if DynamoDB
+    is unreachable we refuse rather than risk overspend. (The plan *read* below
+    fails open to the stricter free tier: it's not spend-critical, and a
+    successful increment still proves we're under budget.)
     """
     table = get_table()
     month = current_month()
@@ -198,9 +210,9 @@ def _enforce_quota(sub: str):
     user_key = f'usage#{sub}#{month}'
     try:
         new_count = try_increment(table, user_key, user_limit)
-    except Exception as exc:  # noqa: BLE001 - fail open to protect UX
-        print(f'per-user quota check failed open: {exc}')
-        return None
+    except Exception as exc:  # noqa: BLE001 - fail CLOSED to protect spend
+        print(f'per-user quota check failed closed: {exc}')
+        raise QuotaUnavailable() from exc
     if new_count is None:
         raise QuotaExceeded('user')
 
@@ -208,10 +220,10 @@ def _enforce_quota(sub: str):
         global_key = f'usage#global#{month}'
         try:
             under_cap = try_increment(table, global_key, _GLOBAL_MONTHLY_LIMIT)
-        except Exception as exc:  # noqa: BLE001 - fail closed to protect spend
+        except Exception as exc:  # noqa: BLE001 - fail CLOSED to protect spend
             print(f'global quota check failed closed: {exc}')
             decrement(table, user_key)  # refund the call we just reserved
-            raise QuotaExceeded('global')
+            raise QuotaUnavailable() from exc
         if under_cap is None:
             decrement(table, user_key)
             raise QuotaExceeded('global')
@@ -288,6 +300,12 @@ def handler(event, context):
                 'body': json.dumps({'message': msg, 'scope': exc.scope}),
                 'headers': headers,
             }
+        except QuotaUnavailable:
+            # Can't reach the counter store, so we can't prove we're under
+            # budget — refuse rather than spend (fail closed). No OpenAI call.
+            return _error(
+                503, 'The Captain is checking the ledger — try again shortly.', headers
+            )
 
     chat_messages = [
         {'role': 'system', 'content': _SYSTEM_PROMPT},

--- a/services/handler_captain.py
+++ b/services/handler_captain.py
@@ -152,11 +152,38 @@ def _user_plan(table, sub: str) -> str:
         return 'free'
 
 
+def _read_used(table, sub: str, month: str) -> int:
+    """Return the user's call count for the month (0 on miss / read error)."""
+    try:
+        resp = table.get_item(Key={'userId': f'usage#{sub}#{month}'})
+        return int(resp.get('Item', {}).get('count', 0))
+    except Exception as exc:  # noqa: BLE001
+        print(f'usage read failed: {exc}')
+        return 0
+
+
+def _status(sub: str, is_admin: bool) -> dict:
+    """Read-only usage snapshot for the UI (plan, limit, used, remaining).
+
+    Admins are unlimited, so limit/remaining are null. Never increments and never
+    calls OpenAI.
+    """
+    table = get_table()
+    month = current_month()
+    used = _read_used(table, sub, month)
+    if is_admin:
+        return {'plan': 'admin', 'limit': None, 'used': used, 'remaining': None}
+    plan = _user_plan(table, sub)
+    limit = _PAID_MONTHLY_LIMIT if plan == 'paid' else _FREE_MONTHLY_LIMIT
+    return {'plan': plan, 'limit': limit, 'used': used,
+            'remaining': max(limit - used, 0)}
+
+
 def _enforce_quota(sub: str):
     """Reserve one call against the user + global monthly quotas.
 
-    Returns the user's remaining quota after this call (``None`` when the check
-    could not be applied), or raises ``QuotaExceeded``.
+    Returns a usage snapshot dict (plan, limit, used, remaining) after this call,
+    ``None`` when the check could not be applied, or raises ``QuotaExceeded``.
 
     Failure policy: the per-user check fails OPEN (a DynamoDB blip must not block
     a user mid-conversation), while the global ceiling fails CLOSED (if we can't
@@ -189,7 +216,8 @@ def _enforce_quota(sub: str):
             decrement(table, user_key)
             raise QuotaExceeded('global')
 
-    return max(user_limit - new_count, 0)
+    return {'plan': plan, 'limit': user_limit, 'used': new_count,
+            'remaining': max(user_limit - new_count, 0)}
 
 
 def handler(event, context):
@@ -216,8 +244,16 @@ def handler(event, context):
         return _error(400, 'Invalid JSON body', headers)
 
     mode = body.get('mode', 'chat')
+    # Read-only usage snapshot for the UI (plan badge, remaining-quota display).
+    # No summary required, no spend, no increment.
+    if mode == 'status':
+        return {
+            'statusCode': 200,
+            'body': json.dumps(_status(sub, is_admin)),
+            'headers': headers,
+        }
     if mode not in ('chat', 'insights'):
-        return _error(400, "Field 'mode' must be 'chat' or 'insights'", headers)
+        return _error(400, "Field 'mode' must be 'chat', 'insights' or 'status'", headers)
 
     summary = body.get('summary')
     if not isinstance(summary, dict):
@@ -234,10 +270,12 @@ def handler(event, context):
 
     # Quota — admins bypass; everyone else reserves one call against their
     # per-user and the global monthly ceiling before we spend on OpenAI.
-    remaining = None
-    if not is_admin:
+    usage = None
+    if is_admin:
+        usage = _status(sub, is_admin=True)
+    else:
         try:
-            remaining = _enforce_quota(sub)
+            usage = _enforce_quota(sub)
         except QuotaExceeded as exc:
             if exc.scope == 'global':
                 msg = ("The Captain is resting — the crew has reached this "
@@ -268,6 +306,6 @@ def handler(event, context):
 
     return {
         'statusCode': 200,
-        'body': json.dumps({'reply': reply, 'remaining': remaining}),
+        'body': json.dumps({'reply': reply, 'usage': usage}),
         'headers': headers,
     }

--- a/services/handler_dynamodb.py
+++ b/services/handler_dynamodb.py
@@ -1,13 +1,11 @@
 import json
-import os
 
-import boto3
 from boto3.dynamodb.conditions import Key
 
 from shared.auth import verify_token
 from shared.cors import build_headers
+from shared.db import get_table
 
-_TABLE_NAME = 'sailor'
 _CURRENT_SCHEMA_VERSION = 2
 
 _EMPTY_V2 = {
@@ -32,21 +30,6 @@ def _migrate_v1_to_v2(item):
             {'id': 'default', 'name': 'Default', 'transactions': legacy_transactions}
         ],
     }
-
-
-def _get_table():
-    env = os.environ.get('ENVIRONMENT', 'dev')
-    if env == 'dev':
-        dynamodb = boto3.resource(
-            'dynamodb',
-            endpoint_url='http://host.docker.internal:8000',
-            region_name='us-east-1',
-            aws_access_key_id='fake',
-            aws_secret_access_key='fake',
-        )
-    else:
-        dynamodb = boto3.resource('dynamodb')
-    return dynamodb.Table(_TABLE_NAME)
 
 
 def handler(event, context):
@@ -75,7 +58,7 @@ def handler(event, context):
             'headers': headers,
         }
 
-    table = _get_table()
+    table = get_table()
     method = event.get('httpMethod')
 
     try:

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -1,3 +1,4 @@
 PyJWT[cryptography]>=2.8.0
 cryptography>=41.0.0
 openai>=1.0.0
+stripe>=8.0.0

--- a/services/shared/db.py
+++ b/services/shared/db.py
@@ -1,0 +1,99 @@
+"""Shared DynamoDB access for the Lambdas.
+
+Centralises the table handle (so dev/prod endpoint selection lives in one place)
+and the atomic monthly-counter primitives used for OpenAI usage quotas. Keeping
+this here means handler_dynamodb, handler_captain and handler_billing all share
+one code path instead of each re-deriving the resource.
+"""
+import os
+import time
+from datetime import datetime, timezone
+
+import boto3
+from botocore.exceptions import ClientError
+
+# The table name is fixed in prod ('sailor') but overridable for tests/local.
+_TABLE_NAME = os.environ.get('TABLE_NAME', 'sailor')
+
+# How long a monthly counter item lives before DynamoDB TTL reaps it. A little
+# over two months so the current and previous buckets always survive (handy for
+# debugging) while nothing accumulates long-term. TTL deletion is free.
+_COUNTER_TTL_DAYS = 70
+
+
+def get_table():
+    """Return the DynamoDB Table handle.
+
+    In dev (``ENVIRONMENT=dev``) it points at DynamoDB Local over Docker;
+    otherwise it uses the Lambda's IAM role against real DynamoDB. Lifted
+    verbatim from handler_dynamodb so every handler resolves the table the
+    same way.
+    """
+    env = os.environ.get('ENVIRONMENT', 'dev')
+    if env == 'dev':
+        dynamodb = boto3.resource(
+            'dynamodb',
+            endpoint_url='http://host.docker.internal:8000',
+            region_name='us-east-1',
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+        )
+    else:
+        dynamodb = boto3.resource('dynamodb')
+    return dynamodb.Table(_TABLE_NAME)
+
+
+def current_month() -> str:
+    """UTC year-month bucket (e.g. '2026-06'), used in counter partition keys."""
+    return datetime.now(timezone.utc).strftime('%Y-%m')
+
+
+def _ttl_epoch() -> int:
+    return int(time.time()) + _COUNTER_TTL_DAYS * 24 * 60 * 60
+
+
+def try_increment(table, key: str, limit: int):
+    """Atomically increment the monthly counter at ``key``, capped at ``limit``.
+
+    Returns the new count when the increment succeeds (the call is within
+    quota), or ``None`` when the cap was already reached. Race-free: the cap is
+    enforced by a DynamoDB ``ConditionExpression``, so concurrent invocations
+    can never overshoot ``limit`` — no read-modify-write window.
+    """
+    try:
+        resp = table.update_item(
+            Key={'userId': key},
+            UpdateExpression=(
+                'ADD #c :one SET expiresAt = if_not_exists(expiresAt, :ttl)'
+            ),
+            ConditionExpression='attribute_not_exists(#c) OR #c < :limit',
+            ExpressionAttributeNames={'#c': 'count'},
+            ExpressionAttributeValues={
+                ':one': 1,
+                ':limit': limit,
+                ':ttl': _ttl_epoch(),
+            },
+            ReturnValues='UPDATED_NEW',
+        )
+        return int(resp['Attributes']['count'])
+    except ClientError as exc:
+        if exc.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            return None
+        raise
+
+
+def decrement(table, key: str) -> None:
+    """Best-effort refund of one unit from the counter at ``key``.
+
+    Used when a later check rejects a call we had already counted. Never raises:
+    a failed refund must not surface as a user-facing error.
+    """
+    try:
+        table.update_item(
+            Key={'userId': key},
+            UpdateExpression='ADD #c :neg',
+            ExpressionAttributeNames={'#c': 'count'},
+            ExpressionAttributeValues={':neg': -1},
+        )
+    except Exception as exc:  # noqa: BLE001 - refund is strictly best-effort
+        print(f'counter refund failed for {key}: {exc}')

--- a/services/shared/db.py
+++ b/services/shared/db.py
@@ -63,8 +63,11 @@ def try_increment(table, key: str, limit: int):
     try:
         resp = table.update_item(
             Key={'userId': key},
+            # SET must precede ADD: real DynamoDB tolerates any clause order, but
+            # DynamoDB Local enforces the documented SET/REMOVE/ADD/DELETE order
+            # and rejects ADD-first with a ValidationException.
             UpdateExpression=(
-                'ADD #c :one SET expiresAt = if_not_exists(expiresAt, :ttl)'
+                'SET expiresAt = if_not_exists(expiresAt, :ttl) ADD #c :one'
             ),
             ConditionExpression='attribute_not_exists(#c) OR #c < :limit',
             ExpressionAttributeNames={'#c': 'count'},

--- a/services/shared/secrets.py
+++ b/services/shared/secrets.py
@@ -1,40 +1,53 @@
 import os
 
 # Module-level cache: populated on first lookup, reused across warm-start
-# invocations (mirrors the JWKS cache in shared/auth.py).
-_openai_api_key: str | None = None
+# invocations (mirrors the JWKS cache in shared/auth.py). Keyed by SSM param name.
+_cache: dict[str, str] = {}
 
 
-def get_openai_api_key() -> str:
-    """Return the OpenAI API key.
+def _get_secret(env_var: str, param_env_var: str) -> str:
+    """Resolve a secret from an env var first, then SSM Parameter Store.
 
     Resolution order:
-      1. ``OPENAI_API_KEY`` env var — used for local dev / `sam local`, where
-         SSM isn't reachable.
-      2. The SSM Parameter Store SecureString named by ``OPENAI_PARAM_NAME``
-         (prod). Standard parameters + the AWS-managed ``aws/ssm`` key are free,
-         which keeps the idle cost at zero.
+      1. ``env_var`` (e.g. ``OPENAI_API_KEY``) — used for local dev / `sam local`,
+         where SSM isn't reachable.
+      2. The SSM Parameter Store SecureString whose name is held in
+         ``param_env_var`` (prod). Standard parameters + the AWS-managed
+         ``aws/ssm`` key are free, keeping idle cost at zero.
 
     Raises RuntimeError if neither is configured.
     """
-    global _openai_api_key
-    if _openai_api_key:
-        return _openai_api_key
+    direct = os.environ.get(env_var)
+    if direct:
+        return direct
 
-    env_key = os.environ.get('OPENAI_API_KEY')
-    if env_key:
-        _openai_api_key = env_key
-        return _openai_api_key
-
-    param_name = os.environ.get('OPENAI_PARAM_NAME')
+    param_name = os.environ.get(param_env_var)
     if param_name:
+        if param_name in _cache:
+            return _cache[param_name]
         import boto3  # provided by the Lambda runtime
 
         ssm = boto3.client('ssm')
         resp = ssm.get_parameter(Name=param_name, WithDecryption=True)
-        _openai_api_key = resp['Parameter']['Value']
-        return _openai_api_key
+        value = resp['Parameter']['Value']
+        _cache[param_name] = value
+        return value
 
     raise RuntimeError(
-        'No OpenAI API key configured: set OPENAI_API_KEY or OPENAI_PARAM_NAME'
+        f'No secret configured: set {env_var} or {param_env_var}'
     )
+
+
+def get_openai_api_key() -> str:
+    """Return the OpenAI API key (env var ``OPENAI_API_KEY`` or SSM)."""
+    return _get_secret('OPENAI_API_KEY', 'OPENAI_PARAM_NAME')
+
+
+def get_stripe_secret_key() -> str:
+    """Return the Stripe secret key (env var ``STRIPE_SECRET_KEY`` or SSM)."""
+    return _get_secret('STRIPE_SECRET_KEY', 'STRIPE_SECRET_PARAM_NAME')
+
+
+def get_stripe_webhook_secret() -> str:
+    """Return the Stripe webhook signing secret (env var or SSM)."""
+    return _get_secret('STRIPE_WEBHOOK_SECRET', 'STRIPE_WEBHOOK_PARAM_NAME')

--- a/services/test_handler_billing.py
+++ b/services/test_handler_billing.py
@@ -1,0 +1,144 @@
+"""Unit tests for the billing Lambda.
+
+Run from the services/ directory:  pytest test_handler_billing.py
+
+Stripe, auth and DynamoDB are monkeypatched so these run offline.
+"""
+import json
+import types
+
+import handler_billing
+
+
+def _event(method='POST', proxy='checkout', body=None, token='valid-token', extra_headers=None):
+    headers = {'origin': 'http://localhost:4200'}
+    if token is not None:
+        headers['Authorization'] = token
+    if extra_headers:
+        headers.update(extra_headers)
+    return {
+        'httpMethod': method,
+        'headers': headers,
+        'pathParameters': {'proxy': proxy},
+        'body': body if isinstance(body, str) or body is None else json.dumps(body),
+    }
+
+
+class _Table:
+    def __init__(self, item=None):
+        self.item = item or {}
+        self.updates = []
+
+    def get_item(self, Key):
+        return {'Item': self.item} if self.item else {}
+
+    def update_item(self, **kwargs):
+        self.updates.append(kwargs)
+
+
+def test_options_preflight():
+    resp = handler_billing.handler(_event(method='OPTIONS', token=None), None)
+    assert resp['statusCode'] == 200
+
+
+def test_unknown_route_404(monkeypatch):
+    monkeypatch.setattr(handler_billing, 'verify_token', lambda t: {'sub': 'u1'})
+    resp = handler_billing.handler(_event(proxy='nope'), None)
+    assert resp['statusCode'] == 404
+
+
+def test_checkout_requires_auth():
+    resp = handler_billing.handler(_event(proxy='checkout', token=None), None)
+    assert resp['statusCode'] == 401
+
+
+def test_checkout_returns_session_url(monkeypatch):
+    monkeypatch.setattr(handler_billing, 'verify_token', lambda t: {'sub': 'u1', 'email': 'a@b.c'})
+    monkeypatch.setattr(handler_billing, 'get_table', lambda: _Table())
+    monkeypatch.setattr(handler_billing, '_PRICE_ID', 'price_123')
+
+    created = {}
+
+    def fake_create(**kwargs):
+        created.update(kwargs)
+        return types.SimpleNamespace(url='https://checkout.stripe.com/abc')
+
+    fake_stripe = types.SimpleNamespace(
+        checkout=types.SimpleNamespace(
+            Session=types.SimpleNamespace(create=fake_create)
+        )
+    )
+    monkeypatch.setattr(handler_billing, '_stripe', lambda: fake_stripe)
+
+    resp = handler_billing.handler(_event(proxy='checkout'), None)
+    assert resp['statusCode'] == 200
+    assert json.loads(resp['body'])['url'] == 'https://checkout.stripe.com/abc'
+    # The sub is stamped on both the session and the subscription metadata.
+    assert created['client_reference_id'] == 'u1'
+    assert created['subscription_data']['metadata']['sub'] == 'u1'
+
+
+def test_webhook_rejects_bad_signature(monkeypatch):
+    def boom(payload, sig, secret):
+        raise ValueError('bad sig')
+
+    fake_stripe = types.SimpleNamespace(
+        Webhook=types.SimpleNamespace(construct_event=boom)
+    )
+    monkeypatch.setattr(handler_billing, '_stripe', lambda: fake_stripe)
+    monkeypatch.setattr(handler_billing, 'get_stripe_webhook_secret', lambda: 'whsec')
+
+    resp = handler_billing.handler(
+        _event(proxy='webhook', token=None, body='{}',
+               extra_headers={'Stripe-Signature': 'forged'}),
+        None,
+    )
+    assert resp['statusCode'] == 400
+
+
+def test_webhook_checkout_completed_sets_paid(monkeypatch):
+    table = _Table()
+    monkeypatch.setattr(handler_billing, 'get_table', lambda: table)
+    monkeypatch.setattr(handler_billing, 'get_stripe_webhook_secret', lambda: 'whsec')
+
+    stripe_event = {
+        'type': 'checkout.session.completed',
+        'data': {'object': {'client_reference_id': 'u1', 'customer': 'cus_1'}},
+    }
+    fake_stripe = types.SimpleNamespace(
+        Webhook=types.SimpleNamespace(construct_event=lambda *a: stripe_event)
+    )
+    monkeypatch.setattr(handler_billing, '_stripe', lambda: fake_stripe)
+
+    resp = handler_billing.handler(
+        _event(proxy='webhook', token=None, body='{}',
+               extra_headers={'Stripe-Signature': 'sig'}),
+        None,
+    )
+    assert resp['statusCode'] == 200
+    assert len(table.updates) == 1
+    vals = table.updates[0]['ExpressionAttributeValues']
+    assert ':plan' in vals and vals[':plan'] == 'paid'
+
+
+def test_webhook_subscription_deleted_sets_free(monkeypatch):
+    table = _Table()
+    monkeypatch.setattr(handler_billing, 'get_table', lambda: table)
+    monkeypatch.setattr(handler_billing, 'get_stripe_webhook_secret', lambda: 'whsec')
+
+    stripe_event = {
+        'type': 'customer.subscription.deleted',
+        'data': {'object': {'metadata': {'sub': 'u1'}, 'status': 'canceled'}},
+    }
+    fake_stripe = types.SimpleNamespace(
+        Webhook=types.SimpleNamespace(construct_event=lambda *a: stripe_event)
+    )
+    monkeypatch.setattr(handler_billing, '_stripe', lambda: fake_stripe)
+
+    resp = handler_billing.handler(
+        _event(proxy='webhook', token=None, body='{}',
+               extra_headers={'Stripe-Signature': 'sig'}),
+        None,
+    )
+    assert resp['statusCode'] == 200
+    assert table.updates[0]['ExpressionAttributeValues'][':plan'] == 'free'

--- a/services/test_handler_captain.py
+++ b/services/test_handler_captain.py
@@ -171,6 +171,7 @@ def test_admin_bypasses_quota(monkeypatch):
         lambda token: {'sub': 'admin-1', 'cognito:groups': ['admin']},
     )
     monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
 
     def fail_if_called(sub):
         raise AssertionError('quota must not be enforced for admins')
@@ -178,6 +179,7 @@ def test_admin_bypasses_quota(monkeypatch):
     monkeypatch.setattr(handler_captain, '_enforce_quota', fail_if_called)
     resp = handler_captain.handler(_event(body=_chat_body()), None)
     assert resp['statusCode'] == 200
+    assert json.loads(resp['body'])['usage']['plan'] == 'admin'
 
 
 def test_per_user_cap_returns_429(monkeypatch):
@@ -233,7 +235,7 @@ def test_paid_plan_uses_higher_limit(monkeypatch):
     assert captured[user_key] == handler_captain._PAID_MONTHLY_LIMIT
 
 
-def test_happy_path_reports_remaining(monkeypatch):
+def test_happy_path_reports_usage(monkeypatch):
     monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
     monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
     monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
@@ -243,7 +245,11 @@ def test_happy_path_reports_remaining(monkeypatch):
 
     resp = handler_captain.handler(_event(body=_chat_body()), None)
     assert resp['statusCode'] == 200
-    assert json.loads(resp['body'])['remaining'] == handler_captain._FREE_MONTHLY_LIMIT - 1
+    usage = json.loads(resp['body'])['usage']
+    assert usage['plan'] == 'free'
+    assert usage['limit'] == handler_captain._FREE_MONTHLY_LIMIT
+    assert usage['used'] == 1
+    assert usage['remaining'] == handler_captain._FREE_MONTHLY_LIMIT - 1
 
 
 def test_per_user_check_fails_open_on_db_error(monkeypatch):
@@ -259,4 +265,61 @@ def test_per_user_check_fails_open_on_db_error(monkeypatch):
     monkeypatch.setattr(handler_captain, 'try_increment', boom)
     resp = handler_captain.handler(_event(body=_chat_body()), None)
     assert resp['statusCode'] == 200
-    assert json.loads(resp['body'])['remaining'] is None
+    assert json.loads(resp['body'])['usage'] is None
+
+
+class _UsageTable:
+    """Minimal table stub for _status: get_item returns plan + counter rows."""
+
+    def __init__(self, plan=None, used=0):
+        self._plan = plan
+        self._used = used
+
+    def get_item(self, Key):
+        key = Key['userId']
+        if key.startswith('usage#'):
+            return {'Item': {'count': self._used}} if self._used else {}
+        return {'Item': {'plan': self._plan}} if self._plan else {}
+
+
+def test_status_mode_free(monkeypatch):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: _UsageTable(plan='free', used=4))
+    resp = handler_captain.handler(_event(body={'mode': 'status'}), None)
+    assert resp['statusCode'] == 200
+    usage = json.loads(resp['body'])
+    assert usage['plan'] == 'free'
+    assert usage['used'] == 4
+    assert usage['limit'] == handler_captain._FREE_MONTHLY_LIMIT
+    assert usage['remaining'] == handler_captain._FREE_MONTHLY_LIMIT - 4
+
+
+def test_status_mode_paid(monkeypatch):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: _UsageTable(plan='paid', used=10))
+    resp = handler_captain.handler(_event(body={'mode': 'status'}), None)
+    usage = json.loads(resp['body'])
+    assert usage['plan'] == 'paid'
+    assert usage['limit'] == handler_captain._PAID_MONTHLY_LIMIT
+
+
+def test_status_mode_admin_is_unlimited(monkeypatch):
+    monkeypatch.setattr(
+        handler_captain, 'verify_token',
+        lambda token: {'sub': 'a1', 'cognito:groups': ['admin']},
+    )
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: _UsageTable(used=3))
+    resp = handler_captain.handler(_event(body={'mode': 'status'}), None)
+    usage = json.loads(resp['body'])
+    assert usage['plan'] == 'admin'
+    assert usage['limit'] is None
+    assert usage['remaining'] is None
+    assert usage['used'] == 3
+
+
+def test_status_mode_needs_no_summary(monkeypatch):
+    """status must not require the summary/messages that chat does."""
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: _UsageTable(plan='free'))
+    resp = handler_captain.handler(_event(body={'mode': 'status'}), None)
+    assert resp['statusCode'] == 200

--- a/services/test_handler_captain.py
+++ b/services/test_handler_captain.py
@@ -23,6 +23,8 @@ def _event(method='POST', body=None, token='valid-token'):
 
 def _patch_ok(monkeypatch, capture=None):
     monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'user-1'})
+    # Quota is exercised by its own tests below; here we let every call through.
+    monkeypatch.setattr(handler_captain, '_enforce_quota', lambda sub: None)
 
     def fake_call(messages):
         if capture is not None:
@@ -140,6 +142,7 @@ def test_insights_mode_synthesizes_instruction(monkeypatch):
 
 def test_openai_failure_returns_502(monkeypatch):
     monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u'})
+    monkeypatch.setattr(handler_captain, '_enforce_quota', lambda sub: None)
 
     def boom(messages):
         raise RuntimeError('api down')
@@ -149,3 +152,111 @@ def test_openai_failure_returns_502(monkeypatch):
         _event(body={'mode': 'insights', 'summary': {'v': 1}}), None
     )
     assert resp['statusCode'] == 502
+
+
+# --- Quotas & admin bypass -------------------------------------------------
+
+def _chat_body():
+    return {
+        'mode': 'chat',
+        'summary': {'portfolioValue': 1000},
+        'messages': [{'role': 'user', 'content': 'How did I do?'}],
+    }
+
+
+def test_admin_bypasses_quota(monkeypatch):
+    """An 'admin'-group member is served without touching the quota machinery."""
+    monkeypatch.setattr(
+        handler_captain, 'verify_token',
+        lambda token: {'sub': 'admin-1', 'cognito:groups': ['admin']},
+    )
+    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+
+    def fail_if_called(sub):
+        raise AssertionError('quota must not be enforced for admins')
+
+    monkeypatch.setattr(handler_captain, '_enforce_quota', fail_if_called)
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 200
+
+
+def test_per_user_cap_returns_429(monkeypatch):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
+    monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'free')
+    # Per-user counter is already at its cap -> ConditionExpression fails -> None.
+    monkeypatch.setattr(handler_captain, 'try_increment', lambda table, key, limit: None)
+
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 429
+    assert json.loads(resp['body'])['scope'] == 'user'
+
+
+def test_global_cap_returns_429_and_refunds_user(monkeypatch):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
+    monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'free')
+    monkeypatch.setattr(handler_captain, '_GLOBAL_MONTHLY_LIMIT', 100)
+
+    def fake_inc(table, key, limit):
+        return None if key.startswith('usage#global') else 1
+
+    refunded = []
+    monkeypatch.setattr(handler_captain, 'try_increment', fake_inc)
+    monkeypatch.setattr(handler_captain, 'decrement', lambda table, key: refunded.append(key))
+
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 429
+    assert json.loads(resp['body'])['scope'] == 'global'
+    # The user's reserved call is refunded so the rejected request isn't charged.
+    assert refunded == ['usage#u1#' + handler_captain.current_month()]
+
+
+def test_paid_plan_uses_higher_limit(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
+    monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'paid')
+
+    def fake_inc(table, key, limit):
+        captured[key] = limit
+        return 1
+
+    monkeypatch.setattr(handler_captain, 'try_increment', fake_inc)
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 200
+    user_key = 'usage#u1#' + handler_captain.current_month()
+    assert captured[user_key] == handler_captain._PAID_MONTHLY_LIMIT
+
+
+def test_happy_path_reports_remaining(monkeypatch):
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
+    monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'free')
+    # First call of the month -> count 1 -> remaining = free limit - 1.
+    monkeypatch.setattr(handler_captain, 'try_increment', lambda table, key, limit: 1)
+
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 200
+    assert json.loads(resp['body'])['remaining'] == handler_captain._FREE_MONTHLY_LIMIT - 1
+
+
+def test_per_user_check_fails_open_on_db_error(monkeypatch):
+    """A DynamoDB blip on the per-user counter must not block the user."""
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
+    monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'free')
+
+    def boom(table, key, limit):
+        raise RuntimeError('dynamo unreachable')
+
+    monkeypatch.setattr(handler_captain, 'try_increment', boom)
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 200
+    assert json.loads(resp['body'])['remaining'] is None

--- a/services/test_handler_captain.py
+++ b/services/test_handler_captain.py
@@ -252,20 +252,49 @@ def test_happy_path_reports_usage(monkeypatch):
     assert usage['remaining'] == handler_captain._FREE_MONTHLY_LIMIT - 1
 
 
-def test_per_user_check_fails_open_on_db_error(monkeypatch):
-    """A DynamoDB blip on the per-user counter must not block the user."""
+def _no_openai(monkeypatch):
+    """Assert OpenAI is never called when the quota store is unreachable."""
+    def boom(messages):
+        raise AssertionError('OpenAI must not be called when the quota store is down')
+
+    monkeypatch.setattr(handler_captain, '_call_openai', boom)
+
+
+def test_per_user_check_fails_closed_on_db_error(monkeypatch):
+    """A DynamoDB error on the per-user counter fails CLOSED (503, no spend)."""
     monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
-    monkeypatch.setattr(handler_captain, '_call_openai', lambda m: 'Aye.')
     monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
     monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'free')
+    _no_openai(monkeypatch)
 
     def boom(table, key, limit):
         raise RuntimeError('dynamo unreachable')
 
     monkeypatch.setattr(handler_captain, 'try_increment', boom)
     resp = handler_captain.handler(_event(body=_chat_body()), None)
-    assert resp['statusCode'] == 200
-    assert json.loads(resp['body'])['usage'] is None
+    assert resp['statusCode'] == 503
+
+
+def test_global_check_fails_closed_on_db_error(monkeypatch):
+    """A DynamoDB error on the global counter fails CLOSED and refunds the user."""
+    monkeypatch.setattr(handler_captain, 'verify_token', lambda token: {'sub': 'u1'})
+    monkeypatch.setattr(handler_captain, 'get_table', lambda: object())
+    monkeypatch.setattr(handler_captain, '_user_plan', lambda table, sub: 'free')
+    monkeypatch.setattr(handler_captain, '_GLOBAL_MONTHLY_LIMIT', 100)
+    _no_openai(monkeypatch)
+
+    def fake_inc(table, key, limit):
+        if key.startswith('usage#global'):
+            raise RuntimeError('dynamo unreachable')
+        return 1
+
+    refunded = []
+    monkeypatch.setattr(handler_captain, 'try_increment', fake_inc)
+    monkeypatch.setattr(handler_captain, 'decrement', lambda table, key: refunded.append(key))
+    resp = handler_captain.handler(_event(body=_chat_body()), None)
+    assert resp['statusCode'] == 503
+    # The reserved per-user call is refunded so the rejected request isn't charged.
+    assert refunded == ['usage#u1#' + handler_captain.current_month()]
 
 
 class _UsageTable:

--- a/services/test_shared_db.py
+++ b/services/test_shared_db.py
@@ -35,6 +35,9 @@ def test_try_increment_returns_new_count_when_under_cap():
     assert db.try_increment(table, 'usage#u1#2026-06', 30) == 7
     # The cap is enforced via a ConditionExpression, not a read-modify-write.
     assert 'ConditionExpression' in table.calls[0]
+    # SET must precede ADD or DynamoDB Local rejects the expression.
+    expr = table.calls[0]['UpdateExpression']
+    assert expr.index('SET') < expr.index('ADD')
 
 
 def test_try_increment_returns_none_when_cap_reached():

--- a/services/test_shared_db.py
+++ b/services/test_shared_db.py
@@ -1,0 +1,59 @@
+"""Unit tests for the shared DynamoDB counter primitives.
+
+Run from the services/ directory:  pytest test_shared_db.py
+
+A fake table stands in for DynamoDB so these run offline.
+"""
+import pytest
+from botocore.exceptions import ClientError
+
+from shared import db
+
+
+class _FakeTable:
+    """Records update_item calls and can simulate a conditional-check failure."""
+
+    def __init__(self, *, conditional_fail=False, count=5, error_code=None):
+        self.conditional_fail = conditional_fail
+        self.count = count
+        self.error_code = error_code
+        self.calls = []
+
+    def update_item(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error_code:
+            raise ClientError({'Error': {'Code': self.error_code}}, 'UpdateItem')
+        if self.conditional_fail:
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException'}}, 'UpdateItem'
+            )
+        return {'Attributes': {'count': self.count}}
+
+
+def test_try_increment_returns_new_count_when_under_cap():
+    table = _FakeTable(count=7)
+    assert db.try_increment(table, 'usage#u1#2026-06', 30) == 7
+    # The cap is enforced via a ConditionExpression, not a read-modify-write.
+    assert 'ConditionExpression' in table.calls[0]
+
+
+def test_try_increment_returns_none_when_cap_reached():
+    table = _FakeTable(conditional_fail=True)
+    assert db.try_increment(table, 'usage#u1#2026-06', 30) is None
+
+
+def test_try_increment_reraises_other_client_errors():
+    table = _FakeTable(error_code='ProvisionedThroughputExceededException')
+    with pytest.raises(ClientError):
+        db.try_increment(table, 'usage#u1#2026-06', 30)
+
+
+def test_decrement_never_raises():
+    table = _FakeTable(error_code='ResourceNotFoundException')
+    # Refund is best-effort; a failure must be swallowed.
+    db.decrement(table, 'usage#u1#2026-06')
+
+
+def test_current_month_format():
+    assert len(db.current_month()) == 7
+    assert db.current_month()[4] == '-'

--- a/template.yaml
+++ b/template.yaml
@@ -38,6 +38,42 @@ Parameters:
     Type: String
     Default: gpt-5.4-mini
     Description: OpenAI chat model for the Captain. Verify live pricing before changing.
+  FreeMonthlyLimit:
+    Type: String
+    Default: '30'
+    Description: Captain calls per user per month on the free plan.
+  PaidMonthlyLimit:
+    Type: String
+    Default: '1000'
+    Description: Captain calls per user per month on the paid plan.
+  GlobalMonthlyLimit:
+    Type: String
+    Default: '0'
+    Description: >
+      Hard service-wide ceiling on Captain calls per month (the spend guarantee).
+      Once reached, ALL captain calls stop until the next month. 0 disables it.
+      Derive from live OpenAI pricing: floor(monthly_budget / cost_per_call).
+  StripeSecretParamName:
+    Type: String
+    Default: /sailor/stripe-secret-key
+    Description: >
+      SSM SecureString holding the Stripe secret key. Created out-of-band (see
+      README); intentionally NOT managed by this stack so the secret never lives
+      in the template or CI logs.
+  StripeWebhookParamName:
+    Type: String
+    Default: /sailor/stripe-webhook-secret
+    Description: SSM SecureString holding the Stripe webhook signing secret.
+  StripePriceId:
+    Type: String
+    Default: ''
+    Description: Stripe Price ID (test or live) for the Captain subscription.
+  BillingSuccessUrl:
+    Type: String
+    Default: https://sailor.toondeboer.com/?upgraded=1
+  BillingCancelUrl:
+    Type: String
+    Default: https://sailor.toondeboer.com/
 
 Globals:
   Function:
@@ -79,6 +115,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Stage
+          TABLE_NAME: !Ref TableName
           ALLOWED_ORIGINS: !Ref AllowedOrigins
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
@@ -99,11 +136,18 @@ Resources:
       Handler: handler_captain.handler
       Environment:
         Variables:
+          # Drives get_table()'s dev-vs-prod endpoint selection — MUST be the
+          # stage (not the 'dev' default) or prod would hit DynamoDB Local.
+          ENVIRONMENT: !Ref Stage
+          TABLE_NAME: !Ref TableName
           ALLOWED_ORIGINS: !Ref AllowedOrigins
           COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
           COGNITO_CLIENT_ID: !Ref CognitoClientId
           OPENAI_PARAM_NAME: !Ref OpenAIParamName
           OPENAI_MODEL: !Ref OpenAIModel
+          FREE_MONTHLY_LIMIT: !Ref FreeMonthlyLimit
+          PAID_MONTHLY_LIMIT: !Ref PaidMonthlyLimit
+          GLOBAL_MONTHLY_LIMIT: !Ref GlobalMonthlyLimit
           # Empty by default (prod reads the key from SSM). Declared so a local
           # `sam local --env-vars env.json` override can inject it — SAM only
           # overrides variables that already exist in the template. Empty string
@@ -117,6 +161,9 @@ Resources:
             - Effect: Allow
               Action: ssm:GetParameter
               Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${OpenAIParamName}'
+        # Read the user's plan and read/write the monthly usage counters.
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TableName
       Events:
         Captain:
           Type: Api
@@ -124,6 +171,48 @@ Resources:
             RestApiId: !Ref Api
             Path: /captain
             # ANY so the Lambda also answers the CORS preflight (OPTIONS).
+            Method: any
+
+  BillingFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handler_billing.handler
+      Environment:
+        Variables:
+          ENVIRONMENT: !Ref Stage
+          TABLE_NAME: !Ref TableName
+          ALLOWED_ORIGINS: !Ref AllowedOrigins
+          COGNITO_USER_POOL_ID: !Ref CognitoUserPoolId
+          COGNITO_CLIENT_ID: !Ref CognitoClientId
+          STRIPE_SECRET_PARAM_NAME: !Ref StripeSecretParamName
+          STRIPE_WEBHOOK_PARAM_NAME: !Ref StripeWebhookParamName
+          STRIPE_PRICE_ID: !Ref StripePriceId
+          BILLING_SUCCESS_URL: !Ref BillingSuccessUrl
+          BILLING_CANCEL_URL: !Ref BillingCancelUrl
+          # Declared so a local `sam local --env-vars env.json` can inject test
+          # keys; empty is falsy, so prod falls through to SSM.
+          STRIPE_SECRET_KEY: ''
+          STRIPE_WEBHOOK_SECRET: ''
+      Policies:
+        # Read-only access to just the two Stripe parameters.
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: ssm:GetParameter
+              Resource:
+                - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StripeSecretParamName}'
+                - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StripeWebhookParamName}'
+        # Read the user's record (customer id) and write the resulting plan.
+        - DynamoDBCrudPolicy:
+            TableName: !Ref TableName
+      Events:
+        Billing:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            # {proxy+} routes /billing/checkout, /billing/webhook, /billing/portal
+            # to this one function; the handler dispatches on the sub-path.
+            Path: /billing/{proxy+}
             Method: any
 
 Outputs:
@@ -139,3 +228,9 @@ Outputs:
   CaptainEndpoint:
     Description: Copy into environment.prod.ts -> captainLambdaUrl
     Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/captain'
+  BillingEndpoint:
+    Description: Copy into environment.prod.ts -> billingLambdaUrl (no trailing slash)
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/billing'
+  StripeWebhookEndpoint:
+    Description: Configure this URL in the Stripe Dashboard as the webhook destination.
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/billing/webhook'


### PR DESCRIPTION
## Why

The Captain Lambda had **no request limit** — any authenticated user could call OpenAI unboundedly, so spend was uncapped (broke the \"never spend more than I earn\" goal and the \$5/mo cost ceiling). The only existing guardrails were per-request *size* caps. This PR adds layered usage quotas, a paid tier to raise them, and an admin bypass.

## What

### Phase A — limits + admin (the spend guarantee)
- **`services/shared/db.py`** (new) — shared `get_table()` (lifted out of `handler_dynamodb.py`) + atomic, race-free monthly counters guarded by a DynamoDB `ConditionExpression`, with a TTL `expiresAt` so counters self-delete for free. Counters live in the existing `sailor` table under reserved `usage#...` keys — no new table/schema.
- **`handler_captain.py`** — admin bypass via the Cognito `admin` group; per-user tier lookup (free vs paid); a **per-user monthly quota** (fails *open* on DB errors → protect UX) and a **global monthly ceiling** (fails *closed* → protect spend, with a refund of the reserved call). Over-quota → `429`; success reports `remaining`.
- **Frontend** — `429` → dedicated `chatQuotaExceeded` state + **Upgrade** CTA in the captain panel (hidden in demo).

### Phase B — Stripe subscription (test mode)
- **`handler_billing.py`** (new) — `/billing/checkout`, `/billing/webhook`, `/billing/portal`. The signature-verified **webhook is the only writer of `plan`** — the client can never self-grant paid access.
- `secrets.py` generalised for the two Stripe SSM secrets; `stripe` added to requirements; `BillingFunction` + outputs in `template.yaml`; `BillingService` drives the Checkout redirect.

### Cost ceiling math (GPT-5.4 mini)
Worst-case call ≈ 12.5k input + 250 output tokens → `12,500×0.75/1M + 250×4.50/1M ≈ $0.0105/call`. For a \$5 budget: `floor(5/0.0105) ≈ 476` → recommend `GLOBAL_MONTHLY_LIMIT=450` (worst-case spend ≈ \$4.73). Documented in README.

## Validation
- `pytest services/` → **31 passed**
- `nx run-many -t lint test build --all` → **success, 6 projects**

## Manual test checklist
- [ ] Deploy with `GlobalMonthlyLimit` + `StripePriceId`; copy `BillingEndpoint` into `environment.prod.ts`.
- [ ] Enable DynamoDB TTL on `expiresAt`; create Cognito `admin` group + add self.
- [ ] Put Stripe test secrets in SSM; set the webhook URL in the Stripe Dashboard.
- [ ] Free user: exhaust `FREE_MONTHLY_LIMIT` → chat shows the 429 Upgrade CTA.
- [ ] Admin user: unlimited (no 429).
- [ ] Test-card checkout → webhook flips `plan` to `paid` → higher limit applies.
- [ ] Forged webhook signature → rejected (400).
- [ ] Set `GlobalMonthlyLimit` low → confirm all calls stop once reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)