### PR TITLE
Fix empty-dashboard UX, landing header, and captain branding

### DIFF
--- a/apps/frontend/src/auth/signup/signup.component.html
+++ b/apps/frontend/src/auth/signup/signup.component.html
@@ -2,7 +2,7 @@
   <!-- Step 1: Register -->
   @if (step === 'register') {
     <div class="card" (keydown.enter)="register()">
-      <div class="wordmark">s<span class="ai">AI</span>lor</div>
+      <div class="wordmark">s<span class="ai">ai</span>lor</div>
       <h1 class="heading">Create an account</h1>
       <p class="subheading">Start tracking your portfolio</p>
       @if (error) {
@@ -66,7 +66,7 @@
   <!-- Step 2: Confirm email -->
   @if (step === 'confirm') {
     <div class="card" (keydown.enter)="confirm()">
-      <div class="wordmark">s<span class="ai">AI</span>lor</div>
+      <div class="wordmark">s<span class="ai">ai</span>lor</div>
       <div class="check-icon">✉</div>
       <h1 class="heading">Check your email</h1>
       <p class="subheading">We sent a 6-digit code to <strong>{{ email }}</strong></p>

--- a/apps/frontend/src/styles/_globals.scss
+++ b/apps/frontend/src/styles/_globals.scss
@@ -59,6 +59,11 @@
   }
 }
 
+// ─── "ai" emphasis (gold highlight for the letters "ai" in product names) ────
+.ai {
+  color: $color-gold;
+}
+
 // ─── Wordmark ("sailor" with gold AI emphasis) ───────────────────────────────
 .wordmark {
   font-family: $font-serif;
@@ -67,7 +72,6 @@
   font-style: italic;
 
   .ai {
-    color: $color-gold;
     font-style: italic;
     font-weight: 700;
   }

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.html
@@ -4,7 +4,7 @@
     <div class="captain-title">
       <lucide-icon name="Ship" [size]="22"></lucide-icon>
       <div>
-        <h2>Ask the Captain</h2>
+        <h2>Ask the capt<span class="ai">ai</span>n</h2>
         <p class="captain-subtitle">A plain-language read of your charts.</p>
       </div>
     </div>
@@ -12,7 +12,7 @@
       @if (!data?.demo && (isPaidMember$ | async) === false) {
         <button class="upgrade-link" (click)="upgrade()" type="button">
           <lucide-icon name="Sparkles" [size]="14"></lucide-icon>
-          Captain Plus
+          <span>capt<span class="ai">ai</span>n Plus</span>
         </button>
       }
       <button class="icon-btn" (click)="close()" aria-label="Close">
@@ -45,7 +45,7 @@
     @if (quotaExceeded$ | async) {
       <div class="captain-quota">
         <lucide-icon name="Anchor" [size]="22"></lucide-icon>
-        <p>You've used all your Captain questions this month.</p>
+        <p>You've used all your capt<span class="ai">ai</span>n questions this month.</p>
         @if (!data?.demo) {
           <button class="upgrade-btn" (click)="upgrade()" type="button">
             Upgrade for more
@@ -53,7 +53,7 @@
         }
       </div>
     } @else if (error$ | async) {
-      <div class="captain-error">The Captain couldn't reply just now. Try again shortly.</div>
+      <div class="captain-error">The capt<span class="ai">ai</span>n couldn't reply just now. Try again shortly.</div>
     }
   </div>
 
@@ -71,7 +71,7 @@
       [(ngModel)]="draft"
       (keyup.enter)="send(draft)"
       placeholder="Ask about your portfolio…"
-      aria-label="Message the Captain"
+      aria-label="Message the captain"
     />
     <button class="send-btn" (click)="send(draft)" [disabled]="!draft.trim()" aria-label="Send">
       <lucide-icon name="Send" [size]="18"></lucide-icon>
@@ -91,6 +91,6 @@
 
   <!-- Disclaimer -->
   <p class="captain-disclaimer">
-    The Captain shares facts about your portfolio, not financial advice.
+    The capt<span class="ai">ai</span>n shares facts about your portfolio, not financial advice.
   </p>
 </div>

--- a/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
+++ b/libs/frontend/ui/src/lib/captain-panel/captain-panel.component.scss
@@ -68,6 +68,12 @@
   white-space: nowrap;
   transition: $transition-base;
 
+  // Both the resting text and the hover background are gold — the default
+  // gold "ai" emphasis would blend in either way, so use cream for contrast.
+  .ai {
+    color: $color-cream;
+  }
+
   &:hover {
     background: $color-gold;
     color: $color-bg-base;

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.html
@@ -21,7 +21,11 @@
       @if (isPaidMember$ | async) {
         <span class="plan-badge" [class.admin]="(plan$ | async) === 'admin'">
           <lucide-icon name="Sparkles" [size]="14"></lucide-icon>
-          {{ (plan$ | async) === 'admin' ? 'Admin' : 'Captain Plus' }}
+          @if ((plan$ | async) === 'admin') {
+            <span>Admin</span>
+          } @else {
+            <span>capt<span class="ai">ai</span>n Plus</span>
+          }
         </span>
       }
     </header>
@@ -62,22 +66,35 @@
     @if (vm.loading) {
       <div class="computing-bar"></div>
     }
-    <!-- Captain's read (auto, daily-cached) — only when there are holdings -->
     @if ((vm.state?.stocks | keyvalue)?.length) {
+      <!-- Captain's read (auto, daily-cached) — only when there are holdings -->
       <section class="page-section">
         <aws-insights-banner></aws-insights-banner>
       </section>
-    }
-    <section class="page-section">
-      <aws-summary [summary]="vm.state?.summary" [currency]="vm.currency ?? 'EUR'"></aws-summary>
-    </section>
-    @if ((vm.state?.stocks | keyvalue)?.length) {
+      <section class="page-section">
+        <aws-summary [summary]="vm.state?.summary" [currency]="vm.currency ?? 'EUR'"></aws-summary>
+      </section>
       <section class="page-section">
         <aws-active-tickers
           [dates]="vm.state?.dates ?? []"
           [stocks]="vm.state?.stocks ?? {}"
           [currencySymbol]="currencySymbol(vm.currency)"
         ></aws-active-tickers>
+      </section>
+    } @else {
+      <section class="page-section">
+        <div class="empty-dashboard">
+          <lucide-icon name="Compass" [size]="40" class="empty-dashboard-icon"></lucide-icon>
+          <h2 class="empty-dashboard-title">Start tracking your investments</h2>
+          <p class="empty-dashboard-text">
+            Create your first portfolio to see your performance, holdings and captain's
+            insights here.
+          </p>
+          <a routerLink="/portfolios" class="btn btn-primary empty-dashboard-cta">
+            Create your first portfolio
+            <lucide-icon name="ArrowRight" [size]="16"></lucide-icon>
+          </a>
+        </div>
       </section>
     }
   </div>

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.scss
@@ -28,6 +28,12 @@
   font-weight: 600;
   letter-spacing: 0.02em;
 
+  // The badge background is already gold — the default gold "ai" emphasis
+  // would disappear into it, so swap to cream for contrast here.
+  .ai {
+    color: $color-cream;
+  }
+
   &.admin {
     background: transparent;
     border: 1px solid $color-gold;
@@ -103,4 +109,40 @@
   &:hover:not(.active) {
     background: rgba($color-gold, 0.06);
   }
+}
+
+.empty-dashboard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 64px 24px;
+  border: 1px solid $color-border;
+  border-radius: $radius-md;
+  background: rgba($color-gold, 0.03);
+}
+
+.empty-dashboard-icon {
+  color: $color-gold;
+  margin-bottom: 8px;
+}
+
+.empty-dashboard-title {
+  @include serif-heading;
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.empty-dashboard-text {
+  color: $color-muted;
+  max-width: 38ch;
+  margin: 0;
+}
+
+.empty-dashboard-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 8px;
 }

--- a/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
+++ b/libs/frontend/ui/src/lib/dashboard/dashboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { take, timer } from 'rxjs';
 import {
   selectBaseCurrency,
@@ -29,7 +29,7 @@ import { InsightsBannerComponent } from '../insights-banner/insights-banner.comp
   selector: 'aws-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
-  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent, InsightsBannerComponent, LucideAngularModule],
+  imports: [SummaryComponent, AsyncPipe, CommonModule, DatePipe, ActiveTickersComponent, InsightsBannerComponent, LucideAngularModule, RouterLink],
 })
 export class DashboardComponent implements OnInit {
   private store = inject(Store);

--- a/libs/frontend/ui/src/lib/demo/demo.component.html
+++ b/libs/frontend/ui/src/lib/demo/demo.component.html
@@ -36,7 +36,7 @@
       <aws-insights-banner [demo]="true"></aws-insights-banner>
       <button class="btn btn-secondary demo-captain-btn" (click)="openCaptain()" type="button">
         <lucide-icon name="Ship" [size]="18"></lucide-icon>
-        Ask the Captain
+        <span>Ask the capt<span class="ai">ai</span>n</span>
       </button>
     </div>
 

--- a/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.html
+++ b/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.html
@@ -4,7 +4,7 @@
       <lucide-icon name="Compass" [size]="20"></lucide-icon>
     </div>
     <div class="insight-body">
-      <span class="insight-label">The Captain's read</span>
+      <span class="insight-label">The capt<span class="ai">ai</span>n's read</span>
       <p class="insight-text">{{ insight.narrative }}</p>
       <span class="insight-note">Facts about your portfolio, not financial advice.</span>
     </div>
@@ -15,7 +15,7 @@
       <lucide-icon name="Compass" [size]="20"></lucide-icon>
     </div>
     <div class="insight-body">
-      <span class="insight-label">The Captain's read</span>
+      <span class="insight-label">The capt<span class="ai">ai</span>n's read</span>
       <div class="shimmer"></div>
       <div class="shimmer short"></div>
     </div>

--- a/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.scss
+++ b/libs/frontend/ui/src/lib/insights-banner/insights-banner.component.scss
@@ -33,6 +33,12 @@
   @include serif-heading;
   font-size: 0.95rem;
   color: $color-gold;
+
+  // The label itself is already gold — swap the "ai" emphasis to cream so it
+  // still reads as a highlight instead of disappearing into the label colour.
+  .ai {
+    color: $color-cream;
+  }
 }
 
 .insight-text {

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.html
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.html
@@ -7,6 +7,7 @@
         <span class="wordmark">s<span class="ai">ai</span>lor</span>
       </a>
       <ul class="nav-links">
+        <li><a href="#captain" (click)="scrollTo('captain', $event)">Meet the captain</a></li>
         <li><a href="#features" (click)="scrollTo('features', $event)">Features</a></li>
         <li><a href="#how-it-works" (click)="scrollTo('how-it-works', $event)">How It Works</a></li>
         <li><a routerLink="/demo" class="nav-demo-link">Live demo</a></li>
@@ -26,6 +27,7 @@
     <!-- Mobile Navigation -->
     <div class="mobile-nav" [class.active]="mobileMenuOpen">
       <ul class="mobile-nav-links">
+        <li><a href="#captain" (click)="scrollTo('captain', $event); closeMobileMenu()">Meet the captain</a></li>
         <li><a href="#features" (click)="scrollTo('features', $event); closeMobileMenu()">Features</a></li>
         <li><a href="#how-it-works" (click)="scrollTo('how-it-works', $event); closeMobileMenu()">How It Works</a></li>
         <li><a routerLink="/demo" (click)="closeMobileMenu()">Live demo</a></li>
@@ -45,7 +47,13 @@
     <lucide-icon name="Compass" [size]="64" class="hero-compass"></lucide-icon>
     <div class="container">
       <h1 class="hero-title">
-        <span class="hero-word" [class.faded]="!heroWordVisible">{{ heroWord }}</span>
+        <span class="hero-word" [class.faded]="!heroWordVisible">
+          @if (heroWord === 'captain') {
+            capt<span class="ai">ai</span>n
+          } @else {
+            {{ heroWord }}
+          }
+        </span>
         Your Investments<br />with <em>AI</em>-Powered Precision
       </h1>
       <p class="hero-subtitle">
@@ -78,6 +86,50 @@
           <div class="stat-card">
             <div class="stat-value">€{{ portfolioValue | number:'1.0-0' }}</div>
             <div class="stat-label">Portfolio Value</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- wave divider into the captain spotlight -->
+    <div class="wave-divider wave-into-navy">
+      <svg viewBox="0 0 1440 120" preserveAspectRatio="none" aria-hidden="true">
+        <path class="wave-back" d="M0,64 C240,112 480,16 720,56 C960,96 1200,24 1440,72 L1440,120 L0,120 Z" />
+        <path class="wave-front" d="M0,80 C240,40 480,120 720,80 C960,40 1200,112 1440,72 L1440,120 L0,120 Z" />
+      </svg>
+    </div>
+  </section>
+
+  <!-- Captain Spotlight Section — our unique selling point -->
+  <section id="captain" class="captain-spotlight">
+    <div class="container captain-spotlight-inner" awsRevealOnScroll>
+      <div class="captain-spotlight-copy">
+        <span class="captain-spotlight-eyebrow">
+          <lucide-icon name="Sparkles" [size]="14"></lucide-icon>
+          What makes sailor different
+        </span>
+        <h2>Meet the capt<span class="ai">ai</span>n</h2>
+        <p>
+          Your personal AI first mate reads your charts and explains what's
+          happening in plain language — daily insights and on-demand answers,
+          no jargon required. It's the one thing no spreadsheet can do for you.
+        </p>
+        <a routerLink="/demo" class="btn btn-primary btn-large captain-spotlight-cta">
+          <span>Ask the capt<span class="ai">ai</span>n</span>
+          <lucide-icon name="ArrowRight" [size]="18"></lucide-icon>
+        </a>
+      </div>
+      <div class="captain-spotlight-preview">
+        <div class="captain-preview-card">
+          <div class="captain-preview-header">
+            <lucide-icon name="Ship" [size]="18"></lucide-icon>
+            <span>Ask the capt<span class="ai">ai</span>n</span>
+          </div>
+          <div class="captain-preview-bubble user">How's my portfolio doing this month?</div>
+          <div class="captain-preview-bubble reply">
+            You're up 4.2% this month, mostly driven by your tech holdings.
+            Dividends from three positions also landed — nice timing just before
+            the dip on the 18th.
           </div>
         </div>
       </div>

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.html
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.html
@@ -7,7 +7,7 @@
         <span class="wordmark">s<span class="ai">ai</span>lor</span>
       </a>
       <ul class="nav-links">
-        <li><a href="#captain" (click)="scrollTo('captain', $event)">Meet the captain</a></li>
+        <li><a href="#captain" (click)="scrollTo('captain', $event)">Meet the capt<span class="ai">ai</span>n</a></li>
         <li><a href="#features" (click)="scrollTo('features', $event)">Features</a></li>
         <li><a href="#how-it-works" (click)="scrollTo('how-it-works', $event)">How It Works</a></li>
         <li><a routerLink="/demo" class="nav-demo-link">Live demo</a></li>
@@ -27,7 +27,7 @@
     <!-- Mobile Navigation -->
     <div class="mobile-nav" [class.active]="mobileMenuOpen">
       <ul class="mobile-nav-links">
-        <li><a href="#captain" (click)="scrollTo('captain', $event); closeMobileMenu()">Meet the captain</a></li>
+        <li><a href="#captain" (click)="scrollTo('captain', $event); closeMobileMenu()">Meet the capt<span class="ai">ai</span>n</a></li>
         <li><a href="#features" (click)="scrollTo('features', $event); closeMobileMenu()">Features</a></li>
         <li><a href="#how-it-works" (click)="scrollTo('how-it-works', $event); closeMobileMenu()">How It Works</a></li>
         <li><a routerLink="/demo" (click)="closeMobileMenu()">Live demo</a></li>

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
@@ -267,6 +267,16 @@ nav {
   display: inline-block;
   transition: opacity 0.3s ease, transform 0.3s ease;
 
+  // The word itself is gradient-clipped text (transparent fill + gold
+  // background). `-webkit-text-fill-color: transparent` is inherited and
+  // wins over a plain `color`, so it must be reset explicitly here —
+  // otherwise the "ai" emphasis silently renders as the same gold gradient
+  // as the rest of the word instead of standing out.
+  .ai {
+    color: $color-cream;
+    -webkit-text-fill-color: $color-cream;
+  }
+
   &.faded {
     opacity: 0;
     transform: translateY(-8px);
@@ -435,6 +445,10 @@ nav {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+
+  // This is a primary (gold-gradient) button — the default gold "ai"
+  // emphasis would disappear into the background, so use cream for contrast.
+  .ai { color: $color-cream; }
 
   lucide-icon { transition: transform 0.3s ease; }
 

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
@@ -33,7 +33,7 @@ header {
   position: fixed;
   width: 100%;
   top: 0;
-  padding-top: 0.5rem;
+  padding: 0.5rem 0;
   z-index: 1000;
   transition: $transition-base;
 

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
@@ -91,6 +91,10 @@ nav {
     &:hover {
       color: $color-gold;
       transform: translateY(-2px);
+
+      // On hover the link itself turns gold — without this, the "ai"
+      // emphasis in "Meet the captain" would blend into the hover colour.
+      .ai { color: $color-cream; }
     }
   }
 
@@ -212,6 +216,10 @@ nav {
         &:hover {
           color: $color-gold;
           transform: translateX(10px);
+
+          // On hover the link itself turns gold — without this, the "ai"
+          // emphasis in "Meet the captain" would blend into the hover colour.
+          .ai { color: $color-cream; }
         }
       }
     }

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
@@ -625,10 +625,12 @@ nav {
 // ─── CTA Section ─────────────────────────────────────────────────────────────
 .cta-section {
   padding: 5rem 0;
-  background: $brand-gradient;
+  // Solid colour (rather than $brand-gradient), and no border-top — both
+  // produced a straight-line seam beneath the wave-into-navy divider above
+  // this section. The wave alone now carries the transition.
+  background: $color-navy;
   color: $color-cream;
   text-align: center;
-  border-top: 1px solid $color-border;
 
   h2 {
     @include serif-heading;

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.scss
@@ -28,14 +28,19 @@
 // ─── Header ──────────────────────────────────────────────────────────────────
 header {
   @include glass-panel($glass-bg, 20px);
+  border: none;
+  border-bottom: 1px solid rgba($color-cream, 0.08);
   position: fixed;
   width: 100%;
   top: 0;
+  padding-top: 0.5rem;
   z-index: 1000;
   transition: $transition-base;
 
   &.scrolled {
     @include glass-panel($glass-bg-strong, 20px);
+    border: none;
+    border-bottom: 1px solid rgba($color-cream, 0.08);
 
     .logo .wordmark { color: $color-cream; }
     .nav-links a { color: $color-cream; }
@@ -47,7 +52,7 @@ nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 0;
+  padding: 1.5rem 0;
   position: relative;
 }
 
@@ -376,6 +381,127 @@ nav {
 .wave-into-navy {
   .wave-front { fill: $color-navy; }
   .wave-back  { fill: $color-navy; }
+}
+
+// ─── Captain Spotlight (unique selling point) ────────────────────────────────
+.captain-spotlight {
+  position: relative;
+  padding: 6rem 0;
+  // Solid colour (rather than $brand-gradient) so it matches the solid
+  // wave-fill colours exactly — a gradient here left a visible seam beneath
+  // the wave divider where the fill colour stopped matching the background.
+  background: $color-navy;
+  color: $color-cream;
+  overflow: hidden;
+}
+
+.captain-spotlight-inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+.captain-spotlight-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: $color-gold;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.captain-spotlight-copy {
+  h2 {
+    @include serif-heading;
+    font-size: 2.5rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    color: $color-sand;
+    font-size: 1.05rem;
+    line-height: 1.7;
+    margin-bottom: 2rem;
+    max-width: 46ch;
+  }
+}
+
+.captain-spotlight-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  lucide-icon { transition: transform 0.3s ease; }
+
+  &:hover lucide-icon { transform: translateX(4px); }
+}
+
+.captain-preview-card {
+  @include glass-panel($glass-bg, 16px);
+  border-radius: $radius-lg;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 420px;
+  margin: 0 auto;
+  box-shadow: $shadow-card;
+}
+
+.captain-preview-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: $color-gold;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid $color-border;
+
+  .ai { color: $color-cream; }
+}
+
+.captain-preview-bubble {
+  border-radius: $radius-md;
+  padding: 0.75rem 1rem;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  max-width: 90%;
+
+  &.user {
+    align-self: flex-end;
+    background: $accent-gradient;
+    color: $color-bg-base;
+    font-weight: 500;
+  }
+
+  &.reply {
+    align-self: flex-start;
+    background: rgba($color-cream, 0.06);
+    border: 1px solid $glass-border;
+    color: $color-cream;
+  }
+}
+
+@include respond-to($bp-md) {
+  .captain-spotlight-inner {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .captain-spotlight-copy p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .captain-spotlight-eyebrow {
+    justify-content: center;
+  }
 }
 
 // ─── Features ────────────────────────────────────────────────────────────────

--- a/libs/frontend/ui/src/lib/landing-page/landing-page.component.ts
+++ b/libs/frontend/ui/src/lib/landing-page/landing-page.component.ts
@@ -48,7 +48,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   currentYear = new Date().getFullYear();
 
   // Rotating hero verb (nautical flavour, cross-faded via CSS).
-  heroWords = ['Navigate', 'Chart', 'Captain', 'Steer'];
+  heroWords = ['Navigate', 'Chart', 'captain', 'Steer'];
   heroWordIndex = 0;
   heroWordVisible = true;
   private wordTimer?: ReturnType<typeof setInterval>;

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.html
@@ -6,9 +6,9 @@
       <lucide-icon name="Menu" [size]="20"></lucide-icon>
     </button>
     <aws-scrolling-text></aws-scrolling-text>
-    <button class="captain-btn" (click)="openCaptain()" aria-label="Ask the Captain">
+    <button class="captain-btn" (click)="openCaptain()" aria-label="Ask the captain">
       <lucide-icon name="Ship" [size]="18"></lucide-icon>
-      <span class="captain-btn-label">Ask the Captain</span>
+      <span class="captain-btn-label">Ask the capt<span class="ai">ai</span>n</span>
     </button>
   </header>
 

--- a/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.scss
+++ b/libs/frontend/ui/src/lib/page-wrapper/page-wrapper.component.scss
@@ -70,6 +70,13 @@ aws-scrolling-text {
   white-space: nowrap;
   transition: $transition-base;
 
+  // The button label itself is already gold — the default gold "ai"
+  // emphasis would be indistinguishable from the rest of the label, so use
+  // cream for contrast.
+  .ai {
+    color: $color-cream;
+  }
+
   &:hover {
     background: rgba($color-gold, 0.18);
     color: $color-gold-light;

--- a/libs/shared/util/src/lib/schemas.ts
+++ b/libs/shared/util/src/lib/schemas.ts
@@ -20,9 +20,9 @@ const transactionDboSchema = z
   .passthrough();
 
 const transactionsDboSchema = z.object({
-  stock: z.array(transactionDboSchema),
-  dividend: z.array(transactionDboSchema),
-  commission: z.array(transactionDboSchema),
+  stock: z.array(transactionDboSchema).default([]),
+  dividend: z.array(transactionDboSchema).default([]),
+  commission: z.array(transactionDboSchema).default([]),
 });
 
 const userSettingsDboSchema = z.object({


### PR DESCRIPTION
## Summary
- Empty-portfolio dashboards no longer raise a Zod validation toast (transaction arrays now default to `[]`); added a friendly empty-state with a CTA linking to portfolio creation.
- Fixed "sAIlor" typo on the signup page wordmark to lowercase "sailor".
- Landing page header: removed the golden border, replaced it with a subtle bottom hairline, and added top padding (not margin, so the header still spans flush to the viewport top) for breathing room.
- Lowercased "Captain" → "captain" everywhere, highlighting the existing "ai" in gold (capt**ai**n) to mirror the "sailor" wordmark treatment, with cream contrast overrides on gold backgrounds (plan badge, upgrade link, insight label).
- Added a "Meet the captain" landing-page section — our AI differentiator — with a chat-preview mockup, wired into the wave-divider chain between the hero and features sections (fixed a gradient/solid-fill colour mismatch that produced a visible seam under the wave curve).
- Fixed a flex+gap rendering bug where `capt<span>ai</span>n` text fragments were getting extra spacing inserted between them ("Ask the capt ai n") by wrapping each label in a single `<span>`.

## Test plan
- [x] Sign up as a new user with no portfolios — confirm no Zod error toast and the empty-state CTA navigates to `/portfolios`
- [x] Visit `/signup` — confirm the wordmark reads "sailor" (lowercase "ai" highlighted in gold)
- [x] Visit the landing page — confirm the header has no golden border, has breathing-room padding, and no page content is visible above it
- [x] Scroll the landing page through hero → "Meet the captain" → features — confirm the wave dividers blend seamlessly with no straight-line seam
- [x] Confirm "captain" appears lowercase with "ai" highlighted in gold (or cream on gold backgrounds) across: dashboard plan badge, captain panel header/upgrade link/quota/disclaimer, insights banner, demo page button, page-wrapper "Ask the captain" button
- [x] Confirm none of the captain labels show extra spacing (e.g. "Ask the capt ai n")

🤖 Generated with [Claude Code](https://claude.com/claude-code)